### PR TITLE
Various matrix generator improvements

### DIFF
--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -1312,6 +1312,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1367,6 +1368,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1400,6 +1402,7 @@ void generate_matrix(
                         if (A.tileIsLocal(i, j)) {
                             #pragma omp task firstprivate(i, j, mb, nb, i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1424,6 +1427,7 @@ void generate_matrix(
             for (int64_t i = 0; i < mt; ++i) {
                 for (int64_t j = 0; j < nt; ++j) {
                     if (A.tileIsLocal(i, j)) {
+                        A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                         auto A_ij = A(i, j);
                         const int64_t mb = A.tileMb(i);
                         const int64_t nb = A.tileNb(j);
@@ -1468,6 +1472,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1506,6 +1511,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1540,6 +1546,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1579,6 +1586,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
@@ -1612,6 +1620,7 @@ void generate_matrix(
                             #pragma omp task firstprivate(i, j, mb, nb, \
                                                           i_global, j_global)
                             {
+                                A.tileGetForWriting( i, j, LayoutConvert::ColMajor );
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {

--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -1570,7 +1570,7 @@ void generate_matrix(
                                 auto A_ij = A(i, j);
                                 for (int64_t ii = 0; ii < mb; ++ii) {
                                     for (int64_t jj = 0; jj < nb; ++jj) {
-                                        A_ij.at(ii, jj) = 0.5 / (max_mn-(i_global+ii+1)-(j_global+jj+1)+1.5);
+                                        A_ij.at(ii, jj) = 0.5 / (max_mn-(i_global+ii)-(j_global+jj)+1.5);
                                     }
                                 }
                             }

--- a/test/matrix_generator.hh
+++ b/test/matrix_generator.hh
@@ -24,35 +24,41 @@ template <typename scalar_t>
 void generate_matrix(
     MatrixParams& params,
     slate::Matrix< scalar_t >& A,
-    std::vector< blas::real_type<scalar_t> >& sigma );
+    std::vector< blas::real_type<scalar_t> >& Sigma,
+    slate::Options const& opts = slate::Options());
 
 template <typename scalar_t>
 void generate_matrix(
     MatrixParams& params,
     slate::BaseTrapezoidMatrix< scalar_t >& A,
-    std::vector< blas::real_type<scalar_t> >& sigma);
+    std::vector< blas::real_type<scalar_t> >& Sigma,
+    slate::Options const& opts = slate::Options());
 
 template <typename scalar_t>
 void generate_matrix(
     MatrixParams& params,
     slate::HermitianMatrix< scalar_t >& A,
-    std::vector< blas::real_type<scalar_t> >& sigma);
+    std::vector< blas::real_type<scalar_t> >& Sigma,
+    slate::Options const& opts = slate::Options());
 
 // Overload without sigma.
 template <typename scalar_t>
 void generate_matrix(
     MatrixParams& params,
-    slate::Matrix< scalar_t >& A );
+    slate::Matrix< scalar_t >& A,
+    slate::Options const& opts = slate::Options());
 
 template <typename scalar_t>
 void generate_matrix(
     MatrixParams& params,
-    slate::BaseTrapezoidMatrix< scalar_t >& A);
+    slate::BaseTrapezoidMatrix< scalar_t >& A,
+    slate::Options const& opts = slate::Options());
 
 template <typename scalar_t>
 void generate_matrix(
     MatrixParams& params,
-    slate::HermitianMatrix< scalar_t >& A);
+    slate::HermitianMatrix< scalar_t >& A,
+    slate::Options const& opts = slate::Options());
 
 void generate_matrix_usage();
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -221,8 +221,9 @@ void test_gesv_work(Params& params, bool run)
 
     slate::Pivots pivots;
 
-    slate::generate_matrix(params.matrix,  A);
-    slate::generate_matrix(params.matrixB, B);
+    slate::Options matgen_opts = {{slate::Option::Target, target}};
+    slate::generate_matrix(params.matrix,  A, matgen_opts);
+    slate::generate_matrix(params.matrixB, B, matgen_opts);
 
     // If check/ref is required, copy test data.
     slate::Matrix<scalar_t> Aref, Bref;


### PR DESCRIPTION
This is a miscellaneous set of improvements coming from the BEAM work.
* Fix some invalid `omp parallel for` usage in the `diag`, `svd`, `heev`, and `poev` generators
* Fix an indexing issue in the `ris` generator
* Add some extra matrix generators (`chebspec` and `kms` from Matlab gallery, `ZielkeNS` from Higham's new AnyMatrix collection, `randr` as a random matrix from the Rademacher distribution)
* Add some seed preprocessing to prevent similar seeds from having similar A[1,1] entries
* Add support for Options
  * Key use is doing `geqrf` and `unmqr` in the `svd` and `heev` generators on device
  * Currently used by only the `gesv` tester when `Target::Devices`
* Add missing `A.tileGetForWriting` calls to structured matrix generators

Relatedly, there's the work in progress [PR#97](https://bitbucket.org/icl/slate-dev/pull-requests/97) which was to add a way to test different matrices with `--repeat` in a reproducible way.  (The current default seed of `-1` gives a different matrix each time, but is not reproducible.)
If that's still wanted, I could get it finalized and added to this PR.