### PR TITLE
conj_transpose renamed

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -134,14 +134,18 @@ private:
 
 public:
     /// Returns shallow copy of op(A) that is transposed.
-    /// @see conjTranspose
+    /// @see conj_transpose
     template<typename MatrixType>
     friend MatrixType transpose(MatrixType& A);
 
     /// Returns shallow copy of op(A) that is conjugate-transpose.
     /// @see transpose
     template<typename MatrixType>
-    friend MatrixType conjTranspose(MatrixType& A);
+    friend MatrixType conj_transpose( MatrixType& A );
+
+    /// @deprecated
+    template<typename MatrixType>
+    friend MatrixType conjTranspose( MatrixType& A );
 
     template <typename T>
     friend void swap(BaseMatrix<T>& A, BaseMatrix<T>& B);
@@ -1181,7 +1185,7 @@ BaseMatrix<out_scalar_t> BaseMatrix<scalar_t>::baseEmptyLike(
         std::swap(mt, nt);
     }
     else if (this->op() == Op::ConjTrans) {
-        B = conjTranspose( B );
+        B = conj_transpose( B );
         std::swap(ioffset, joffset);
         std::swap(mt, nt);
     }

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -68,7 +68,7 @@ MatrixType transpose(MatrixType&& A)
 /// @ingroup util
 ///
 template<typename MatrixType>
