### PR TITLE
Constants

### DIFF
--- a/src/cholqr.cc
+++ b/src/cholqr.cc
@@ -26,8 +26,10 @@ void cholqr(
     Matrix<scalar_t>& R,
     Options const& opts )
 {
+    // Constants
     const scalar_t one  = 1.0;
     const scalar_t zero = 0.0;
+
     auto AH = conjTranspose( A );
     HermitianMatrix<scalar_t> R_hermitian( Uplo::Upper, R );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R_hermitian );
@@ -74,20 +76,22 @@ void cholqr(
 {
     slate_assert( R.uplo() == Uplo::Upper );
 
-    scalar_t s_one = 1.0;
-    blas::real_type<scalar_t> one  = 1.0;
-    blas::real_type<scalar_t> zero = 0.0;
+    // Constants
+    scalar_t one = 1.0;
+    blas::real_type<scalar_t> r_one  = 1.0;
+    blas::real_type<scalar_t> r_zero = 0.0;
+
     auto AH = conjTranspose( A );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R );
 
     // Compute R = AH * A.
-    herk( one, AH, zero, R, opts );
+    herk( r_one, AH, r_zero, R, opts );
 
     // Compute Ut * U = chol(R).
     potrf( R, opts );
 
     // Compute Q = A * U^{-1}.
-    trsm( Side::Right, s_one, U, A, opts );
+    trsm( Side::Right, one, U, A, opts );
 }
 
 } // namespace impl

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -31,10 +31,10 @@ void gelqf(
     using lapack::device_info_int;
     using blas::real;
 
+    // Constants
+    const int priority_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
-
-    const int priority_one = 1;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
@@ -170,7 +170,7 @@ void gelqf(
             }
 
             // panel, high priority
-            #pragma omp task depend(inout:block[k]) priority(priority_one)
+            #pragma omp task depend(inout:block[k]) priority(1)
             {
                 //--------------------
                 // Instead of doing LQ of panel, we do QR of transpose( panel ),
@@ -188,7 +188,7 @@ void gelqf(
                 internal::geqrf<target>(
                     std::move(AT_panel), std::move(TlT_panel),
                     dwork_array, work_size, ib,
-                    max_panel_threads, priority_one);
+                    max_panel_threads, priority_1 );
 
                 // Find first local tile, which is triangular factor (T in I - VTV^H),
                 // and copy it to Tlocal.
@@ -265,7 +265,7 @@ void gelqf(
 
                 #pragma omp task depend(in:block[k]) \
                                  depend(inout:block[i]) \
-                                 priority(priority_one)
+                                 priority(1)
                 {
                     // Apply local reflectors
                     internal::unmlq<Target::HostTask>(

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -83,7 +83,8 @@ void gemmA(
                 for (int64_t i = 0; i < B.mt(); ++i)
                     bcast_list_B.push_back(
                         {i, k, {A.sub( 0, A.mt()-1, i, i )}} );
-                B.template listBcast<target>( bcast_list_B, layout, k );
+                int tag_k = k;
+                B.template listBcast<target>( bcast_list_B, layout, tag_k );
             }
         }
 
@@ -134,8 +135,9 @@ void gemmA(
                     for (int64_t i = 0; i < B.mt(); ++i)
                         bcast_list_B.push_back(
                             {i, k+lookahead, {A.sub( 0, A.mt()-1, i, i )}} );
+                    int tag_kl = k+lookahead;
                     B.template listBcast<target>(
-                        bcast_list_B, layout, k+lookahead );
+                        bcast_list_B, layout, tag_kl );
                 }
             }
 

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -57,7 +57,7 @@ void gemmC(
     uint8_t* gemm  =  gemm_vector.data();
     uint8_t* c     =     c_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -123,7 +123,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  std::move(C),
-                    layout, default_priority, default_queue, opts2);
+                    layout, default_priority, queue_0, opts2);
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
@@ -172,7 +172,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, k, k),
                            B.sub(k, k, 0, B.nt()-1),
                     one,   std::move( C ),
-                    layout, default_priority, default_queue, opts2);
+                    layout, default_priority, queue_0, opts2);
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
                 auto B_rowblock = B.sub(k, k, 0, B.nt()-1);

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -38,6 +38,8 @@ void gemmC(
 
     // Constants
     const scalar_t one = 1.0;
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     const Layout layout = Layout::ColMajor;
 
     // Options
@@ -56,8 +58,6 @@ void gemmC(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     uint8_t* c     =     c_vector.data();
-    const int default_priority = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -123,7 +123,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  std::move(C),
-                    layout, default_priority, queue_0, opts2);
+                    layout, priority_0, queue_0, opts2 );
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
@@ -172,7 +172,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, k, k),
                            B.sub(k, k, 0, B.nt()-1),
                     one,   std::move( C ),
-                    layout, default_priority, queue_0, opts2);
+                    layout, priority_0, queue_0, opts2 );
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
                 auto B_rowblock = B.sub(k, k, 0, B.nt()-1);

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -219,9 +219,9 @@ void geqrf(
                             else
                                 bcast_list_V.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}});
                         }
