### PR TITLE
gesv_mixed

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -554,7 +554,7 @@ ifneq ($(only_unit),1)
         src/gemmC.cc \
         src/geqrf.cc \
         src/gesv.cc \
-        src/gesvMixed.cc \
+        src/gesv_mixed.cc \
         src/gesv_mixed_gmres.cc \
         src/gesv_nopiv.cc \
         src/gesvd.cc \
@@ -584,7 +584,7 @@ ifneq ($(only_unit),1)
         src/pbtrf.cc \
         src/pbtrs.cc \
         src/posv.cc \
-        src/posvMixed.cc \
+        src/posv_mixed.cc \
         src/posv_mixed_gmres.cc \
         src/potrf.cc \
         src/potri.cc \
@@ -1042,7 +1042,7 @@ scalapack_api_src += \
         scalapack_api/scalapack_gels.cc \
         scalapack_api/scalapack_gemm.cc \
         scalapack_api/scalapack_gesv.cc \
-        scalapack_api/scalapack_gesvMixed.cc \
+        scalapack_api/scalapack_gesv_mixed.cc \
         scalapack_api/scalapack_getrf.cc \
         scalapack_api/scalapack_getrs.cc \
         scalapack_api/scalapack_hemm.cc \
@@ -1100,7 +1100,7 @@ lapack_api_src += \
         lapack_api/lapack_gels.cc \
         lapack_api/lapack_gemm.cc \
         lapack_api/lapack_gesv.cc \
-        lapack_api/lapack_gesvMixed.cc \
+        lapack_api/lapack_gesv_mixed.cc \
         lapack_api/lapack_getrf.cc \
         lapack_api/lapack_getri.cc \
         lapack_api/lapack_getrs.cc \

--- a/examples/ex06_linear_system_lu.cc
+++ b/examples/ex06_linear_system_lu.cc
@@ -58,7 +58,7 @@ void test_lu_mixed()
     // traditional API
     // TODO: pass using &iters?
     int iters = 0;
-    slate::gesvMixed( A, pivots, B, X, iters );
+    slate::gesv_mixed( A, pivots, B, X, iters );
     printf( "rank %d: iters %d\n", mpi_rank, iters );
 }
 

--- a/examples/ex07_linear_system_cholesky.cc
+++ b/examples/ex07_linear_system_cholesky.cc
@@ -55,7 +55,7 @@ void test_cholesky_mixed()
     // traditional API
     // TODO: pass using &iters?
     int iters = 0;
-    slate::posvMixed( A, B, X, iters );
+    slate::posv_mixed( A, B, X, iters );
     printf( "rank %d: iters %d\n", mpi_rank, iters );
 }
 

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -482,9 +482,9 @@ void gesv_nopiv(
     Options const& opts = Options());
 
 //-----------------------------------------
-// gesvMixed()
+// gesv_mixed()
 template <typename scalar_t>
