### PR TITLE
GPU-aware-MPI permuteRows

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2384,7 +2384,7 @@ void BaseMatrix<scalar_t>::tileIbcastToSet(
 
         at(i, j, device).recv(new_vec[recv_from.front()], mpi_comm_, layout, tag);
         tileLayout(i, j, device, layout);
-        tileModified(i, j, device);
+        tileModified(i, j, device, true);
     }
 
     if (! send_to.empty()) {

--- a/src/internal/internal_swap.cc
+++ b/src/internal/internal_swap.cc
@@ -597,9 +597,13 @@ void permuteRows(
                             remote_count[r] = remote_index[r] - remote_offsets[r];
                         }
 
+                        #if defined(SLATE_WITH_GPU_AWARE_MPI)
+                        scalar_t* remote_rows = remote_rows_dev;
+                        #else
                         int64_t remote_rows_size = remote_offsets[comm_size]*nb;
                         std::vector<scalar_t> remote_rows_vect (remote_rows_size);
                         scalar_t* remote_rows = remote_rows_vect.data();
+                        #endif
 
                         // Gather remote rows to root.
                         std::vector<MPI_Request> requests (comm_size);
@@ -615,8 +619,10 @@ void permuteRows(
                         }
                         MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
 
+                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
                         blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
                                                       remote_rows_size, *compute_queue);
+                        #endif
 
                         // Swap rows locally.
                         for (int64_t i = begin; i != end; i += inc) {
@@ -650,8 +656,10 @@ void permuteRows(
                         }
                         compute_queue->sync();
 
+                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
                         blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
                                                       remote_rows_size, *compute_queue);
+                        #endif
 
                         // Scatter remote rows.
                         // reuse requests array from before
@@ -683,7 +691,6 @@ void permuteRows(
                         }
 
                         if (remote_length > 0) {
-                            int64_t remote_rows_size = remote_length*nb;
 
                             // Pack pivot rows into workspace.
                             int64_t count = 0;
@@ -707,19 +714,25 @@ void permuteRows(
                             compute_queue->sync();
 
                             // Send rows, then recv updated rows.
-                            // todo: MPI GPU direct.
+                            #if defined(SLATE_WITH_GPU_AWARE_MPI)
+                            scalar_t* remote_rows = remote_rows_dev;
+                            #else
+                            int64_t remote_rows_size = remote_length*nb;
                             std::vector<scalar_t> remote_rows_vect (remote_rows_size);
                             scalar_t* remote_rows = remote_rows_vect.data();
                             blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
                                                           remote_rows_size, *compute_queue);
+                            #endif
 
                             MPI_Send(remote_rows, remote_length, row_type,
                                      root_rank, tag, comm);
                             MPI_Recv(remote_rows, remote_length, row_type,
                                      root_rank, tag, comm, MPI_STATUS_IGNORE);
 
+                            #if !defined(SLATE_WITH_GPU_AWARE_MPI)
                             blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
                                                           remote_rows_size, *compute_queue);
+                            #endif
 
                             // Unpack pivot rows from workspace.
                             count = 0;


### PR DESCRIPTION
Here's my code to use GPU-aware MPI in `permuteRows`.
I also fixed an assertion error in the current master branch when `SLATE_WITH_GPU_AWARE_MPI` is enabled (related to overwriting tiles where other devices are `MOSI::Modified`).

This only gives a couple percent speedup on Crusher.
My earlier tests indicate most of the runtime is in the panel since the CPU/GPU imbalance is much worse than Summit.  (E.g., for n=200,000 on 8 nodes, the trailing-matrix GEMM's in the panel alone takes over half the total runtime).


So tangentially, it might be worth exploring a GPU panel for partial pivoting.  I think batched amax and scal device routines are the main missing pieces (at least from cuBLAS).