-                        int tag_0  = 0;
-                        int life_3 = 3;
-                        int life_2 = 2;
+                        const int tag_0  = 0;
+                        const int life_3 = 3;
+                        const int life_2 = 2;
                         A.template listBcast<target>(
                             bcast_list_V_first, layout, tag_0, life_3, set_hold );
                         A.template listBcast<target>(

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -107,11 +107,11 @@ void geqrf(
     std::vector< scalar_t* > dwork_array( num_devices, nullptr );
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0; // use default batch size
-        const int64_t num_queues = 3 + lookahead;
-        A.allocateBatchArrays(batch_size_zero, num_queues);
+        const int64_t batch_size_default = 0; // use default batch size
+        int num_queues = 3 + lookahead;
+        A.allocateBatchArrays( batch_size_default, num_queues );
         A.reserveDeviceWorkspace();
-        W.allocateBatchArrays(batch_size_zero, num_queues);
+        W.allocateBatchArrays( batch_size_default, num_queues );
         // todo: this is demanding too much device workspace memory
         // only one tile-row of matrix W per MPI process is going to be used,
         // but W with size of whole A is being allocated

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -28,7 +28,13 @@ void getrf(
     using real_t = blas::real_type<scalar_t>;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
+    const int life_1 = 1;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
 
     // Options
     real_t pivot_threshold
@@ -56,11 +62,6 @@ void getrf(
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
     pivots.resize(min_mt_nt);
 
-    const int priority_one = 1;
-    const int priority_zero = 0;
-    int life_factor_one = 1;
-    const int queue_0 = 0;
-    const int queue_1 = 1;
     const int64_t batch_size_zero = 0;
     const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
@@ -89,12 +90,12 @@ void getrf(
             pivots.at(k).resize(diag_len);
 
             // panel, high priority
-            #pragma omp task depend(inout:column[k]) priority(priority_one)
+            #pragma omp task depend(inout:column[k]) priority(1)
             {
                 // factor A(k:mt-1, k)
                 internal::getrf_panel<Target::HostTask>(
                     A.sub(k, A_mt-1, k, k), diag_len, ib, pivots.at(k),
-                    pivot_threshold, max_panel_threads, priority_one, k);
+                    pivot_threshold, max_panel_threads, priority_1, k );
 
                 BcastList bcast_list_A;
                 int tag_k = k;
@@ -103,7 +104,7 @@ void getrf(
                     bcast_list_A.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}});
                 }
                 A.template listBcast<target>(
-                    bcast_list_A, Layout::ColMajor, tag_k, life_factor_one, is_shared);
+                    bcast_list_A, Layout::ColMajor, tag_k, life_1, is_shared );
 
                 // Root broadcasts the pivot to all ranks.
                 // todo: Panel ranks send the pivots to the right.
@@ -118,14 +119,14 @@ void getrf(
             // update lookahead column(s), high priority
             for (int64_t j = k+1; j < k+1+lookahead && j < A_nt; ++j) {
                 #pragma omp task depend(in:column[k]) \
-                                 depend(inout:column[j]) priority(priority_one)
+                                 depend(inout:column[j]) priority(1)
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
                     int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, queue_jk1 );
+                        target_layout, priority_1, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -135,7 +136,7 @@ void getrf(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_one, Layout::ColMajor, queue_jk1 );
+                        priority_1, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -146,7 +147,7 @@ void getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        target_layout, priority_one, queue_jk1 );
+                        target_layout, priority_1, queue_jk1 );
                 }
             }
             // pivot to the left
@@ -159,7 +160,7 @@ void getrf(
                     int tag_0 = 0;
                     internal::permuteRows<Target::HostTask>(
                         Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
-                        host_layout, priority_zero, tag_0, queue_0);
+                        host_layout, priority_0, tag_0, queue_0 );
                 }
             }
             // update trailing submatrix, normal priority
@@ -173,7 +174,7 @@ void getrf(
                     // todo: target
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, k+1+lookahead, A_nt-1),
-                        pivots.at(k), target_layout, priority_zero, tag_kl1, queue_1);
+                        pivots.at(k), target_layout, priority_0, tag_kl1, queue_1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -185,7 +186,7 @@ void getrf(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, A_nt-1),
-                        priority_zero, Layout::ColMajor, queue_1);
+                        priority_0, Layout::ColMajor, queue_1 );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastList bcast_list_A;
@@ -202,7 +203,7 @@ void getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, k+1+lookahead, A_nt-1),
                         one,  A.sub(k+1, A_mt-1, k+1+lookahead, A_nt-1),