-void gesvMixed(
+void gesv_mixed(
     Matrix<scalar_t>& A, Pivots& pivots,
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& X,
@@ -492,13 +492,36 @@ void gesvMixed(
     Options const& opts = Options());
 
 template <typename scalar_hi, typename scalar_lo>
-void gesvMixed(
+void gesv_mixed(
     Matrix<scalar_hi>& A, Pivots& pivots,
     Matrix<scalar_hi>& B,
     Matrix<scalar_hi>& X,
     int& iter,
     Options const& opts = Options());
 
+template <typename scalar_t>
+[[deprecated( "Use gesv_mixed instead. Remove 2024-02." )]]
+void gesvMixed(
+    Matrix<scalar_t>& A, Pivots& pivots,
+    Matrix<scalar_t>& B,
+    Matrix<scalar_t>& X,
+    int& iter,
+    Options const& opts = Options())
+{
+    gesv_mixed( A, pivots, B, X, iter, opts );
+}
+
+template <typename scalar_hi, typename scalar_lo>
+[[deprecated( "Use gesv_mixed instead. Remove 2024-02." )]]
+void gesvMixed(
+    Matrix<scalar_hi>& A, Pivots& pivots,
+    Matrix<scalar_hi>& B,
+    Matrix<scalar_hi>& X,
+    int& iter,
+    Options const& opts = Options())
+{
+    gesv_mixed( A, pivots, B, X, iter, opts );
+}
 
 //-----------------------------------------
 // gesv_mixed_gmres()
@@ -619,9 +642,9 @@ void posv(
 }
 
 //-----------------------------------------
-// posvMixed()
+// posv_mixed()
 template <typename scalar_t>
-void posvMixed(
+void posv_mixed(
     HermitianMatrix<scalar_t>& A,
              Matrix<scalar_t>& B,
              Matrix<scalar_t>& X,
@@ -629,14 +652,38 @@ void posvMixed(
     Options const& opts = Options());
 
 template <typename scalar_hi, typename scalar_lo>
-void posvMixed(
+void posv_mixed(
     HermitianMatrix<scalar_hi>& A,
              Matrix<scalar_hi>& B,
              Matrix<scalar_hi>& X,
     int& iter,
     Options const& opts = Options());
 
-// todo: forward real-symmetric matrices to posvMixed?
+// todo: forward real-symmetric matrices to posv_mixed?
+
+template <typename scalar_t>
+[[deprecated( "Use posv_mixed instead. Remove 2024-02." )]]
+void posvMixed(
+    HermitianMatrix<scalar_t>& A,
+             Matrix<scalar_t>& B,
+             Matrix<scalar_t>& X,
+    int& iter,
+    Options const& opts = Options())
+{
+    posv_mixed( A, B, X, iter, opts );
+}
+
+template <typename scalar_hi, typename scalar_lo>
+[[deprecated( "Use posv_mixed instead. Remove 2024-02." )]]
+void posvMixed(
+    HermitianMatrix<scalar_hi>& A,
+             Matrix<scalar_hi>& B,
+             Matrix<scalar_hi>& X,
+    int& iter,
+    Options const& opts = Options())
+{
+    posv_mixed( A, B, X, iter, opts );
+}
 
 //-----------------------------------------
 // posv_mixed_gmres()

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -500,7 +500,7 @@ void gesv_mixed(
     Options const& opts = Options());
 
 template <typename scalar_t>
-[[deprecated( "Use gesv_mixed instead. Remove 2024-02." )]]
+[[deprecated( "Use gesv_mixed instead. Will be removed 2024-02." )]]
 void gesvMixed(
     Matrix<scalar_t>& A, Pivots& pivots,
     Matrix<scalar_t>& B,
@@ -512,7 +512,7 @@ void gesvMixed(
 }
 
 template <typename scalar_hi, typename scalar_lo>
-[[deprecated( "Use gesv_mixed instead. Remove 2024-02." )]]
+[[deprecated( "Use gesv_mixed instead. Will be removed 2024-02." )]]
 void gesvMixed(
     Matrix<scalar_hi>& A, Pivots& pivots,
     Matrix<scalar_hi>& B,
@@ -662,7 +662,7 @@ void posv_mixed(
 // todo: forward real-symmetric matrices to posv_mixed?
 
 template <typename scalar_t>
-[[deprecated( "Use posv_mixed instead. Remove 2024-02." )]]
+[[deprecated( "Use posv_mixed instead. Will be removed 2024-02." )]]
 void posvMixed(
     HermitianMatrix<scalar_t>& A,
              Matrix<scalar_t>& B,
@@ -674,7 +674,7 @@ void posvMixed(
 }
 
 template <typename scalar_hi, typename scalar_lo>
-[[deprecated( "Use posv_mixed instead. Remove 2024-02." )]]
+[[deprecated( "Use posv_mixed instead. Will be removed 2024-02." )]]
 void posvMixed(
     HermitianMatrix<scalar_hi>& A,
              Matrix<scalar_hi>& B,
@@ -881,7 +881,7 @@ void gels_cholqr(
 
 // Backward compatibility
 template <typename scalar_t>
-[[deprecated( "Use gels( A, BX[, opts] ) instead." )]]
+[[deprecated( "Use gels( A, BX[, opts] ) instead. Will be removed 2024-02." )]]
 void gels(
     Matrix<scalar_t>& A, TriangularFactors<scalar_t>& T,
     Matrix<scalar_t>& BX,

--- a/lapack_api/lapack_gesv_mixed.cc
+++ b/lapack_api/lapack_gesv_mixed.cc
@@ -64,12 +64,13 @@ void slate_gesv(const int n, const int nrhs, scalar_t* a, const int lda, int* ip
 
     // computes the solution to the system of linear equations with a square coefficient matrix A and multiple right-hand sides.
     int iters;
-    slate::gesvMixed(A, pivots, B, X, iters, {
-            {slate::Option::Lookahead, lookahead},
-            {slate::Option::Target, target},
-            {slate::Option::MaxPanelThreads, panel_threads},
-            {slate::Option::InnerBlocking, ib}
-        });
+    slate::gesv_mixed(
+        A, pivots, B, X, iters, {
+        {slate::Option::Lookahead, lookahead},
+        {slate::Option::Target, target},
+        {slate::Option::MaxPanelThreads, panel_threads},
+        {slate::Option::InnerBlocking, ib}
+    });
     *iter = iters;
 
     // extract pivots from SLATE's Pivots structure into LAPACK ipiv array

--- a/scalapack_api/scalapack_gesv_mixed.cc
+++ b/scalapack_api/scalapack_gesv_mixed.cc
@@ -15,7 +15,7 @@ extern "C" void Cblacs_gridinfo(int context, int* np_row, int* np_col, int*  my_
 
 // Type generic function calls the SLATE routine
 template< typename scalar_t >
-void slate_pgesvMixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* b, int ib, int jb, int* descb, scalar_t* x, int ix, int jx, int* descx, int* iter, int* info);
+void slate_pgesv_mixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* b, int ib, int jb, int* descb, scalar_t* x, int ix, int jx, int* descx, int* iter, int* info);
 
 // -----------------------------------------------------------------------------
 // C interfaces (FORTRAN_UPPER, FORTRAN_LOWER, FORTRAN_UNDERSCORE)
@@ -25,39 +25,39 @@ void slate_pgesvMixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, 
 
 extern "C" void PDSGESV(int* n, int* nrhs, double* a, int* ia, int* ja, int* desca, int* ipiv, double* b, int* ib, int* jb, int* descb, double* x, int* ix, int* jx, int* descx, int* iter, int* info)
 {
-    slate_pgesvMixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
+    slate_pgesv_mixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
 }
 
 extern "C" void pdsgesv(int* n, int* nrhs, double* a, int* ia, int* ja, int* desca, int* ipiv, double* b, int* ib, int* jb, int* descb, double* x, int* ix, int* jx, int* descx, int* iter, int* info)
 {
-    slate_pgesvMixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
+    slate_pgesv_mixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
 }
 
 extern "C" void pdsgesv_(int* n, int* nrhs, double* a, int* ia, int* ja, int* desca, int* ipiv, double* b, int* ib, int* jb, int* descb, double* x, int* ix, int* jx, int* descx, int* iter, int* info)
 {
-    slate_pgesvMixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
+    slate_pgesv_mixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
 }
 
 // -----------------------------------------------------------------------------
 
 extern "C" void PZCGESV(int* n, int* nrhs, std::complex<double>* a, int* ia, int* ja, int* desca, int* ipiv, std::complex<double>* b, int* ib, int* jb, int* descb, std::complex<double>* x, int* ix, int* jx, int* descx, int* iter, int* info)
 {
-    slate_pgesvMixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
+    slate_pgesv_mixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
 }
 
 extern "C" void pzcgesv(int* n, int* nrhs, std::complex<double>* a, int* ia, int* ja, int* desca, int* ipiv, std::complex<double>* b, int* ib, int* jb, int* descb, std::complex<double>* x, int* ix, int* jx, int* descx, int* iter, int* info)
 {
-    slate_pgesvMixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
+    slate_pgesv_mixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
 }
 
 extern "C" void pzcgesv_(int* n, int* nrhs, std::complex<double>* a, int* ia, int* ja, int* desca, int* ipiv, std::complex<double>* b, int* ib, int* jb, int* descb, std::complex<double>* x, int* ix, int* jx, int* descx, int* iter, int* info)
 {
-    slate_pgesvMixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
+    slate_pgesv_mixed(*n, *nrhs, a, *ia, *ja, desca, ipiv, b, *ib, *jb, descb, x, *ix, *jx, descx, iter, info);
 }
 
 // -----------------------------------------------------------------------------
 template< typename scalar_t >
-void slate_pgesvMixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* b, int ib, int jb, int* descb, scalar_t* x, int ix, int jx, int* descx, int* iter, int* info)
+void slate_pgesv_mixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* b, int ib, int jb, int* descb, scalar_t* x, int ix, int jx, int* descx, int* iter, int* info)
 {
     using real_t = blas::real_type<scalar_t>;
 
@@ -92,15 +92,16 @@ void slate_pgesvMixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, 
     X = slate_scalapack_submatrix(Xm, Xn, X, ix, jx, descx);
 
     if (verbose && myprow == 0 && mypcol == 0)
-        logprintf("%s\n", "gesvMixed");
+        logprintf("%s\n", "gesv_mixed");
 
     if (std::is_same<real_t, double>::value) {
-        slate::gesvMixed(A, pivots, B, X, *iter, {
-                {slate::Option::Lookahead, lookahead},
-                {slate::Option::Target, target},
-                {slate::Option::MaxPanelThreads, panel_threads},
-                {slate::Option::InnerBlocking, inner_blocking}
-            });
+        slate::gesv_mixed(
+            A, pivots, B, X, *iter, {
+            {slate::Option::Lookahead, lookahead},
+            {slate::Option::Target, target},
+            {slate::Option::MaxPanelThreads, panel_threads},
+            {slate::Option::InnerBlocking, inner_blocking}
+        });
     }
 
     // Extract pivots from SLATE's global Pivots structure into ScaLAPACK local ipiv array

--- a/src/gesv_mixed.cc
+++ b/src/gesv_mixed.cc
@@ -21,7 +21,7 @@ namespace slate {
 /// \]
 /// where $A$ is an n-by-n matrix and $X$ and $B$ are n-by-nrhs matrices.
 ///
-/// gesvMixed first factorizes the matrix using getrf in low precision (single)
+/// gesv_mixed first factorizes the matrix using getrf in low precision (single)
 /// and uses this factorization within an iterative refinement procedure to
 /// produce a solution with high precision (double) normwise backward error
 /// quality (see below). If the approach fails, the method falls back to a
@@ -97,11 +97,12 @@ namespace slate {
 /// @ingroup gesv
 ///
 template <typename scalar_hi, typename scalar_lo>
-void gesvMixed( Matrix<scalar_hi>& A, Pivots& pivots,
-                Matrix<scalar_hi>& B,
-                Matrix<scalar_hi>& X,
-                int& iter,
-                Options const& opts)
+void gesv_mixed(
+    Matrix<scalar_hi>& A, Pivots& pivots,
+    Matrix<scalar_hi>& B,
+    Matrix<scalar_hi>& X,
+    int& iter,
+    Options const& opts)
 {
     Target target = get_option( opts, Option::Target, Target::HostTask );
 
@@ -252,25 +253,25 @@ void gesvMixed( Matrix<scalar_hi>& A, Pivots& pivots,
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template <>
-void gesvMixed<double>(
+void gesv_mixed<double>(
     Matrix<double>& A, Pivots& pivots,
     Matrix<double>& B,
     Matrix<double>& X,
     int& iter,
     Options const& opts)
 {
-    gesvMixed<double, float>( A, pivots, B, X, iter, opts );
+    gesv_mixed<double, float>( A, pivots, B, X, iter, opts );
 }
 
 template <>
-void gesvMixed< std::complex<double> >(
+void gesv_mixed< std::complex<double> >(
     Matrix< std::complex<double> >& A, Pivots& pivots,
     Matrix< std::complex<double> >& B,
     Matrix< std::complex<double> >& X,
     int& iter,
     Options const& opts)
 {
-    gesvMixed<std::complex<double>, std::complex<float>>(
+    gesv_mixed<std::complex<double>, std::complex<float>>(
         A, pivots, B, X, iter, opts );
 }
 

--- a/src/posv_mixed.cc
+++ b/src/posv_mixed.cc
@@ -23,7 +23,7 @@ namespace slate {
 /// where $A$ is an n-by-n Hermitian positive definite matrix and $X$ and $B$
 /// are n-by-nrhs matrices.
 ///
-/// posvMixed first factorizes the matrix using potrf in low precision (single)
+/// posv_mixed first factorizes the matrix using potrf in low precision (single)
 /// and uses this factorization within an iterative refinement procedure to
 /// produce a solution with high precision (double) normwise backward error
 /// quality (see below). If the approach fails, the method falls back to a
@@ -97,11 +97,12 @@ namespace slate {
 /// @ingroup posv
 ///
 template <typename scalar_hi, typename scalar_lo>
-void posvMixed( HermitianMatrix<scalar_hi>& A,
-                Matrix<scalar_hi>& B,
-                Matrix<scalar_hi>& X,
-                int& iter,
-                Options const& opts)
+void posv_mixed(
+    HermitianMatrix<scalar_hi>& A,
+    Matrix<scalar_hi>& B,
+    Matrix<scalar_hi>& X,
+    int& iter,
+    Options const& opts)
 {
     // XXX This is only used for the memory management and may be inconsistent
     // with the routines called in this routine.
@@ -255,25 +256,25 @@ void posvMixed( HermitianMatrix<scalar_hi>& A,
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template <>
-void posvMixed<double>(
+void posv_mixed<double>(
     HermitianMatrix<double>& A,
     Matrix<double>& B,
     Matrix<double>& X,
     int& iter,
     Options const& opts)
 {
-    posvMixed<double, float>( A, B, X, iter, opts );
+    posv_mixed<double, float>( A, B, X, iter, opts );
 }
 
 template <>
-void posvMixed< std::complex<double> >(
+void posv_mixed< std::complex<double> >(
     HermitianMatrix< std::complex<double> >& A,
     Matrix< std::complex<double> >& B,
     Matrix< std::complex<double> >& X,
     int& iter,
     Options const& opts)
 {
-    posvMixed<std::complex<double>, std::complex<float>>( A, B, X, iter, opts );
+    posv_mixed<std::complex<double>, std::complex<float>>( A, B, X, iter, opts );
 }
 
 } // namespace slate

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -381,7 +381,7 @@ if (opts.lu):
     [ 'getriOOP', gen + dtype + la + n ],
     #[ 'gerfs', gen + dtype + la + n + trans ],
     #[ 'geequ', gen + dtype + la + n ],
-    [ 'gesvMixed',  gen + dtype_double + la + n ],
+    [ 'gesv_mixed',   gen + dtype_double + la + n ],
     [ 'gesv_mixed_gmres',  gen + dtype_double + la + n + ' --nrhs 1' ],
     ]
 
@@ -404,7 +404,7 @@ if (opts.chol):
     [ 'potri', gen + dtype + la + n + uplo ],
     #[ 'porfs', gen + dtype + la + n + uplo ],
     #[ 'poequ', gen + dtype + la + n ],  # only diagonal elements (no uplo)
-    [ 'posvMixed',  gen + dtype_double + la + n + uplo ],
+    [ 'posv_mixed', gen + dtype_double + la + n + uplo ],
     [ 'posv_mixed_gmres',  gen + dtype_double + la + n + uplo + ' --nrhs 1' ],
     [ 'trtri', gen + dtype + la + n + uplo + diag ],
     ]

--- a/test/test.cc
+++ b/test/test.cc
@@ -110,7 +110,7 @@ std::vector< testsweeper::routines_t > routines = {
     { "gesv",               test_gesv,         Section::gesv },
     { "gesv_nopiv",         test_gesv,         Section::gesv },
     { "gesv_tntpiv",        test_gesv,         Section::gesv },
-    { "gesvMixed",          test_gesv,         Section::gesv },
+    { "gesv_mixed",         test_gesv,         Section::gesv },
     { "gesv_mixed_gmres",   test_gesv,         Section::gesv },
     { "gbsv",               test_gbsv,         Section::gesv },
     { "",                   nullptr,           Section::newline },
@@ -138,7 +138,7 @@ std::vector< testsweeper::routines_t > routines = {
     // -----
     // Cholesky
     { "posv",               test_posv,         Section::posv },
-    { "posvMixed",          test_posv,         Section::posv },
+    { "posv_mixed",         test_posv,         Section::posv },
     { "posv_mixed_gmres",   test_posv,         Section::posv },
     { "pbsv",               test_pbsv,         Section::posv },
     { "",                   nullptr,           Section::newline },

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -255,7 +255,6 @@ void test_gesv_work(Params& params, bool run)
 
     double gflop;
     if (params.routine == "gesv"
-        || params.routine == "gesv_nopiv"
         || params.routine == "gesv_mixed"
         || params.routine == "gesv_mixed_gmres")
         gflop = lapack::Gflop<scalar_t>::gesv(n, nrhs);

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -94,7 +94,7 @@ void test_gesv_work(Params& params, bool run)
     bool do_getrs = params.routine == "getrs"
                     || (check && params.routine == "getrf");
 
-    if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres") {
+    if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres") {
         params.iters();
     }
 
@@ -117,7 +117,7 @@ void test_gesv_work(Params& params, bool run)
         origin = slate::Origin::Host;
     }
 
-    if ((params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres")
+    if ((params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres")
         && ! std::is_same<real_t, double>::value) {
         params.msg() = "skipping: unsupported mixed precision; must be type=d or z";
         return;
@@ -187,7 +187,7 @@ void test_gesv_work(Params& params, bool run)
         A.insertLocalTiles(origin_target);
         B.insertLocalTiles(origin_target);
 
-        if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres") {
+        if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres") {
             X_data.resize(lldB*nlocB);
             if (nonuniform_nb) {
                 X = slate::Matrix<scalar_t>(n, nrhs, tileNb, tileNb, tileRank,
@@ -210,7 +210,7 @@ void test_gesv_work(Params& params, bool run)
         B = slate::Matrix<scalar_t>::fromScaLAPACK(
             n, nrhs, &B_data[0], lldB, nb, nb, grid_order, p, q, MPI_COMM_WORLD );
 
-        if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres") {
+        if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres") {
             X_data.resize(lldB*nlocB);
             X = slate::Matrix<scalar_t>::fromScaLAPACK(
                 n, nrhs, &X_data[0], lldB, nb, nb, grid_order, p, q, MPI_COMM_WORLD );
@@ -255,7 +255,8 @@ void test_gesv_work(Params& params, bool run)
 
     double gflop;
     if (params.routine == "gesv"
-        || params.routine == "gesvMixed"
+        || params.routine == "gesv_nopiv"
+        || params.routine == "gesv_mixed"
         || params.routine == "gesv_mixed_gmres")
         gflop = lapack::Gflop<scalar_t>::gesv(n, nrhs);
     else
@@ -283,10 +284,10 @@ void test_gesv_work(Params& params, bool run)
             // Using traditional BLAS/LAPACK name
             // slate::gesv(A, pivots, B, opts);
         }
-        else if (params.routine == "gesvMixed") {
+        else if (params.routine == "gesv_mixed") {
             if constexpr (std::is_same<real_t, double>::value) {
                 int iters = 0;
-                slate::gesvMixed(A, pivots, B, X, iters, opts);
+                slate::gesv_mixed( A, pivots, B, X, iters, opts );
                 params.iters() = iters;
             }
         }
@@ -348,7 +349,7 @@ void test_gesv_work(Params& params, bool run)
 
         // Norm of updated-rhs/solution matrix: || X ||_1
         real_t X_norm;
-        if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres")
+        if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres")
             X_norm = slate::norm(slate::Norm::One, X);
         else
             X_norm = slate::norm(slate::Norm::One, B);
@@ -366,7 +367,7 @@ void test_gesv_work(Params& params, bool run)
             opAref = Aref;
 
         // Bref -= op(Aref)*B
-        if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres") {
+        if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres") {
             slate::multiply(-one, opAref, X, one, Bref);
             // Using traditional BLAS/LAPACK name
             // slate::gemm(-one, opAref, X, one, Bref);
@@ -384,7 +385,7 @@ void test_gesv_work(Params& params, bool run)
 
         real_t tol = params.tol() * 0.5 * std::numeric_limits<real_t>::epsilon();
         params.okay() = (params.error() <= tol);
-        if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres")
+        if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres")
             params.okay() = params.okay() && params.iters() >= 0;
     }
 

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -66,7 +66,7 @@ void test_posv_work(Params& params, bool run)
     bool do_potrs = (
         (check && params.routine == "potrf") || params.routine == "potrs");
 
-    if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
+    if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres") {
         params.iters();
     }
 
@@ -94,13 +94,13 @@ void test_posv_work(Params& params, bool run)
         return;
     }
 
-    if ((params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
+    if ((params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres")
         && ! std::is_same<real_t, double>::value) {
         params.msg() = "skipping: unsupported mixed precision; must be type=d or z";
         return;
     }
 
-    if ((params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
+    if ((params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres")
         && target == slate::Target::Devices) {
         params.msg() = "skipping: unsupported devices support";
         return;
@@ -170,7 +170,7 @@ void test_posv_work(Params& params, bool run)
 
         B.insertLocalTiles(origin_target);
 
-        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
+        if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres") {
             X_data.resize(lldB*nlocB);
             X = slate::Matrix<scalar_t>(n, nrhs, nb, p, q, MPI_COMM_WORLD);
             X.insertLocalTiles(origin_target);
@@ -184,7 +184,7 @@ void test_posv_work(Params& params, bool run)
                 uplo, n, &A_data[0], lldA, nb, p, q, MPI_COMM_WORLD);
         B = slate::Matrix<scalar_t>::fromScaLAPACK(
                 n, nrhs, &B_data[0], lldB, nb, p, q, MPI_COMM_WORLD);
-        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
+        if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres") {
             X_data.resize(lldB*nlocB);
             X = slate::Matrix<scalar_t>::fromScaLAPACK(
                     n, nrhs, &X_data[0], lldB, nb, p, q, MPI_COMM_WORLD);
@@ -218,7 +218,7 @@ void test_posv_work(Params& params, bool run)
 
     double gflop;
     if (params.routine == "posv"
-        || params.routine == "posvMixed"
+        || params.routine == "posv_mixed"
         || params.routine == "posv_mixed_gmres")
         gflop = lapack::Gflop<scalar_t>::posv(n, nrhs);
     else
@@ -247,10 +247,10 @@ void test_posv_work(Params& params, bool run)
             // Using traditional BLAS/LAPACK name
             // slate::posv(A, B, opts);
         }
-        else if (params.routine == "posvMixed") {
+        else if (params.routine == "posv_mixed") {
             if constexpr (std::is_same<real_t, double>::value) {
                 int iters = 0;
-                slate::posvMixed(A, B, X, iters, opts);
+                slate::posv_mixed( A, B, X, iters, opts );
                 params.iters() = iters;
             }
         }
@@ -307,13 +307,13 @@ void test_posv_work(Params& params, bool run)
 
         // Norm of updated-rhs/solution matrix: || X ||_1
         real_t X_norm;
-        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
+        if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres")
             X_norm = slate::norm(slate::Norm::One, X);
         else
             X_norm = slate::norm(slate::Norm::One, B);
 
         // Bref -= Aref*B
-        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
+        if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres") {
             slate::multiply(-one, Aref, X, one, Bref);
             // Using traditional BLAS/LAPACK name
             // slate::hemm(slate::Side::Left, -one, Aref, X, one, Bref);
@@ -331,7 +331,7 @@ void test_posv_work(Params& params, bool run)
 
         real_t tol = params.tol() * 0.5 * std::numeric_limits<real_t>::epsilon();
         params.okay() = (params.error() <= tol);
-        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
+        if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres")
             params.okay() = params.okay() && params.iters() >= 0;
     }
 


### PR DESCRIPTION
Rename `{gesv,posv}Mixed` => `{gesv,posv}_mixed`. We've adopted style that all top-level functions are snake_case.

See PR #6: conj_transpose
See [bitbucket PR 180](https://bitbucket.org/icl/slate-dev/pull-requests/180): GMRES. This will have merge conflicts.