-MatrixType conjTranspose(MatrixType& A)
+MatrixType conj_transpose( MatrixType& A )
 {
     MatrixType AT = A;
     if (AT.op_ == Op::NoTrans)
@@ -84,9 +84,9 @@ MatrixType conjTranspose(MatrixType& A)
 //--------------------------------------
 /// Converts rvalue refs to lvalue refs.
 template<typename MatrixType>
-MatrixType conjTranspose(MatrixType&& A)
+MatrixType conj_transpose( MatrixType&& A )
 {
-    return conjTranspose(A);
+    return conj_transpose( A );
 }
 
 //------------------------------------------------------------------------------
@@ -98,16 +98,18 @@ MatrixType conjTranspose(MatrixType&& A)
 /// @ingroup util
 ///
 template<typename MatrixType>
-MatrixType conj_transpose(MatrixType& A)
+[[deprecated( "Use conj_transpose instead. Remove 2024-02." )]]
+MatrixType conjTranspose( MatrixType& A )
 {
-    return conjTranspose(A);
+    return conj_transpose( A );
 }
 
 //--------------------------------------
 template<typename MatrixType>
-MatrixType conj_transpose(MatrixType&& A)
+[[deprecated( "Use conj_transpose instead. Remove 2024-02." )]]
+MatrixType conjTranspose( MatrixType&& A )
 {
-    return conjTranspose(A);
+    return conj_transpose( A );
 }
 
 //------------------------------------------------------------------------------
@@ -158,11 +160,11 @@ public:
 
     /// Returns shallow copy of tile that is conjugate-transposed.
     template <typename TileType>
-    friend TileType conjTranspose(TileType& A);
+    friend TileType conj_transpose( TileType& A );
 
     /// @deprecated
     template <typename TileType>
-    friend TileType conj_transpose(TileType& A);
+    friend TileType conjTranspose( TileType& A );
 
     /// Returns number of rows of op(A), where A is this tile
     int64_t mb() const { return (op_ == Op::NoTrans ? mb_ : nb_); }

--- a/include/slate/Tile_blas.hh
+++ b/include/slate/Tile_blas.hh
@@ -20,10 +20,10 @@ namespace tile {
 
 //------------------------------------------------------------------------------
 /// General matrix multiply: $op(C) = \alpha op(A) op(B) + \beta C$.
-/// Use transpose() or conjTranspose() to set $op(A)$, $op(B)$, and $op(C)$.
+/// Use transpose() or conj_transpose() to set $op(A)$, $op(B)$, and $op(C)$.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 /// @ingroup gemm_tile
 ///
 template <typename scalar_t>
@@ -264,7 +264,7 @@ void hemm(
 
 //------------------------------------------------------------------------------
 /// Hermitian rank-k update: $C = \alpha op(A) op(A)^H + \beta C$.
-/// Use conjTranspose to set $op(A)$.
+/// Use conj_transpose to set $op(A)$.
 /// In the complex case, C cannot be transpose.
 /// @ingroup herk_tile
 ///
@@ -304,7 +304,7 @@ void herk(
 //------------------------------------------------------------------------------
 /// Hermitian rank-2k update:
 ///     $C = \alpha op(A) op(B)^T + \alpha op(B) op(A)^T + \beta C$.
-/// Use transpose or conjTranspose to set $op(A)$ and $op(B)$.
+/// Use transpose or conj_transpose to set $op(A)$ and $op(B)$.
 /// In the complex case, C cannot be transpose.
 /// @ingroup her2k_tile
 ///
@@ -514,8 +514,8 @@ void hemv(scalar_t alpha, Tile<scalar_t> const&& A,
 
 //------------------------------------------------------------------------------
 /// Symmetric rank-k update: $C = \alpha op(A) op(A)^T + \beta C$.
-/// Use transpose or conjTranspose to set $op(A)$.
-/// In the complex case, C cannot be conjTranspose.
+/// Use transpose or conj_transpose to set $op(A)$.
+/// In the complex case, C cannot be conj_transpose.
 /// @ingroup syrk_tile
 ///
 // Allowing C^H would require two conjugations: conj( conj(C) + A*A^T ).
@@ -556,8 +556,8 @@ void syrk(
 //------------------------------------------------------------------------------
 /// Symmetric rank-2k update:
 ///     $C = \alpha op(A) op(B)^T + \alpha op(B) op(A)^T + \beta C$.
-/// Use transpose or conjTranspose to set $op(A)$ and $op(B)$.
-/// In the complex case, C cannot be conjTranspose.
+/// Use transpose or conj_transpose to set $op(A)$ and $op(B)$.
+/// In the complex case, C cannot be conj_transpose.
 /// @ingroup syr2k_tile
 ///
 // Allowing C^H would require two conjugations: conj( conj(C) + A*A^T ).
@@ -672,10 +672,10 @@ void trmm(
 
 //------------------------------------------------------------------------------
 /// Triangular solve: $B = \alpha op(A)^{-1} B$ or $B = \alpha B op(A)^{-1}$.
-/// Use transpose/conjTranspose to set op(A). uplo is set in the tile.
+/// Use transpose/conj_transpose to set op(A). uplo is set in the tile.
 /// In the complex case,
-/// if $op(B)$ is transpose, then $op(A)$ cannot be conjTranspose;
-/// if $op(B)$ is conjTranspose, then $op(A)$ cannot be transpose.
+/// if $op(B)$ is transpose, then $op(A)$ cannot be conj_transpose;
+/// if $op(B)$ is conj_transpose, then $op(A)$ cannot be transpose.
 /// @ingroup trsm_tile
 ///
 template <typename scalar_t>

--- a/lapack_api/lapack_gels.cc
+++ b/lapack_api/lapack_gels.cc
@@ -96,7 +96,7 @@ void slate_pgels(const char* transstr, int m, int n, int nrhs, scalar_t* a, int 
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     slate::gels(opA, B, {
         {slate::Option::Lookahead, lookahead},

--- a/lapack_api/lapack_gemm.cc
+++ b/lapack_api/lapack_gemm.cc
@@ -83,12 +83,12 @@ void slate_gemm(const char* transastr, const char* transbstr, int m, int n, int 
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     if (transB == blas::Op::Trans)
         B = transpose(B);
     else if (transB == blas::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     slate::gemm(alpha, A, B, beta, C, {
         {slate::Option::Lookahead, lookahead},

--- a/lapack_api/lapack_getrs.cc
+++ b/lapack_api/lapack_getrs.cc
@@ -102,7 +102,7 @@ void slate_getrs(const char* transstr, const int n, const int nrhs, scalar_t* a,
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     // solve
     slate::getrs(opA, pivots, B, {

--- a/lapack_api/lapack_her2k.cc
+++ b/lapack_api/lapack_her2k.cc
@@ -72,8 +72,8 @@ void slate_her2k(const char* uplostr, const char* transastr, const int n, const 
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == C.mt());
     assert(B.mt() == C.mt());

--- a/lapack_api/lapack_herk.cc
+++ b/lapack_api/lapack_herk.cc
@@ -67,7 +67,7 @@ void slate_herk(const char* uplostr, const char* transastr, const int n, const i
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     slate::herk(alpha, A, beta, C, {

--- a/lapack_api/lapack_syr2k.cc
+++ b/lapack_api/lapack_syr2k.cc
@@ -84,8 +84,8 @@ void slate_syr2k(const char* uplostr, const char* transastr, const int n, const 
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == C.mt());
     assert(B.mt() == C.mt());

--- a/lapack_api/lapack_syrk.cc
+++ b/lapack_api/lapack_syrk.cc
@@ -79,7 +79,7 @@ void slate_syrk(const char* uplostr, const char* transastr, const int n, const i
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     slate::syrk(alpha, A, beta, C, {

--- a/lapack_api/lapack_trmm.cc
+++ b/lapack_api/lapack_trmm.cc
@@ -81,7 +81,7 @@ void slate_trmm(const char* sidestr, const char* uplostr, const char* transastr,
     if (transA == Op::Trans)
         A = transpose(A);
     else if (transA == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     slate::trmm(side, alpha, A, B, {
         {slate::Option::Lookahead, lookahead},

--- a/lapack_api/lapack_trsm.cc
+++ b/lapack_api/lapack_trsm.cc
@@ -81,7 +81,7 @@ void slate_trsm(const char* sidestr, const char* uplostr, const char* transastr,
     if (transA == Op::Trans)
         A = transpose(A);
     else if (transA == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     slate::trsm(side, alpha, A, B, {
         {slate::Option::Lookahead, lookahead},

--- a/old/src/gemm.cc
+++ b/old/src/gemm.cc
@@ -370,7 +370,7 @@ void gemm(scalar_t alpha, Matrix<scalar_t>& A,
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemm( alpha, AT, BT, beta, C );
 ///
 //------------------------------------------------------------------------------

--- a/old/src/internal/internal_gemm_split.cc
+++ b/old/src/internal/internal_gemm_split.cc
@@ -17,8 +17,8 @@ namespace internal {
 /// where A is a single block column and B is a single block row.
 /// Dispatches to target implementations.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 ///
 /// @param[inout] batchArrays
 ///     holds the pointer arrays to be prepared for later execution

--- a/scalapack_api/scalapack_gels.cc
+++ b/scalapack_api/scalapack_gels.cc
@@ -132,7 +132,7 @@ void slate_pgels(const char* transstr, int m, int n, int nrhs, scalar_t* a, int 
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "gels");

--- a/scalapack_api/scalapack_gemm.cc
+++ b/scalapack_api/scalapack_gemm.cc
@@ -148,12 +148,12 @@ void slate_pgemm(const char* transastr, const char* transbstr, int m, int n, int
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     if (transB == blas::Op::Trans)
         B = transpose(B);
     else if (transB == blas::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "gemm");

--- a/scalapack_api/scalapack_getrs.cc
+++ b/scalapack_api/scalapack_getrs.cc
@@ -178,7 +178,7 @@ void slate_pgetrs(const char* transstr, int n, int nrhs, scalar_t* a, int ia, in
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     // call the SLATE getrs routine
     slate::getrs(opA, pivots, B, opts);

--- a/scalapack_api/scalapack_her2k.cc
+++ b/scalapack_api/scalapack_her2k.cc
@@ -92,8 +92,8 @@ void slate_pher2k(const char* uplostr, const char* transstr, int n, int k, scala
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == CH.mt());
     assert(B.mt() == CH.mt());

--- a/scalapack_api/scalapack_herk.cc
+++ b/scalapack_api/scalapack_herk.cc
@@ -88,7 +88,7 @@ void slate_pherk(const char* uplostr, const char* transstr, int n, int k, blas::
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     slate::herk(alpha, A, beta, C, {

--- a/scalapack_api/scalapack_syr2k.cc
+++ b/scalapack_api/scalapack_syr2k.cc
@@ -129,8 +129,8 @@ void slate_psyr2k(const char* uplostr, const char* transstr, int n, int k, scala
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == CS.mt());
     assert(B.mt() == CS.mt());

--- a/scalapack_api/scalapack_syrk.cc
+++ b/scalapack_api/scalapack_syrk.cc
@@ -122,7 +122,7 @@ void slate_psyrk(const char* uplostr, const char* transstr, int n, int k, scalar
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     if (verbose && myprow == 0 && mypcol == 0)

--- a/scalapack_api/scalapack_trmm.cc
+++ b/scalapack_api/scalapack_trmm.cc
@@ -124,7 +124,7 @@ void slate_ptrmm(const char* sidestr, const char* uplostr, const char* transastr
     if (transA == Op::Trans)
         AT = transpose(AT);
     else if (transA == Op::ConjTrans)
-        AT = conjTranspose(AT);
+        AT = conj_transpose( AT );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "trmm");

--- a/scalapack_api/scalapack_trsm.cc
+++ b/scalapack_api/scalapack_trsm.cc
@@ -124,7 +124,7 @@ void slate_ptrsm(const char* sidestr, const char* uplostr, const char* transastr
     if (transA == Op::Trans)
         AT = transpose(AT);
     else if (transA == Op::ConjTrans)
-        AT = conjTranspose(AT);
+        AT = conj_transpose( AT );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "trsm");

--- a/src/cholqr.cc
+++ b/src/cholqr.cc
@@ -30,7 +30,7 @@ void cholqr(
     const scalar_t one  = 1.0;
     const scalar_t zero = 0.0;
 
-    auto AH = conjTranspose( A );
+    auto AH = conj_transpose( A );
     HermitianMatrix<scalar_t> R_hermitian( Uplo::Upper, R );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R_hermitian );
 
@@ -81,7 +81,7 @@ void cholqr(
     blas::real_type<scalar_t> r_one  = 1.0;
     blas::real_type<scalar_t> r_zero = 0.0;
 
-    auto AH = conjTranspose( A );
+    auto AH = conj_transpose( A );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R );
 
     // Compute R = AH * A.

--- a/src/colNorms.cc
+++ b/src/colNorms.cc
@@ -41,7 +41,7 @@ void colNorms(
         //     in_norm = Norm::One;
     }
     if (A.op() == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     else if (A.op() == Op::Trans)
         A = transpose(A);
 

--- a/src/gbmm.cc
+++ b/src/gbmm.cc
@@ -211,7 +211,7 @@ void gbmm(
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gbmm( alpha, AT, BT, beta, C );
 ///
 //------------------------------------------------------------------------------

--- a/src/gecondest.cc
+++ b/src/gecondest.cc
@@ -141,11 +141,11 @@ void gecondest(
         }
         else {
             // Multiply by inv(U^H).
-            auto UH = conjTranspose( U );
+            auto UH = conj_transpose( U );
             slate::trsmB(Side::Left, alpha, UH, X, opts);
 
             // Multiply by inv(L^H).
-            auto LH = conjTranspose( L );
+            auto LH = conj_transpose( L );
             slate::trsmB(Side::Left, alpha, LH, X, opts);
         }
 

--- a/src/gemm.cc
+++ b/src/gemm.cc
@@ -18,7 +18,7 @@ namespace slate {
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemm( alpha, AT, BT, beta, C );
 ///
 /// Complexity (in real): $2 m n k$ flops.

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -195,7 +195,7 @@ void gemmA(
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemm( alpha, AT, BT, beta, C );
 ///
 /// This algorithmic variant manages computation to be local to the

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -205,7 +205,7 @@ void gemmC(
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemmC( alpha, AT, BT, beta, C );
 ///
 //------------------------------------------------------------------------------

--- a/src/gesvd.cc
+++ b/src/gesvd.cc
@@ -39,7 +39,7 @@ void gesvd(
     if (flip) {
         slate_not_implemented("m < n not yet supported");
         swap(m, n);
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
 
     // Scale matrix to allowable range, if necessary.

--- a/src/hbmm.cc
+++ b/src/hbmm.cc
@@ -55,9 +55,9 @@ void hbmm(
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
-        C = conjTranspose(C);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
+        C = conj_transpose( C );
         alpha = conj(alpha);
         beta  = conj(beta);
     }
@@ -320,7 +320,7 @@ void hbmm(
                 if (i_end-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, i_end-1);
                     internal::gemm<target>(
-                        alpha, conjTranspose(Arow_k),
+                        alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, i_end-1, 0, C.nt()-1),
                         layout);

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -44,8 +44,8 @@ void hegst(
     slate_assert(A.nt() == B.nt());
 
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
 
     int64_t nt = A.nt();
@@ -91,7 +91,7 @@ void hegst(
                         B.template tileBcast<target>(k, k, Asub, layout);
 
                         internal::trsm<target>(
-                            Side::Right,  one,  conjTranspose(TBkk),
+                            Side::Right,  one,  conj_transpose( TBkk ),
                                                 std::move(Asub));
                     }
 
@@ -197,7 +197,7 @@ void hegst(
                                         one,  std::move(Asub));
 
                         internal::trmm<Target::HostTask>(
-                            Side::Left, one,  conjTranspose(TBkk),
+                            Side::Left, one,  conj_transpose( TBkk ),
                                               std::move(Asub));
                     }
                 }

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -47,9 +47,9 @@ void hemmA(
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
-        C = conjTranspose(C);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
+        C = conj_transpose( C );
         alpha = conj(alpha);
         beta  = conj(beta);
     }
@@ -424,7 +424,7 @@ void hemmA(
                 if (A.mt()-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, A.nt()-1);
                     internal::gemmA<target>(
-                        alpha, conjTranspose(Arow_k),
+                        alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, C.mt()-1, 0, C.nt()-1),
                         layout);

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -56,9 +56,9 @@ void hemmC(
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
-        A = conjTranspose( A );
-        B = conjTranspose( B );
-        C = conjTranspose( C );
+        A = conj_transpose( A );
+        B = conj_transpose( B );
+        C = conj_transpose( C );
         alpha = conj( alpha );
         beta  = conj( beta );
     }
@@ -236,7 +236,7 @@ void hemmC(
                     auto Arow_k = A.sub(k, k, 0, k-1);
                     auto Brow_k = B.sub( k, k, 0, B.nt()-1 );
                     internal::gemm<target>(
-                        alpha,  conjTranspose( Arow_k ),
+                        alpha,  conj_transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
@@ -352,7 +352,7 @@ void hemmC(
                 if (A.mt()-1 > 0) {
                     auto Arow_0 = A.sub( 0, 0, 1, A.mt()-1 );
                     internal::gemm<target>(
-                        alpha, conjTranspose( Arow_0 ),
+                        alpha, conj_transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
@@ -441,7 +441,7 @@ void hemmC(
                     if (A.mt()-1 > k) {
                         auto Arow_k = A.sub( k, k, k+1, A.mt()-1 );
                         internal::gemm<target>(
-                            alpha,  conjTranspose( Arow_k ),
+                            alpha,  conj_transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
                             layout, priority_0, queue_0, opts_local );

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -40,7 +40,7 @@ void her2k(
 
     // if upper, change to lower
     if (C.uplo() == Uplo::Upper)
-        C = conjTranspose(C);
+        C = conj_transpose( C );
 
     // A is mt-by-nt, C is mt-by-mt
     assert(A.mt() == C.mt());
@@ -200,8 +200,8 @@ void her2k(
 /// matrix, and A and B are an n-by-k matrices.
 /// The matrices can be conjugate-transposed beforehand, e.g.,
 ///
-///     auto AT = slate::conjTranspose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto AT = slate::conj_transpose( A );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::her2k( alpha, AT, BT, beta, C );
 ///
 /// Complexity (in real): $\approx 2 k n^{2}$ flops.

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -45,7 +45,7 @@ void herk(
 
     // if upper, change to lower
     if (C.uplo() == Uplo::Upper)
-        C = conjTranspose(C);
+        C = conj_transpose( C );
 
     // A is mt-by-nt, C is mt-by-mt
     assert(A.mt() == C.mt());
@@ -176,7 +176,7 @@ void herk(
 /// matrix, and A is an n-by-k matrix.
 /// The matrices can be conjugate-transposed beforehand, e.g.,
 ///
-///     auto AT = slate::conjTranspose( A );
+///     auto AT = slate::conj_transpose( A );
 ///     slate::herk( alpha, AT, beta, C );
 ///
 /// Complexity (in real): $\approx k n^{2}$ flops.

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -106,7 +106,7 @@ void hesv(HermitianMatrix<scalar_t>& A, Pivots& pivots,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     // factorization
     hetrf(A_, pivots, T, pivots2, H, opts);

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -155,7 +155,7 @@ void hetrf(
             {
                 //printf( " >> update T(%ld, %ld) on rank-%d <<\n", k, k, rank); fflush(stdout);
                 auto Hj = H.sub(k, k, 0, k-2);
-                Hj = conjTranspose(Hj);
+                Hj = conj_transpose( Hj );
 
                 #if 0
                 slate::internal::gemm_W<Target::HostTask>(
@@ -186,7 +186,7 @@ void hetrf(
                 if (T.tileIsLocal(k, k)) {
                     H.tileInsert(k, k);
                     auto Lkj = A.sub(k, k, k-2, k-2);
-                    Lkj = conjTranspose(Lkj);
+                    Lkj = conj_transpose( Lkj );
                     tile::gemm<scalar_t>(
                         one,  T(k,   k-1),
                               Lkj(0, 0),
@@ -292,7 +292,7 @@ void hetrf(
                                 H.tileBcast(k, j, A.sub(k+1, A_mt-1, j, j), layout, tag1);
                             }
                             auto Hj = H.sub(k, k, 0, k-2);
-                            Hj = conjTranspose(Hj);
+                            Hj = conj_transpose( Hj );
 
                             #if 1
                                 slate::internal::gemmA<Target::HostTask>(
@@ -333,7 +333,7 @@ void hetrf(
                             }
                             for (int64_t j = 0; j < k-1; ++j) {
                                 auto Hj = H.sub(k, k, j, j);
-                                Hj = conjTranspose(Hj);
+                                Hj = conj_transpose( Hj );
                                 slate::internal::gemm<target>(
                                     -one, A.sub(k+1, A_mt-1, j, j),
                                           Hj.sub(0, 0, 0, 0),
@@ -355,7 +355,7 @@ void hetrf(
                     H.tileBcast(k, k-1, A.sub(k+1, A_mt-1, k, k), layout, tag1);
 
                     auto Hj = H.sub(k, k, k-1, k-1);
-                    Hj = conjTranspose(Hj);
+                    Hj = conj_transpose( Hj );
                     slate::internal::gemm<target>(
                         -one, A.sub(k+1, A_mt-1, k-1, k-1),
                               Hj.sub(0,   0,     0, 0),
@@ -412,7 +412,7 @@ void hetrf(
                         auto Akk = A.sub(k, k, k-1, k-1);
                         auto Lkk = TriangularMatrix< scalar_t >(Uplo::Lower, Diag::NonUnit, Akk);
 
-                        Lkk = conjTranspose(Lkk);
+                        Lkk = conj_transpose( Lkk );
                         tile::trsm(
                             Side::Right, Diag::Unit,
                             one, Lkk(0, 0), T(k+1, k) );

--- a/src/hetrs.cc
+++ b/src/hetrs.cc
@@ -73,7 +73,7 @@ void hetrs(HermitianMatrix<scalar_t>& A, Pivots& pivots,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     int64_t A_nt = A_.nt();
     int64_t A_mt = A_.mt();
@@ -102,7 +102,7 @@ void hetrs(HermitianMatrix<scalar_t>& A, Pivots& pivots,
         // backward substitution with L^T from Aasen's
         auto Lkk = TriangularMatrix<scalar_t>( Diag::NonUnit, A_, 1, A_mt-1, 0, A_nt-2 );
         auto Bkk = B.sub(1, B_mt-1, 0, B_nt-1);
-        Lkk = conjTranspose(Lkk);
+        Lkk = conj_transpose( Lkk );
         trsm(Side::Left, one, Lkk, Bkk, opts);
 
         // pivot right-hand-sides

--- a/src/internal/internal_copyhb2st.cc
+++ b/src/internal/internal_copyhb2st.cc
@@ -45,7 +45,7 @@ void copyhb2st(internal::TargetType<Target::HostTask>,
 
     // If lower, change to upper.
     if (A.uplo() == Uplo::Lower) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
 
     // Make sure it is a tri-diagonal matrix.

--- a/src/internal/internal_copytb2bd.cc
+++ b/src/internal/internal_copytb2bd.cc
@@ -43,7 +43,7 @@ void copytb2bd(internal::TargetType<Target::HostTask>,
 
     // If lower, change to upper.
     if (A.uplo() == Uplo::Lower) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
 
     // Make sure it is a bi-diagonal matrix.

--- a/src/internal/internal_gebr.cc
+++ b/src/internal/internal_gebr.cc
@@ -90,7 +90,7 @@ void gerf(int64_t n, scalar_t* v, Matrix<scalar_t>& A)
     v[0] = one;
 
     // w = A^H v
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     std::vector<scalar_t> w(AH.m());
 
     scalar_t* wi = w.data();
@@ -164,7 +164,7 @@ void gebr1(internal::TargetType<Target::HostTask>,
 
     // Zero A[0, 1:n-1].
     // Apply A Q^H => becomes Q A^H.
-    auto A1 = conjTranspose(A);
+    auto A1 = conj_transpose( A );
     gerfg(A1, n1, v1);
     gerf(n1, v1, A1);
 
@@ -220,7 +220,7 @@ void gebr2(internal::TargetType<Target::HostTask>,
 
     // Zero A[0, 1:n-1].
     // Apply A Q^H => becomes Q A^H.
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     gerfg(AH, n2, v2);
     gerf(n2, v2, AH);
 }
@@ -266,7 +266,7 @@ void gebr3(internal::TargetType<Target::HostTask>,
     trace::Block trace_block("internal::gebr3");
 
     // Apply the reflector from task 2: Q A.
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     gerf(n1, v1, AH);
 
     // Zero A[1:m-1, 0].

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -17,8 +17,8 @@ namespace internal {
 /// where A is a single block column and B is a single block row.
 /// Dispatches to target implementations.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 ///
 /// @param[in] layout
 ///     Indicates the Layout (ColMajor/RowMajor) to operate with.

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -20,8 +20,8 @@ namespace internal {
 /// for all i = 0 : A.mt, j = 0 : A.nt, k=.
 /// Dispatches to target implementations.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 /// @ingroup gemm_internal
 ///
 template <Target target, typename scalar_t>

--- a/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
+++ b/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
@@ -78,7 +78,7 @@ void he2hb_her2k_offdiag_ranks(
                     A.tileGetForReading( i, 0, layout_conv );
                     C.tileGetForWriting( j, i, layout_conv );
                     // Aji -= Wjk Vik^H
-                    tile::gemm( alpha, B( j, 0 ), conjTranspose( A( i, 0 ) ),
+                    tile::gemm( alpha, B( j, 0 ), conj_transpose( A( i, 0 ) ),
                                 beta, C( j, i ) );
                     B.tileTick( j, 0 );
                     A.tileTick( i, 0 );

--- a/src/internal/internal_hebr.cc
+++ b/src/internal/internal_hebr.cc
@@ -65,7 +65,7 @@ void herf(int64_t n, scalar_t* v, HermitianMatrix<scalar_t>& A)
             else {
                 auto Aij = i > j
                          ? A(i, j)
-                         : conjTranspose(A(j, i));
+                         : conj_transpose( A( j, i ) );
                 tile::gemv( one, Aij, vj, beta, wi );
             }
             beta = one;
@@ -206,7 +206,7 @@ void hebr2(internal::TargetType<Target::HostTask>,
     trace::Block trace_block("internal::hebr2");
 
     // Apply the reflector from task type 1 or 2.
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     gerf(n1, v1, AH);
 
     // Zero A[1:n-1, 0].

--- a/src/internal/internal_unmlq.cc
+++ b/src/internal/internal_unmlq.cc
@@ -152,7 +152,7 @@ void unmlq(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op == Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -202,7 +202,7 @@ void unmlq(internal::TargetType<target>,
         if (row_indices.size() > 1) {
             // C1 <- C1 - V1^H W
             internal::gemm<target>(
-                    -one, conjTranspose(V.sub(0, 0, row_indices[1], mt-1)),
+                    -one, conj_transpose( V.sub( 0, 0, row_indices[1], mt-1 ) ),
                           std::move(Wr),
                     one,  C.sub(row_indices[1], mt-1, 0, nt-1),
                     layout);
@@ -211,7 +211,7 @@ void unmlq(internal::TargetType<target>,
         if (trapezoid) {
             // C0b <- C0b - V0b^H W
             internal::gemm<Target::HostTask>(
-                    -one, conjTranspose(std::move(V0b)),
+                    -one, conj_transpose( std::move( V0b ) ),
                           std::move(Wr),
                     one,  std::move(C0b),
                     layout);
@@ -220,7 +220,7 @@ void unmlq(internal::TargetType<target>,
         // W <- V0^H W
         internal::trmm<Target::HostTask>(
                 Side::Left,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wr));
 
         // C0 <- C0 - W
@@ -328,7 +328,7 @@ void unmlq(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op == Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -339,14 +339,14 @@ void unmlq(internal::TargetType<target>,
         internal::copy(std::move(C0), std::move(Wc));
         internal::trmm<Target::HostTask>(
                 Side::Right,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wc));
 
         if (trapezoid) {
             // W <- C0b V0b^H + W
             internal::gemm<Target::HostTask>(
                     one, std::move(C0b),
-                         conjTranspose(V0b),
+                         conj_transpose( V0b ),
                     one, std::move(Wc),
                     layout);
         }
@@ -361,7 +361,7 @@ void unmlq(internal::TargetType<target>,
             }
             internal::gemm<target>(
                     one, std::move(Ci),
-                         conjTranspose(V.sub(0, 0, col, col)),
+                         conj_transpose( V.sub( 0, 0, col, col ) ),
                     one, std::move(Wc),
                     layout);
         }

--- a/src/internal/internal_unmqr.cc
+++ b/src/internal/internal_unmqr.cc
@@ -150,7 +150,7 @@ void unmqr(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Lower, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op != Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -163,14 +163,14 @@ void unmqr(internal::TargetType<target>,
                 priority, queue_index);
         internal::trmm<target>(
                 Side::Left,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wr),
                 priority, queue_index);
 
         if (trapezoid) {
             // W <- V0b^H C0b + W
             internal::gemm<target>(
-                    one, conjTranspose(V0b),
+                    one, conj_transpose( V0b ),
                          std::move(C0b),
                     one, std::move(Wr),
                     layout,
@@ -186,7 +186,7 @@ void unmqr(internal::TargetType<target>,
                 Ci.tileGetAndHoldAllOnDevices(LayoutConvert(layout));
             }
             internal::gemm<target>(
-                    one, conjTranspose(V.sub(row, row, 0, 0)),
+                    one, conj_transpose( V.sub( row, row, 0, 0 ) ),
                          std::move(Ci),
                     one, std::move(Wr),
                     layout,
@@ -331,7 +331,7 @@ void unmqr(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Lower, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op != Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -388,7 +388,7 @@ void unmqr(internal::TargetType<target>,
             // C1 <- C1 - W V1^H
             internal::gemm<target>(
                     -one, std::move(Wc),
-                          conjTranspose(V.sub(col_indices[1], nt-1, 0, 0)),
+                          conj_transpose( V.sub( col_indices[1], nt-1, 0, 0 ) ),
                     one,  C.sub(0, mt-1, col_indices[1], nt-1),
                     layout,
                     priority, queue_index);
@@ -398,7 +398,7 @@ void unmqr(internal::TargetType<target>,
             // C0b <- C0b - W V0b^H
             internal::gemm<target>(
                     -one, std::move(Wc),
-                          conjTranspose(V0b),
+                          conj_transpose( V0b ),
                     one,  std::move(C0b),
                     layout,
                     priority, queue_index);
@@ -407,7 +407,7 @@ void unmqr(internal::TargetType<target>,
         // W <- W V0^H
         internal::trmm<target>(
                 Side::Right,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wc),
                 priority, queue_index);
 

--- a/src/norm.cc
+++ b/src/norm.cc
@@ -39,7 +39,7 @@ norm(
             in_norm = Norm::One;
     }
     if (A.op() == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     else if (A.op() == Op::Trans)
         A = transpose(A);
 

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -40,7 +40,7 @@ void pbtrf(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     int64_t A_nt = A.nt();
 

--- a/src/pbtrs.cc
+++ b/src/pbtrs.cc
@@ -65,10 +65,10 @@ void pbtrs(HermitianBandMatrix<scalar_t>& A,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     auto L = TriangularBandMatrix<scalar_t>(Diag::NonUnit, A_);
-    auto LT = conjTranspose(L);
+    auto LT = conj_transpose( L );
 
     tbsm(Side::Left, one, L, B, opts);
 

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -39,7 +39,7 @@ void potrf(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 
@@ -170,7 +170,7 @@ void potrf(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 

--- a/src/potrs.cc
+++ b/src/potrs.cc
@@ -67,10 +67,10 @@ void potrs(HermitianMatrix<scalar_t>& A,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     auto L = TriangularMatrix<scalar_t>(Diag::NonUnit, A_);
-    auto LT = conjTranspose(L);
+    auto LT = conj_transpose( L );
 
     trsm(Side::Left, one, L, B, opts);
 

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -45,8 +45,8 @@ void tbsm(
     // op(B) = op(A)^{-1} * op(B)
     if (side == Side::Right) {
         if (A.op() == Op::ConjTrans || B.op() == Op::ConjTrans) {
-            A = conjTranspose(A);
-            B = conjTranspose(B);
+            A = conj_transpose( A );
+            B = conj_transpose( B );
             alpha = conj(alpha);
         }
         else {

--- a/src/trcondest.cc
+++ b/src/trcondest.cc
@@ -122,7 +122,7 @@ void trcondest(
         }
         else {
             // Multiply by inv(A^H).
-            auto AH = conjTranspose( A );
+            auto AH = conj_transpose( A );
             slate::trsmB(Side::Left, alpha, AH, X, opts);
         }
 

--- a/src/trtri.cc
+++ b/src/trtri.cc
@@ -36,7 +36,7 @@ void trtri(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 

--- a/src/trtrm.cc
+++ b/src/trtrm.cc
@@ -36,7 +36,7 @@ void trtrm(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 
@@ -84,7 +84,7 @@ void trtrm(
                 auto H = HermitianMatrix<scalar_t>(A);
                 auto H0 = H.sub(0, k-1);
                 auto Ak = A.sub(k, k, 0, k-1);
-                Ak = conjTranspose(Ak);
+                Ak = conj_transpose( Ak );
 
                 internal::herk<target>(
                     real_t(1.0), std::move(Ak),
@@ -99,7 +99,7 @@ void trtrm(
 
                 // A(k, 0:k-1) = A(k, 0:k-1) * A(k, k)^H
                 auto Akk = A.sub(k, k);
-                Akk = conjTranspose(Akk);
+                Akk = conj_transpose( Akk );
                 internal::trmm<Target::HostTask>(
                     Side::Left,
                     one, std::move( Akk ), A.sub(k, k, 0, k-1) );

--- a/test/test_bdsqr.cc
+++ b/test/test_bdsqr.cc
@@ -180,7 +180,7 @@ void test_bdsqr_work(Params& params, bool run)
             Id.insertLocalTiles();
             set(zero, one, Id);
 
-            auto UT = conjTranspose(U);
+            auto UT = conj_transpose( U );
             slate::gemm(one, UT, U, -one, Id);
             params.ortho_U() = slate::norm(slate::Norm::Fro, Id) / m;
             params.okay() = params.okay() && (params.ortho_U() <= tol);
@@ -191,7 +191,7 @@ void test_bdsqr_work(Params& params, bool run)
             Id.insertLocalTiles();
             set(zero, one, Id);
 
-            auto VTT = conjTranspose(VT);
+            auto VTT = conj_transpose( VT );
             slate::gemm(one, VTT, VT, -one, Id);
             params.ortho_V() = slate::norm(slate::Norm::Fro, Id) / n;
             params.okay() = params.okay() && (params.ortho_V() <= tol);

--- a/test/test_gbmm.cc
+++ b/test/test_gbmm.cc
@@ -147,12 +147,12 @@ void test_gbmm_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         A_band = transpose(A_band);
     else if (transA == slate::Op::ConjTrans)
-        A_band = conjTranspose(A_band);
+        A_band = conj_transpose( A_band );
 
     if (transB == slate::Op::Trans)
         B = transpose(B);
     else if (transB == slate::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     slate_assert(A_band.mt() == C.mt());
     slate_assert(B.nt() == C.nt());
@@ -189,7 +189,7 @@ void test_gbmm_work(Params& params, bool run)
         if (transA == slate::Op::Trans)
             A = transpose(A);
         else if (transA == slate::Op::ConjTrans)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
 
         print_matrix("Cref", Cref, params);
 

--- a/test/test_gbsv.cc
+++ b/test/test_gbsv.cc
@@ -184,7 +184,7 @@ void test_gbsv_work(Params& params, bool run)
             if (trans == slate::Op::Trans)
                 opA = transpose(A);
             else if (trans == slate::Op::ConjTrans)
-                opA = conjTranspose(A);
+                opA = conj_transpose( A );
 
             slate::lu_solve_using_factor(opA, pivots, B, opts);
             // Using traditional BLAS/LAPACK name
@@ -257,7 +257,7 @@ void test_gbsv_work(Params& params, bool run)
         if (trans == slate::Op::Trans)
             opAorig = transpose(Aorig);
         else if (trans == slate::Op::ConjTrans)
-            opAorig = conjTranspose(Aorig);
+            opAorig = conj_transpose( Aorig );
         slate::multiply(-one, opAorig, B, one, Bref);
         // Using traditional BLAS/LAPACK name
         // slate::gbmm(-one, opAorig, B, one, Bref);

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -158,7 +158,7 @@ void test_gels_work(Params& params, bool run)
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (verbose >= 1) {
         printf( "%% A   %6lld-by-%6lld\n", llong(   A.m() ), llong(   A.n() ) );
@@ -207,7 +207,7 @@ void test_gels_work(Params& params, bool run)
         if (trans == slate::Op::Trans)
             opAref = transpose(Aref);
         else if (trans == slate::Op::ConjTrans)
-            opAref = conjTranspose(Aref);
+            opAref = conj_transpose( Aref );
     }
 
     double gflop = lapack::Gflop<scalar_t>::gels(m, n, nrhs);
@@ -269,7 +269,7 @@ void test_gels_work(Params& params, bool run)
             // RA = R^H op(A)
             slate::Matrix<scalar_t> RA(nrhs, opAn, nb, p, q, MPI_COMM_WORLD);
             RA.insertLocalTiles();
-            auto RT = conjTranspose(Bref);
+            auto RT = conj_transpose( Bref );
             slate::multiply(one, RT, opA, zero, RA);
             // Using traditional BLAS/LAPACK name
             // slate::gemm(one, RT, opA, zero, RA);

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -160,12 +160,12 @@ void test_gemm_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         A = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     if (transB == slate::Op::Trans)
         B = transpose(B);
     else if (transB == slate::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     slate_assert(A.mt() == C.mt());
     slate_assert(B.nt() == C.nt());

--- a/test/test_genorm.cc
+++ b/test/test_genorm.cc
@@ -98,7 +98,7 @@ void test_genorm_work(Params& params, bool run)
     if (trans == slate::Op::Trans)
         A = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     print_matrix("A", A, params);
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -303,7 +303,7 @@ void test_gesv_work(Params& params, bool run)
             if (trans == slate::Op::Trans)
                 opA = transpose(A);
             else if (trans == slate::Op::ConjTrans)
-                opA = conjTranspose(A);
+                opA = conj_transpose( A );
 
             if (params.routine == "getrs"
                 || params.routine == "getrf")
@@ -350,7 +350,7 @@ void test_gesv_work(Params& params, bool run)
         if (trans == slate::Op::Trans)
             opAref = slate::transpose(Aref);
         else if (trans == slate::Op::ConjTrans)
-            opAref = slate::conj_transpose(Aref);
+            opAref = slate::conj_transpose( Aref );
         else
             opAref = Aref;
 

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -156,8 +156,8 @@ void test_her2k_work(Params& params, bool run)
         opB = transpose(B);
     }
     else if (trans == slate::Op::ConjTrans) {
-        opA = conjTranspose(A);
-        opB = conjTranspose(B);
+        opA = conj_transpose( A );
+        opB = conj_transpose( B );
     }
     slate_assert(A.mt() == C.mt());
     slate_assert(B.mt() == C.mt());
@@ -187,12 +187,12 @@ void test_her2k_work(Params& params, bool run)
         // Y = beta C X
         slate::multiply( scalar_t(beta), C, X, zero, Y, opts );
         // Z = A^H X
-        auto AH = conjTranspose( opA );
+        auto AH = conj_transpose( opA );
         slate::multiply( one, AH, X, zero, Z, opts );
         // Y = conj(alpha) B Z + Y
         slate::multiply( conj( alpha ), opB, Z, one, Y, opts );
         // Z = B^H X
-        auto BH = conjTranspose( opB );
+        auto BH = conj_transpose( opB );
         slate::multiply( one, BH, X, zero, Z, opts );
         // Y = alpha A Z + Y
         slate::multiply( alpha, opA, Z, one, Y, opts );

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -139,7 +139,7 @@ void test_herk_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         opA = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
     slate_assert(opA.mt() == C.mt());
 
     if (trace) slate::trace::Trace::on();
@@ -162,7 +162,7 @@ void test_herk_work(Params& params, bool run)
         // Y = beta C X
         slate::multiply( scalar_t(beta), C, X, zero, Y, opts );
         // Z = A^H X
-        auto AH = conjTranspose( opA );
+        auto AH = conj_transpose( opA );
         slate::multiply( one, AH, X, zero, Z, opts );
         // Y = alpha A Z + Y
         slate::multiply( scalar_t(alpha), opA, Z, one, Y, opts );

--- a/test/test_steqr2.cc
+++ b/test/test_steqr2.cc
@@ -154,7 +154,7 @@ void test_steqr2_work(Params& params, bool run)
         //
         //==================================================
         if (wantz) {
-            auto ZT = conjTranspose(Z);
+            auto ZT = conj_transpose( Z );
             set(zero, one, A);
             slate::gemm(one, ZT, Z, -one, A);
             params.ortho() = slate::norm(slate::Norm::Fro, A) / n;

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -159,8 +159,8 @@ void test_syr2k_work(Params& params, bool run)
         opB = transpose(B);
     }
     else if (trans == slate::Op::ConjTrans) {
-        opA = conjTranspose(A);
-        opB = conjTranspose(B);
+        opA = conj_transpose( A );
+        opB = conj_transpose( B );
     }
     slate_assert(opA.mt() == C.mt());
     slate_assert(opB.mt() == C.mt());

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -137,7 +137,7 @@ void test_syrk_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         opA = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
     slate_assert(opA.mt() == C.mt());
 
     if (trace) slate::trace::Trace::on();

--- a/test/test_tbsm.cc
+++ b/test/test_tbsm.cc
@@ -150,12 +150,12 @@ void test_tbsm_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         A = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     //if (transB == slate::Op::Trans)
     //    B = transpose(B);
     //else if (transB == slate::Op::ConjTrans)
-    //    B = conjTranspose(B);
+    //    B = conj_transpose( B );
 
     if (verbose > 1) {
         // todo: print_matrix( A ) calls Matrix version;

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -140,12 +140,12 @@ void test_trmm_work(Params& params, bool run)
     if (transA == Op::Trans)
         opA = transpose(A);
     else if (transA == Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (transB == Op::Trans)
         B = transpose(B);
     else if (transB == Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     // If check run, perform first half of SLATE residual check.
     slate::Matrix<scalar_t> X, X2, Y;

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -149,7 +149,7 @@ void test_trsm_work(Params& params, bool run)
     if (transA == Op::Trans)
         opA = transpose(A);
     else if (transA == Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (trace) slate::trace::Trace::on();
     else slate::trace::Trace::off();

--- a/tools/c_api/generate_matrix.py
+++ b/tools/c_api/generate_matrix.py
@@ -162,8 +162,8 @@ matrix_routines = [
     ['int64_t',      '_n',                                 'slate_Matrix',                                                  'n()'],
     ['bool',         '_tileIsLocal',                       'slate_Matrix, int64_t i, int64_t j',                            'tileIsLocal(i, j)'],
     ['slate_Tile',   '_at',                                'slate_Matrix, int64_t i, int64_t j',                            'at(i, j)'],
-    ['void',         '_transpose_in_place',                'slate_Matrix',                                                  'transpose(*A_)'],
-    ['void',         '_conjTranspose_in_place',            'slate_Matrix',                                                  'conjTranspose(*A_)'],
+    ['void',         '_transpose_in_place',                'slate_Matrix',                                                  'transpose( *A_ )'],
+    ['void',         '_conj_transpose_in_place',           'slate_Matrix',                                                  'conj_transpose( *A_ )'],
 ]
 
 contents = ''
@@ -231,7 +231,7 @@ for matrix_type in matrix_types:
                 else:
                     if routine[1] == '_destroy':
                         contents0 += '    ' + routine[3] + ' A_;\n'
-                    elif (routine[1] == '_conjTranspose_in_place') or (routine[1] == '_transpose_in_place'):
+                    elif (routine[1] == '_conj_transpose_in_place') or (routine[1] == '_transpose_in_place'):
                         contents0 += '    *A_ = slate::' + routine[3] + ';\n'
                     else:
                         contents0 += '    A_->' + routine[3] + ';\n'

--- a/unit_test/test_BandMatrix.cc
+++ b/unit_test/test_BandMatrix.cc
@@ -91,11 +91,11 @@ void test_BandMatrix_transpose()
 }
 
 //------------------------------------------------------------------------------
-void test_BandMatrix_conjTranspose()
+void test_BandMatrix_conj_transpose()
 {
     auto A = slate::BandMatrix<double>(m, n, kl, ku, nb, p, q, mpi_comm);
 
-    auto AT = conjTranspose( A );
+    auto AT = conj_transpose( A );
 
     test_assert(AT.mt() == ceildiv(n, nb));
     test_assert(AT.nt() == ceildiv(m, nb));
@@ -447,7 +447,7 @@ void run_tests()
     if (mpi_rank == 0)
         printf("\nMethods\n");
     run_test(test_BandMatrix_transpose,       "transpose",      mpi_comm);
-    run_test(test_BandMatrix_conjTranspose,  "conjTranspose", mpi_comm);
+    run_test(test_BandMatrix_conj_transpose,  "conj_transpose", mpi_comm);
     run_test(test_BandMatrix_swap,            "swap",           mpi_comm);
     run_test(test_BandMatrix_tileInsert_new,  "BandMatrix::tileInsert(i, j, dev) ", mpi_comm);
     run_test(test_BandMatrix_tileInsert_data, "BandMatrix::tileInsert(i, j, dev, data, lda)",  mpi_comm);

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -805,15 +805,15 @@ void test_Matrix_transpose()
 }
 
 //------------------------------------------------------------------------------
-/// Test conjTranspose(A).
-void test_Matrix_conjTranspose()
+/// Test conj_transpose( A ).
+void test_Matrix_conj_transpose()
 {
     int lda = roundup(m, mb);
     std::vector<double> Ad( lda*n );
     auto A = slate::Matrix<double>::fromLAPACK(
         m, n, Ad.data(), lda, mb, nb, p, q, mpi_comm );
 
-    auto AT = conjTranspose( A );
+    auto AT = conj_transpose( A );
 
     test_assert(AT.mt() == ceildiv(n, nb));
     test_assert(AT.nt() == ceildiv(m, mb));
@@ -1990,7 +1990,7 @@ void test_Matrix_tileReduceFromSet()
                  m, n, Ad.data(), lda, nb, p, q, mpi_comm );
 
     auto AT = transpose( A );
-    auto AH = conjTranspose( A );
+    auto AH = conj_transpose( A );
 
     std::set<int> all_reduce_set;
 
@@ -2067,7 +2067,7 @@ void run_tests()
     run_test(test_Matrix_emptyLikeMbNb,        "Matrix::emptyLikeMbNb",                    mpi_comm);
     run_test(test_Matrix_emptyLikeOp,          "Matrix::emptyLikeOp",                      mpi_comm);
     run_test(test_Matrix_transpose,            "transpose",                                mpi_comm);
-    run_test(test_Matrix_conjTranspose,        "conjTranspose",                            mpi_comm);
+    run_test(test_Matrix_conj_transpose,       "conj_transpose",                           mpi_comm);
     run_test(test_Matrix_swap,                 "swap",                                     mpi_comm);
     run_test(test_Matrix_tileInsert_new,       "Matrix::tileInsert(i, j, dev) ",           mpi_comm);
     run_test(test_Matrix_tileInsert_data,      "Matrix::tileInsert(i, j, dev, data, lda)", mpi_comm);

--- a/unit_test/test_Tile.cc
+++ b/unit_test/test_Tile.cc
@@ -132,8 +132,9 @@ void verify_data_transpose_(slate::Tile<scalar_t>& A, int expect_rank,
 //
 // todo: setup data with imaginary bits.
 template <typename scalar_t>
-void verify_data_conjTranspose_(slate::Tile<scalar_t>& A, int expect_rank,
-                                 const char* file, int line)
+void verify_data_conj_transpose_(
+    slate::Tile<scalar_t>& A, int expect_rank,
+    const char* file, int line)
 {
     try {
         using blas::conj;
@@ -152,8 +153,8 @@ void verify_data_conjTranspose_(slate::Tile<scalar_t>& A, int expect_rank,
     }
 }
 
-#define verify_data_conjTranspose(A, expect_rank) \
-        verify_data_conjTranspose_(A, expect_rank, __FILE__, __LINE__)
+#define verify_data_conj_transpose( A, expect_rank ) \
+        verify_data_conj_transpose_( A, expect_rank, __FILE__, __LINE__ )
 
 //------------------------------------------------------------------------------
 /// Tests Tile() default constructor and simple data accessors.
@@ -330,9 +331,9 @@ void test_transpose_complex()
 }
 
 //------------------------------------------------------------------------------
-/// Tests conjTranspose(Tile).
+/// Tests conj_transpose( Tile ).
 template <typename scalar_t>
-void test_conjTranspose()
+void test_conj_transpose()
 {
     const int m = 20;
     const int n = 30;
@@ -341,8 +342,8 @@ void test_conjTranspose()
     slate::Tile<scalar_t> A(m, n, data, lda, -1, slate::TileKind::UserOwned);
     setup_data(A);
 
-    //----- conjTranspose
-    auto AC = conjTranspose(A);
+    //----- conj_transpose
+    auto AC = conj_transpose( A );
 
     test_assert(AC.mb() == n);  // trans
     test_assert(AC.nb() == m);  // trans
@@ -356,10 +357,10 @@ void test_conjTranspose()
     test_assert(AC.bytes() == sizeof(scalar_t) * m * n);
     test_assert(AC.size() == size_t(m * n));
 
-    verify_data_conjTranspose(AC, mpi_rank);
+    verify_data_conj_transpose( AC, mpi_rank );
 
-    //----- conjTranspose again
-    auto ACC = conjTranspose(AC);
+    //----- conj_transpose again
+    auto ACC = conj_transpose( AC );
 
     test_assert(ACC.mb() == m);  // restored
     test_assert(ACC.nb() == n);  // restored
@@ -377,8 +378,8 @@ void test_conjTranspose()
 
     auto AT = transpose(A);
     if (AT.is_real) {
-        //----- transpose + conjTranspose for real
-        auto ATC = conjTranspose(AT);
+        //----- transpose + conj_transpose for real
+        auto ATC = conj_transpose( AT );
 
         test_assert(ATC.mb() == m);  // restored
         test_assert(ATC.nb() == n);  // restored
@@ -394,7 +395,7 @@ void test_conjTranspose()
 
         verify_data(ATC, mpi_rank);
 
-        //----- conjTranspose + transpose for real
+        //----- conj_transpose + transpose for real
         auto ACT = transpose(AC);
 
         test_assert(ACT.mb() == m);  // restored
@@ -412,20 +413,20 @@ void test_conjTranspose()
         verify_data(ATC, mpi_rank);
     }
     else {
-        //----- transpose + conjTranspose is unsupported for complex
-        test_assert_throw_std(conjTranspose(AT) /* std::exception */);
+        //----- transpose + conj_transpose is unsupported for complex
+        test_assert_throw_std(conj_transpose( AT ) /* std::exception */);
         test_assert_throw_std(transpose(AC)      /* std::exception */);
     }
 }
 
-void test_conjTranspose_double()
+void test_conj_transpose_double()
 {
-    test_conjTranspose< double >();
+    test_conj_transpose< double >();
 }
 
-void test_conjTranspose_complex()
+void test_conj_transpose_complex()
 {
-    test_conjTranspose< std::complex<double> >();
+    test_conj_transpose< std::complex<double> >();
 }
 
 //------------------------------------------------------------------------------
@@ -455,12 +456,12 @@ void test_lower()
     test_assert(ATT.uploLogical()  == blas::Uplo::Lower);
     test_assert(ATT.uploPhysical() == blas::Uplo::Lower);
 
-    auto AC = conjTranspose(A);
+    auto AC = conj_transpose( A );
     test_assert(AC.uplo()         == blas::Uplo::Upper);
     test_assert(AC.uploLogical()  == blas::Uplo::Upper);
     test_assert(AC.uploPhysical() == blas::Uplo::Lower);
 
-    auto ACC = conjTranspose(AC);
+    auto ACC = conj_transpose( AC );
     test_assert(ACC.uplo()         == blas::Uplo::Lower);
     test_assert(ACC.uploLogical()  == blas::Uplo::Lower);
     test_assert(ACC.uploPhysical() == blas::Uplo::Lower);
@@ -503,12 +504,12 @@ void test_upper()
     test_assert(ATT.uploLogical()  == blas::Uplo::Upper);
     test_assert(ATT.uploPhysical() == blas::Uplo::Upper);
 
-    auto AC = conjTranspose(A);
+    auto AC = conj_transpose( A );
     test_assert(AC.uplo()         == blas::Uplo::Lower);
     test_assert(AC.uploLogical()  == blas::Uplo::Lower);
     test_assert(AC.uploPhysical() == blas::Uplo::Upper);
 
-    auto ACC = conjTranspose(AC);
+    auto ACC = conj_transpose( AC );
     test_assert(ACC.uplo()         == blas::Uplo::Upper);
     test_assert(ACC.uploLogical()  == blas::Uplo::Upper);
     test_assert(ACC.uploPhysical() == blas::Uplo::Upper);
@@ -785,11 +786,11 @@ void run_tests()
             test_transpose_complex,
             "transpose, complex");
         run_test(
-            test_conjTranspose_double,
-            "conjTranspose, double");
+            test_conj_transpose_double,
+            "conj_transpose, double");
         run_test(
-            test_conjTranspose_complex,
-            "conjTranspose, complex");
+            test_conj_transpose_complex,
+            "conj_transpose, complex");
         run_test(
             test_lower_double,
             "uplo(lower)");

--- a/unit_test/test_internal_blas.cc
+++ b/unit_test/test_internal_blas.cc
@@ -326,7 +326,7 @@ void test_gemm(slate::Target target)
         if (ic == 1)
             C = transpose(C);
         else if (ic == 2)
-            C = conjTranspose(C);
+            C = conj_transpose( C );
         assert(C.mt() == slate::ceildiv(m, nb));
         assert(C.nt() == slate::ceildiv(n, nb));
         if (target == slate::Target::Devices)
@@ -347,7 +347,7 @@ void test_gemm(slate::Target target)
         if (ib == 1)
             B = transpose(B);
         else if (ib == 2)
-            B = conjTranspose(B);
+            B = conj_transpose( B );
         assert(B.mt() == slate::ceildiv(k, nb));
         assert(B.nt() == slate::ceildiv(n, nb));
 
@@ -361,7 +361,7 @@ void test_gemm(slate::Target target)
         if (ia == 1)
             A = transpose(A);
         else if (ia == 2)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
         assert(A.mt() == slate::ceildiv(m, nb));
         assert(A.nt() == slate::ceildiv(k, nb));
 
@@ -497,7 +497,7 @@ void test_syrk(slate::Target target)
         if (ic == 1)
             C = transpose(C);
         else if (ic == 2)
-            C = conjTranspose(C);
+            C = conj_transpose( C );
         assert(C.mt() == slate::ceildiv(n, nb));
         assert(C.nt() == slate::ceildiv(n, nb));
         if (target == slate::Target::Devices)
@@ -529,7 +529,7 @@ void test_syrk(slate::Target target)
         if (ia == 1)
             A = transpose(A);
         else if (ia == 2)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
         assert(A.mt() == slate::ceildiv(n, nb));
         assert(A.nt() == slate::ceildiv(k, nb));
 
@@ -670,7 +670,7 @@ void test_herk(slate::Target target)
         if (ic == 1)
             C = transpose(C);
         else if (ic == 2)
-            C = conjTranspose(C);
+            C = conj_transpose( C );
         assert(C.mt() == slate::ceildiv(n, nb));
         assert(C.nt() == slate::ceildiv(n, nb));
         if (target == slate::Target::Devices)
@@ -702,7 +702,7 @@ void test_herk(slate::Target target)
         if (ia == 1)
             A = transpose(A);
         else if (ia == 2)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
         assert(A.mt() == slate::ceildiv(n, nb));
         assert(A.nt() == slate::ceildiv(k, nb));
 


### PR DESCRIPTION
Rename `conjTranspose` => `conj_transpose`. We've adopted style that all top-level functions are snake_case.

Builds on PR #5. I will retarget this after PR #5 is merged.