-                        target_layout, priority_zero, queue_1);
+                        target_layout, priority_0, queue_1 );
                 }
             }
             if (is_shared) {

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -122,9 +122,10 @@ void getrf(
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
+                    int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, j-k+1);
+                        target_layout, priority_one, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -134,7 +135,7 @@ void getrf(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_one, Layout::ColMajor, j-k+1);
+                        priority_one, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -145,7 +146,7 @@ void getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        target_layout, priority_one, j-k+1);
+                        target_layout, priority_one, queue_jk1 );
                 }
             }
             // pivot to the left

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -157,7 +157,7 @@ void getrf(
                                  depend(inout:column[k-1])
                 {
                     // swap rows in A(k:mt-1, 0:k-1)
-                    int tag_0 = 0;
+                    const int tag_0 = 0;
                     internal::permuteRows<Target::HostTask>(
                         Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
                         host_layout, priority_0, tag_0, queue_0 );

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -62,8 +62,6 @@ void getrf(
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
     pivots.resize(min_mt_nt);
 
-    const int64_t batch_size_zero = 0;
-    const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
 
     // OpenMP needs pointer types, but vectors are exception safe
@@ -74,7 +72,9 @@ void getrf(
     // So, the data dependencies protect the corresponding MPI tags
 
     if (target == Target::Devices) {
-        A.allocateBatchArrays(batch_size_zero, num_queues);
+        const int64_t batch_size_default = 0;
+        int num_queues = 2 + lookahead;
+        A.allocateBatchArrays( batch_size_default, num_queues );
         A.reserveDeviceWorkspace();
     }
 

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -30,8 +30,13 @@ void getrf_tntpiv(
     using lapack::device_info_int;
     using lapack::device_pivot_int;
 
-
+    // Constants
     const scalar_t one = 1.0;
+    const int life_1 = 1;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
@@ -52,14 +57,9 @@ void getrf_tntpiv(
     if (target == Target::Devices)
         target_layout = Layout::RowMajor;
 
-    const int priority_one = 1;
-    const int priority_zero = 0;
     int64_t A_nt = A.nt();
     int64_t A_mt = A.mt();
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
-    int life_factor_one = 1;
-    const int queue_0 = 0;
-    const int queue_1 = 1;
     const int64_t batch_size_zero = 0;
     const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
@@ -148,7 +148,7 @@ void getrf_tntpiv(
 
             // panel, high priority
             #pragma omp task depend(inout:column[k]) \
-                             priority(priority_one)
+                             priority(1)
             {
                 auto Apanel = Awork.sub( k, A_mt-1, k, k );
                 Apanel.insertLocalTiles();
@@ -158,7 +158,7 @@ void getrf_tntpiv(
                 internal::getrf_tntpiv_panel<target>(
                     A.sub(k, A_mt-1, k, k), std::move(Apanel),
                     dwork_array, work_size, diag_len, ib,
-                    pivots.at(k), max_panel_threads, priority_one);
+                    pivots.at(k), max_panel_threads, priority_1 );
 
                 // Root broadcasts the pivot to all ranks.
                 // todo: Panel ranks send the pivots to the right.
@@ -174,7 +174,7 @@ void getrf_tntpiv(
                 int tag_k = k;
                 internal::permuteRows<target>(
                     Direction::Forward, A.sub(k, A_mt-1, k, k),
-                    pivots.at(k), target_layout, priority_one, tag_k, queue_0);
+                    pivots.at(k), target_layout, priority_1, tag_k, queue_0 );
 
                 // Copy factored diagonal tile into place.
                 internal::copy<Target::HostTask>(
@@ -187,7 +187,7 @@ void getrf_tntpiv(
                                                A.sub(k, k, k+1, A_nt-1)}});
 
                 A.template listBcast<target>(
-                    bcast_list_A, host_layout, tag_k, life_factor_one, is_shared);
+                    bcast_list_A, host_layout, tag_k, life_1, is_shared );
 
                 Apanel.clear();
             }
@@ -196,7 +196,7 @@ void getrf_tntpiv(
             // A_k+1:mt,k = A_k+1:mt,k * Tkk^{-1}
             #pragma omp task depend(inout:column[k]) \
                              depend(inout:listBcastMT_token) \
-                             priority(priority_one)
+                             priority(1)
             {
                 auto Akk = A.sub(k, k, k, k);
                 auto Tkk = TriangularMatrix<scalar_t>(
@@ -206,7 +206,7 @@ void getrf_tntpiv(
                     Side::Right,
                     one, std::move(Tkk),
                          A.sub( k+1, A_mt-1, k, k ),
-                    priority_one, Layout::ColMajor, queue_0);
+                    priority_1, Layout::ColMajor, queue_0 );
 
                 BcastListTag bcast_list;
                 // bcast the tiles of the panel to the right hand side
@@ -216,21 +216,21 @@ void getrf_tntpiv(
                     bcast_list.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}, tag});
                 }
                 A.template listBcastMT<target>(
-                    bcast_list, Layout::ColMajor, life_factor_one, is_shared);
+                    bcast_list, Layout::ColMajor, life_1, is_shared );
             }
 
             // update lookahead column(s), high priority
             for (int64_t j = k+1; j < k+1+lookahead && j < A_nt; ++j) {
                 #pragma omp task depend(in:column[k]) \
                                  depend(inout:column[j]) \
-                                 priority(priority_one)
+                                 priority(1)
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
                     int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, queue_jk1 );
+                        target_layout, priority_1, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk = TriangularMatrix<scalar_t>(
@@ -240,7 +240,7 @@ void getrf_tntpiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub( k, k, j, j ),
-                        priority_one, Layout::ColMajor, queue_jk1 );
+                        priority_1, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -253,7 +253,7 @@ void getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, j, j ),
                         one,  A.sub( k+1, A_mt-1, j, j ),
-                        host_layout, priority_one, queue_jk1 );
+                        host_layout, priority_1, queue_jk1 );
                 }
             }
 
@@ -267,7 +267,7 @@ void getrf_tntpiv(
                     int tag = 1 + k + A_mt * 2;
                     internal::permuteRows<Target::HostTask>(
                         Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
-                        host_layout, priority_zero, tag, queue_0);
+                        host_layout, priority_0, tag, queue_0 );
                 }
             }
 
@@ -282,7 +282,7 @@ void getrf_tntpiv(
                     int tag_kl1 = k+1+lookahead;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, k+1+lookahead, A_nt-1),
-                        pivots.at(k), target_layout, priority_zero, tag_kl1, queue_1);
+                        pivots.at(k), target_layout, priority_0, tag_kl1, queue_1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -293,7 +293,7 @@ void getrf_tntpiv(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub( k, k, k+1+lookahead, A_nt-1 ),
-                        priority_zero, Layout::ColMajor, queue_1);
+                        priority_0, Layout::ColMajor, queue_1 );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastListTag bcast_list;
@@ -311,7 +311,7 @@ void getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, k+1+lookahead, A_nt-1 ),
                         one,  A.sub( k+1, A_mt-1, k+1+lookahead, A_nt-1 ),
-                        host_layout, priority_zero, queue_1);
+                        host_layout, priority_0, queue_1 );
                 }
             }
             if (is_shared) {

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -60,8 +60,6 @@ void getrf_tntpiv(
     int64_t A_nt = A.nt();
     int64_t A_mt = A.mt();
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
-    const int64_t batch_size_zero = 0;
-    const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
     pivots.resize(min_mt_nt);
 
@@ -73,7 +71,9 @@ void getrf_tntpiv(
     std::vector< scalar_t* > dwork_array( num_devices, nullptr );
 
     if (target == Target::Devices) {
-        A.allocateBatchArrays(batch_size_zero, num_queues);
+        const int64_t batch_size_default = 0;
+        int num_queues = 2 + lookahead;
+        A.allocateBatchArrays( batch_size_default, num_queues );
         A.reserveDeviceWorkspace();
 
         int64_t mlocal = 0;

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -227,9 +227,10 @@ void getrf_tntpiv(
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
+                    int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, j-k+1);
+                        target_layout, priority_one, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk = TriangularMatrix<scalar_t>(
@@ -239,7 +240,7 @@ void getrf_tntpiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub( k, k, j, j ),
-                        priority_one, Layout::ColMajor, j-k+1);
+                        priority_one, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -252,7 +253,7 @@ void getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, j, j ),
                         one,  A.sub( k+1, A_mt-1, j, j ),
-                        host_layout, priority_one, j-k+1);
+                        host_layout, priority_one, queue_jk1 );
                 }
             }
 

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -202,8 +202,8 @@ void he2hb(
                                           A.sub( i+1, nt-1, i, i ) }, i } );
                         }
                     }
-                    int life_5 = 5;
-                    int life_6 = 6;
+                    const int life_5 = 5;
+                    const int life_6 = 6;
                     A.template listBcastMT<target>(
                         bcast_list_V_first, layout, life_5, set_hold );
                     A.template listBcastMT<target>(
@@ -247,7 +247,7 @@ void he2hb(
                                 { i0, k, { Tlocal.sub( i, i, k+1, i ),
                                            Tlocal.sub( i+1, nt-1, i, i ) }, i } );
                         }
-                        int life_1 = 1;
+                        const int life_1 = 1;
                         Tlocal.template listBcastMT<target>(
                             bcast_list_T, layout, life_1, set_hold );
                     }

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -36,15 +36,14 @@ void he2hb(
     assert( A.uplo() == Uplo::Lower );  // for now
 
     // Constants
-    // Assumes column major
-    const Layout layout = Layout::ColMajor;
-    const LayoutConvert layout_conv = LayoutConvert( layout );
-
-    const int priority_one = 1;
     const scalar_t zero = 0.0;
     const scalar_t one  = 1.0;
     const scalar_t half = 0.5;
     const real_t r_one  = 1.0;
+    const int priority_1 = 1;
+    // Assumes column major
+    const Layout layout = Layout::ColMajor;
+    const LayoutConvert layout_conv = LayoutConvert( layout );
 
     // Options
     int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
@@ -168,7 +167,7 @@ void he2hb(
                 internal::geqrf<Target::HostTask>(
                     std::move( A_panel ),
                     std::move( Tlocal_panel ),
-                    ib, max_panel_threads, priority_one);
+                    ib, max_panel_threads, priority_1 );
 
                 // triangle-triangle reductions
                 // ttqrt handles tile transfers internally

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -41,6 +41,8 @@ void he2hb(
     const scalar_t half = 0.5;
     const real_t r_one  = 1.0;
     const int priority_1 = 1;
+    const int batch_size_default = 0;
+    const int num_queues = 10;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layout_conv = LayoutConvert( layout );
@@ -105,7 +107,6 @@ void he2hb(
     // Since W( 0, 0 ) is otherwise unused, store TVAVT there.
     W.tileInsert( 0, 0 );
     auto TVAVT = W.sub( 0, 0, 0, 0 );
-    int num_queues = 10;
 
     int my_rank = A.mpiRank();
 
@@ -153,7 +154,7 @@ void he2hb(
                     if (target == Target::Devices) {
                         A.allocateBatchArrays();
                         A.reserveDeviceWorkspace();
-                        W.allocateBatchArrays( 0, num_queues );
+                        W.allocateBatchArrays( batch_size_default, num_queues );
                         W.reserveDeviceWorkspace();
                     }
                 }

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -202,8 +202,12 @@ void he2hb(
                                           A.sub( i+1, nt-1, i, i ) }, i } );
                         }
                     }
-                    A.template listBcastMT<target>( bcast_list_V_first, layout, 5, set_hold );
-                    A.template listBcastMT<target>( bcast_list_V, layout, 6, set_hold );
+                    int life_5 = 5;
+                    int life_6 = 6;
+                    A.template listBcastMT<target>(
+                        bcast_list_V_first, layout, life_5, set_hold );
+                    A.template listBcastMT<target>(
+                        bcast_list_V, layout, life_6, set_hold );
 
                     if (first_indices.size() > 1) {
                         //BcastList bcast_list_T;
@@ -243,7 +247,9 @@ void he2hb(
                                 { i0, k, { Tlocal.sub( i, i, k+1, i ),
                                            Tlocal.sub( i+1, nt-1, i, i ) }, i } );
                         }
-                        Tlocal.template listBcastMT<target>( bcast_list_T, layout, 1, set_hold );
+                        int life_1 = 1;
+                        Tlocal.template listBcastMT<target>(
+                            bcast_list_T, layout, life_1, set_hold );
                     }
                 } // task
 

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -26,6 +26,14 @@ void hegst(
     using BcastList = typename Matrix<scalar_t>::BcastList;
     using real_t = blas::real_type<scalar_t>;
 
+    // Constants
+    const scalar_t half = 0.5;
+    const scalar_t one  = 1.0;
+    const real_t r_one  = 1.0;
+    const int tag_0  = 0;
+    const int life_2 = 2;
+    const Layout layout = Layout::ColMajor;
+
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
@@ -41,15 +49,6 @@ void hegst(
     }
 
     int64_t nt = A.nt();
-
-    const scalar_t half = 0.5;
-    const scalar_t one  = 1.0;
-    const real_t r_one  = 1.0;
-
-    const int tag_zero        = 0;
-    const int life_factor_two = 2;
-
-    const Layout layout = Layout::ColMajor;
 
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> column_vector(nt);
@@ -99,7 +98,7 @@ void hegst(
                     #pragma omp task depend(inout:column[k])
                     {
                         A.tileBcast(
-                            k, k, Asub, layout, tag_zero, life_factor_two);
+                            k, k, Asub, layout, tag_0, life_2 );
 
                         BcastList bcast_list;
                         for (int64_t i = k+1; i < nt; ++i) {
@@ -107,7 +106,7 @@ void hegst(
                                                          A.sub(i, nt-1, i, i)}});
                         }
                         B.template listBcast<target>(
-                            bcast_list, layout, tag_zero, life_factor_two);
+                            bcast_list, layout, tag_0, life_2 );
                     }
 
                     #pragma omp task depend(in:column[k]) \
@@ -154,7 +153,7 @@ void hegst(
                     #pragma omp task depend(inout:column[0])
                     {
                         A.tileBcast(
-                            k, k, Asub, layout, tag_zero, life_factor_two);
+                            k, k, Asub, layout, tag_0, life_2 );
 
                         BcastList bcast_list;
                         for (int64_t i = 0; i < k; ++i) {
@@ -162,7 +161,7 @@ void hegst(
                                                          A.sub(i, i,   0, i)}});
                         }
                         B.template listBcast<target>(
-                            bcast_list, layout, tag_zero, life_factor_two);
+                            bcast_list, layout, tag_0, life_2 );
 
                         B.template tileBcast<target>(k, k, Asub, layout);
                     }

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -48,7 +48,8 @@ void hemmC(
 
     // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -81,8 +82,6 @@ void hemmC(
     std::vector<uint8_t>  gemm_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -157,7 +156,7 @@ void hemmC(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local );
+                    priority_0, opts_local );
 
                 // Erase remote tile on all devices including host
                 A.eraseRemoteWorkspaceTile( 0, 0 );
@@ -170,7 +169,7 @@ void hemmC(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -240,7 +239,7 @@ void hemmC(
                         alpha,  conjTranspose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -250,7 +249,7 @@ void hemmC(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -261,7 +260,7 @@ void hemmC(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -345,7 +344,7 @@ void hemmC(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local);
+                    priority_0, opts_local );
 
                 A.eraseRemoteWorkspaceTile( 0, 0 );
                 A.eraseLocalWorkspaceTile( 0, 0 );
@@ -356,7 +355,7 @@ void hemmC(
                         alpha, conjTranspose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -424,7 +423,7 @@ void hemmC(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -434,7 +433,7 @@ void hemmC(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -445,7 +444,7 @@ void hemmC(
                             alpha,  conjTranspose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -82,7 +82,7 @@ void hemmC(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -170,7 +170,7 @@ void hemmC(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -240,7 +240,7 @@ void hemmC(
                         alpha,  conjTranspose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -261,7 +261,7 @@ void hemmC(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -356,7 +356,7 @@ void hemmC(
                         alpha, conjTranspose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -424,7 +424,7 @@ void hemmC(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -445,7 +445,7 @@ void hemmC(
                             alpha,  conjTranspose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -59,7 +59,7 @@ void her2k(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -122,7 +122,7 @@ void her2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, default_queue, layout, opts_local );
+                default_priority, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -169,7 +169,7 @@ void her2k(
                     alpha,         std::move( A_colk ),
                                    std::move( B_colk ),
                     real_t( 1.0 ), std::move( C ),
-                    default_priority, default_queue, layout, opts_local );
+                    default_priority, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -58,7 +58,7 @@ void her2k(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -122,7 +122,7 @@ void her2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -169,7 +169,7 @@ void her2k(
                     alpha,         std::move( A_colk ),
                                    std::move( B_colk ),
                     real_t( 1.0 ), std::move( C ),
-                    default_priority, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -55,7 +55,7 @@ void herk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -106,7 +106,7 @@ void herk(
             internal::herk<target>(
                 alpha, A.sub(0, A.mt()-1, 0, 0),
                 beta,  std::move(C),
-                default_priority, queue_0, layout, opts2);
+                priority_0, queue_0, layout, opts2);
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
@@ -145,7 +145,7 @@ void herk(
                 internal::herk<target>(
                     alpha,       A.sub(0, A.mt()-1, k, k),
                     real_t(1.0), std::move(C),
-                    default_priority, queue_0, layout, opts2);
+                    priority_0, queue_0, layout, opts2);
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -56,7 +56,7 @@ void herk(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -106,7 +106,7 @@ void herk(
             internal::herk<target>(
                 alpha, A.sub(0, A.mt()-1, 0, 0),
                 beta,  std::move(C),
-                default_priority, default_queue, layout, opts2);
+                default_priority, queue_0, layout, opts2);
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
@@ -145,7 +145,7 @@ void herk(
                 internal::herk<target>(
                     alpha,       A.sub(0, A.mt()-1, k, k),
                     real_t(1.0), std::move(C),
-                    default_priority, default_queue, layout, opts2);
+                    default_priority, queue_0, layout, opts2);
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -34,6 +34,12 @@ void hetrf(
     using BcastList  = typename Matrix<scalar_t>::BcastList;
     using ReduceList = typename Matrix<scalar_t>::ReduceList;
 
+    // Constants
+    const scalar_t zero = 0.0;
+    const scalar_t one  = 1.0;
+    const int64_t ione  = 1;
+    const int64_t izero = 0;
+    const int priority_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -61,11 +67,6 @@ void hetrf(
     //uint8_t* ind1 = Ind1.data();
     //uint8_t* ind2 = Ind2.data();
 
-    const scalar_t zero = 0.0;
-    const scalar_t one  = 1.0;
-    int64_t ione  = 1;
-    int64_t izero = 0;
-    int priority_one = 1;
     assert(A.uplo() == Uplo::Lower); // upper not implemented, yet
 
     pivots.resize(A_mt);
@@ -337,7 +338,7 @@ void hetrf(
                                     -one, A.sub(k+1, A_mt-1, j, j),
                                           Hj.sub(0, 0, 0, 0),
                                     one,  A.sub(k+1, A_mt-1, k, k),
-                                    layout, priority_one);
+                                    layout, priority_1 );
                             }
                         }
                     }
@@ -359,7 +360,7 @@ void hetrf(
                         -one, A.sub(k+1, A_mt-1, k-1, k-1),
                               Hj.sub(0,   0,     0, 0),
                         one,  A.sub(k+1, A_mt-1, k, k),
-                        layout, priority_one);
+                        layout, priority_1 );
                 }
             }
 
@@ -370,7 +371,7 @@ void hetrf(
                 //printf( " >> LU panel(%ld:%ld,%ld) diag_len=%ld on rank-%d <<\n", k+1, A_mt-1, k, diag_len, rank); fflush(stdout);
                 internal::getrf_panel<Target::HostTask>(
                     A.sub(k+1, A_mt-1, k, k), diag_len, ib,
-                    pivots.at(k+1), max_panel_threads, priority_one);
+                    pivots.at(k+1), max_panel_threads, priority_1 );
 
                 // copy U(k, k) into T(k+1, k)
                 //printf( " >> compute T(%ld,%ld) on rank-%d <<\n", k+1, k, rank); fflush(stdout);

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -269,10 +269,11 @@ void potrf(
                                  depend(inout:column[j])
                 {
                     // A(j, j) -= A(j, k) * A(j, k)^H
+                    int queue_jk1 = j-k+2;
                     internal::herk<Target::Devices>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
-                        priority_zero, j-k+2, layout, opts2);
+                        priority_zero, queue_jk1, layout, opts2 );
 
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
@@ -281,7 +282,7 @@ void potrf(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, priority_zero, j-k+2, opts2);
+                            layout, priority_zero, queue_jk1, opts2 );
                     }
                 }
             }

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -268,11 +268,11 @@ void potrf(
                                  depend(inout:column[j])
                 {
                     // A(j, j) -= A(j, k) * A(j, k)^H
-                    int queue_jk1 = j-k+2;
+                    int queue_jk2 = j-k+2;
                     internal::herk<Target::Devices>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
-                        priority_0, queue_jk1, layout, opts2 );
+                        priority_0, queue_jk2, layout, opts2 );
 
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
@@ -281,7 +281,7 @@ void potrf(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, priority_0, queue_jk1, opts2 );
+                            layout, priority_0, queue_jk2, opts2 );
                     }
                 }
             }

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -146,7 +146,7 @@ void potrf(
     using real_t = blas::real_type<scalar_t>;
     using BcastListTag = typename Matrix<scalar_t>::BcastListTag;
 
-	// Constants
+    // Constants
     const scalar_t one = 1.0;
     const int priority_0 = 0;
     const int queue_0 = 0;
@@ -178,9 +178,6 @@ void potrf(
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
 
-    const int64_t batch_size_zero = 0;
-    const int num_queues = 3 + lookahead;  // Number of kernels with lookahead
-
     // Allocate batch arrays = number of kernels without lookahead + lookahead
     // number of kernels without lookahead = 3
     // (internal::potrf, internal::gemm, and internal::trsm)
@@ -189,7 +186,9 @@ void potrf(
     // and the batch_arrays_index starts from
     // the number of kernels without lookahead, and then incremented by 1
     // for every execution for the internal::herk
-    A.allocateBatchArrays(batch_size_zero, num_queues);
+    const int64_t batch_size_default = 0;
+    int num_queues = 3 + lookahead;  // Number of kernels with lookahead
+    A.allocateBatchArrays( batch_size_default, num_queues );
     A.reserveDeviceWorkspace();
 
     // Allocate

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -78,7 +78,7 @@ void symm(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -164,7 +164,7 @@ void symm(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -231,7 +231,7 @@ void symm(
                         alpha,  transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -252,7 +252,7 @@ void symm(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -342,7 +342,7 @@ void symm(
                         alpha, transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -407,7 +407,7 @@ void symm(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -428,7 +428,7 @@ void symm(
                             alpha,  transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -46,7 +46,8 @@ void symm(
 
     // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -77,8 +78,6 @@ void symm(
     std::vector<uint8_t>  gemm_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -151,7 +150,7 @@ void symm(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local );
+                    priority_0, opts_local );
 
                 // Erase remote tile on all devices including host
                 A.eraseRemoteWorkspaceTile( 0, 0 );
@@ -164,7 +163,7 @@ void symm(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -231,7 +230,7 @@ void symm(
                         alpha,  transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -241,7 +240,7 @@ void symm(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -252,7 +251,7 @@ void symm(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -334,7 +333,7 @@ void symm(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local);
+                    priority_0, opts_local );
 
                 if (A.mt()-1 > 0) {
                     auto Arow_0 = A.sub( 0, 0, 1, A.mt()-1 );
@@ -342,7 +341,7 @@ void symm(
                         alpha, transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -407,7 +406,7 @@ void symm(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -417,7 +416,7 @@ void symm(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -428,7 +427,7 @@ void symm(
                             alpha,  transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -63,7 +63,7 @@ void syr2k(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -124,7 +124,7 @@ void syr2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, default_queue, layout, opts_local );
+                default_priority, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -171,7 +171,7 @@ void syr2k(
                     alpha, std::move( A_colk ),
                            std::move( B_colk ),
                     one,   std::move( C ),
-                    default_priority, default_queue, layout, opts_local );
+                    default_priority, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -62,7 +62,7 @@ void syr2k(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -124,7 +124,7 @@ void syr2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -171,7 +171,7 @@ void syr2k(
                     alpha, std::move( A_colk ),
                            std::move( B_colk ),
                     one,   std::move( C ),
-                    default_priority, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -33,8 +33,10 @@ void syrk(
 {
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -59,8 +61,6 @@ void syrk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int priority_0 = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -59,7 +59,7 @@ void syrk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -111,7 +111,7 @@ void syrk(
             internal::syrk<target>(
                 alpha, std::move( A_col0 ),
                 beta,  std::move( C ),
-                default_priority, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -150,7 +150,7 @@ void syrk(
                 internal::syrk<target>(
                     alpha, std::move( A_colk ),
                     one,   std::move( C ),
-                    default_priority, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -60,7 +60,7 @@ void syrk(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -111,7 +111,7 @@ void syrk(
             internal::syrk<target>(
                 alpha, std::move( A_col0 ),
                 beta,  std::move( C ),
-                default_priority, default_queue, layout, opts_local );
+                default_priority, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -150,7 +150,7 @@ void syrk(
                 internal::syrk<target>(
                     alpha, std::move( A_colk ),
                     one,   std::move( C ),
-                    default_priority, default_queue, layout, opts_local );
+                    default_priority, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -35,6 +35,7 @@ void tbsm(
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major
+    const int priority_1 = 1;
     const Layout layout = Layout::ColMajor;
 
     // Options
@@ -282,7 +283,7 @@ void tbsm(
                                     -one, A.sub(k, k, i, i),
                                           B.sub(i, i, 0, nt-1),
                                     one,  B.sub(k, k, 0, nt-1),
-                                    layout, 1);
+                                    layout, priority_1 );
                     }
                 }
 

--- a/src/trmm.cc
+++ b/src/trmm.cc
@@ -27,9 +27,9 @@ void trmm(
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0; // use default batch size
-        const int64_t num_arrays_two = 2; // Number of kernels without lookahead
-        B.allocateBatchArrays(batch_size_zero, num_arrays_two);
+        const int64_t batch_size_default = 0; // use default batch size
+        const int num_queues = 2; // Number of kernels without lookahead
+        B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }
 

--- a/src/trsmA.cc
+++ b/src/trsmA.cc
@@ -27,8 +27,6 @@ void trsmA(
     int64_t lookahead = get_option<int64_t>(opts, Option::Lookahead, 1);
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0;
-        const int64_t num_arrays_two = 2; // Number of kernels without lookahead
         // Allocate batch arrays = number of kernels without
         // lookahead + lookahead
         // number of kernels without lookahead = 2
@@ -41,7 +39,9 @@ void trsmA(
         // and the batch_arrays_index starts from
         // the number of kernels without lookahead, and then incremented by 1
         // for every execution for the internal::gemm with lookahead
-        B.allocateBatchArrays(batch_size_zero, num_arrays_two);
+        const int64_t batch_size_default = 0;
+        int num_queues = 2; // Number of kernels without lookahead
+        B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }
 

--- a/src/trsmB.cc
+++ b/src/trsmB.cc
@@ -27,7 +27,6 @@ void trsmB(
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0;
         // Allocate batch arrays = number of kernels without
         // lookahead + lookahead
         // number of kernels without lookahead = 2
@@ -45,8 +44,9 @@ void trsmB(
         // 1) trsm                            (         1 )
         // 2) gemm for trailing matrix update (         1 )
         // 3) lookahead number of gemm's      ( lookahead )
-        const int num_queues = 2 + lookahead;
-        B.allocateBatchArrays( batch_size_zero, num_queues );
+        const int64_t batch_size_default = 0;
+        int num_queues = 2 + lookahead;
+        B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }
 

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -27,7 +27,6 @@ void unmlq(
     Options const& opts )
 {
     // trace::Block trace_block("unmlq");
-    // const int priority_one = 1;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -27,7 +27,6 @@ void unmqr(
     Options const& opts )
 {
     // trace::Block trace_block("unmqr");
-    // const int priority_one = 1;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major

--- a/src/unmtr_hb2st.cc
+++ b/src/unmtr_hb2st.cc
@@ -29,10 +29,10 @@ void unmtr_hb2st(slate::internal::TargetType<target>,
 {
     if (target == Target::Devices) {
         trace::Block trace_block("quealloc");
-        const int64_t batch_size_zero = 0; // use default batch size
+        const int64_t batch_size_default = 0; // use default batch size
         // use separate queue for each parallel task in internal_unmtr_hb2st
-        const int64_t num_queues = omp_get_max_threads();
-        C.allocateBatchArrays(batch_size_zero, num_queues);
+        int num_queues = omp_get_max_threads();
+        C.allocateBatchArrays( batch_size_default, num_queues );
     }
 
     // set min number for omp nested active parallel regions

--- a/src/work/work_trmm.cc
+++ b/src/work/work_trmm.cc
@@ -65,8 +65,12 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     using blas::conj;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -91,14 +95,9 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    const int priority_0 = 0;
-    const int priority_1 = 1;
-
     // Requires at least 2 queues
     if (target == Target::Devices)
         assert(B.numComputeQueues() >= 2);
-    const int64_t queue_0 = 0;
-    const int64_t queue_1 = 1;
 
     if (A.uplo() == Uplo::Upper) {
         // ----------------------------------------
@@ -189,7 +188,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(0, k-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(0, k-1, 0, nt-1),
-                    layout, priority_0, queue_0);
+                    layout, priority_0, queue_0 );
 
                 internal::trmm<target>(
                     Side::Left,
@@ -292,7 +291,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(k+1, mt-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(k+1, mt-1, 0, nt-1),
-                    layout, priority_0, queue_0);
+                    layout, priority_0, queue_0 );
 
                 // todo: target? needs batch trmm
                 internal::trmm<target>(

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -57,12 +57,17 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     using blas::conj;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
-
-    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
-
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
+
+    // Options
+    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     // if on right, change to left by (conj)-transposing A and B to get
     // op(B) = op(A)^{-1} * op(B)
@@ -85,9 +90,6 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    const int priority_one  = 1;
-    const int priority_zero = 0;
-
     Options opts2 = opts;
 
     // Requires 2+lookahead queues
@@ -100,9 +102,6 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
         // clean up tiles.
         opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
     }
-
-    const int64_t queue_0 = 0;
-    const int64_t queue_1 = 1;
 
     if (A.uplo() == Uplo::Lower) {
         // ----------------------------------------
@@ -122,7 +121,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_one, layout, queue_1, opts2);
+                    priority_1, layout, queue_1, opts2 );
 
                 // send A(i=k+1:mt-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -150,7 +149,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, queue_ik1, opts2 );
+                        layout, priority_1, queue_ik1, opts2 );
                 }
             }
 
@@ -168,7 +167,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(k+1+lookahead, mt-1, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(k+1+lookahead, mt-1, 0, nt-1),
-                        layout, priority_zero, queue_0, opts2);
+                        layout, priority_0, queue_0, opts2 );
                 }
             }
 
@@ -207,7 +206,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_one, layout, queue_1, opts2);
+                    priority_1, layout, queue_1, opts2 );
 
                 // send A(i=0:k-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -232,7 +231,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, queue_ikl2, opts2 );
+                        layout, priority_1, queue_ikl2, opts2 );
                 }
             }
 
@@ -249,7 +248,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(0, k-1-lookahead, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(0, k-1-lookahead, 0, nt-1),
-                        layout, priority_zero, queue_0, opts2);
+                        layout, priority_0, queue_0, opts2 );
                 }
             }
 

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -145,11 +145,12 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 #pragma omp task depend(in:row[k]) \
                                  depend(inout:row[i]) priority(1)
                 {
+                    int queue_ik1 = i-k+1;
                     internal::gemm<target>(
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, i-k+1, opts2);
+                        layout, priority_one, queue_ik1, opts2 );
                 }
             }
 
@@ -226,11 +227,12 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 #pragma omp task depend(in:row[k]) \
                                  depend(inout:row[i]) priority(1)
                 {
+                    int queue_ikl2 = i-k+lookahead+2;
                     internal::gemm<target>(
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, i-k+lookahead+2, opts2);
+                        layout, priority_one, queue_ikl2, opts2 );
                 }
             }
 

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -60,6 +60,12 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     using std::real;
     using std::imag;
 
+    // Constants
+    const scalar_t one = 1.0;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    //const int queue_0 = 0;
+    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -84,16 +90,9 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    const int priority_one  = 1;
-    const int priority_zero = 0;
-
     // Requires 2 queues
     if (target == Target::Devices)
         assert(B.numComputeQueues() >= 2);
-    //const int64_t queue_0 = 0;
-    const int64_t queue_1 = 1;
-
-    const scalar_t one = 1.0;
 
     if (A.uplo() == Uplo::Lower) {
         // ----------------------------------------
@@ -144,7 +143,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_one, layout, queue_1);
+                        priority_1, layout, queue_1 );
                 }
 
                 // Send the solution back to where it belongs
@@ -200,7 +199,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(i, i, 0, nt-1),
-                        layout, priority_one);
+                        layout, priority_1 );
                 }
             }
 
@@ -232,7 +231,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(k+1+lookahead, mt-1, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(k+1+lookahead, mt-1, 0, nt-1),
-                        layout, priority_zero); //, queue_0);
+                        layout, priority_0 ); //, queue_0 );
                 }
             }
         }
@@ -287,7 +286,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_one, layout, queue_1);
+                        priority_1, layout, queue_1 );
                 }
 
                 // Send the solution back to where it belongs
@@ -343,7 +342,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(i, i, 0, nt-1),
-                        layout, priority_one);
+                        layout, priority_1 );
                 }
             }
 
@@ -375,7 +374,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(0, k-1-lookahead, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(0, k-1-lookahead, 0, nt-1),
-                        layout, priority_zero); //, queue_0);
+                        layout, priority_0 ); //, queue_0 );
                 }
             }
         }


### PR DESCRIPTION
Rename constants and group into a common section near the top of each function. [See style guide.](https://bitbucket.org/icl/slate/wiki/style/code-style-guide.md#markdown-header-constants)
Names like priority_zero are renamed priority_0.
Add constants for literals that are otherwise obscure, e.g.,
```
    blas::gemm( ..., layout, 1, j-k+1 );
```
becomes
```
    blas::gemm( ..., layout, priority_1, queue_jk1 );
```
Wouldn't it be nice if C++ supported named arguments like Python:
```
    blas::gemm( ..., layout, priority=1, queue=j-k+1 );
```
On the other hand, I don't see the point of repeating `priority(priority_one)`, so just used `priority(1)`.

I called it `batch_size_default` rather than `batch_size_0` because what it means is use the default batch size, i.e., the local number of tiles in the matrix.