### PR TITLE
Omptarget

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,7 +89,7 @@ fortran_api     := $(strip $(fortran_api))
 # Export variables to sub-make for testsweeper, BLAS++, LAPACK++.
 export CXX blas blas_int blas_threaded openmp static gpu_backend
 
-CXXFLAGS   += -O3 -std=c++17 -Wall -pedantic -MMD #  -Wshadow
+CXXFLAGS   += -O3 -std=c++17 -Wall -Wshadow -pedantic -MMD
 NVCCFLAGS  += -O3 -std=c++11 --compiler-options '-Wall -Wno-unused-function'
 HIPCCFLAGS += -std=c++11 -DTCE_HIP -fno-gpu-rdc
 
@@ -495,7 +495,7 @@ omptarget_src := \
         src/omptarget/device_synorm.cc \
         src/omptarget/device_transpose.cc \
         src/omptarget/device_trnorm.cc \
-	    src/omptarget/device_tzadd.cc \
+        src/omptarget/device_tzadd.cc \
         src/omptarget/device_tzcopy.cc \
         src/omptarget/device_tzscale.cc \
         src/omptarget/device_tzset.cc \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -89,7 +89,7 @@ fortran_api     := $(strip $(fortran_api))
 # Export variables to sub-make for testsweeper, BLAS++, LAPACK++.
 export CXX blas blas_int blas_threaded openmp static gpu_backend
 
-CXXFLAGS   += -O3 -std=c++17 -Wall -Wshadow -pedantic -MMD
+CXXFLAGS   += -O3 -std=c++17 -Wall -pedantic -MMD #  -Wshadow
 NVCCFLAGS  += -O3 -std=c++11 --compiler-options '-Wall -Wno-unused-function'
 HIPCCFLAGS += -std=c++11 -DTCE_HIP -fno-gpu-rdc
 
@@ -125,10 +125,8 @@ ifneq ($(cuda),1)
 endif
 
 omptarget = 0
-ifneq ($(cuda),1)
-    ifneq ($(filter auto omptarget, $(gpu_backend)),)
-	omptarget = 1
-    endif
+ifneq ($(filter auto omptarget, $(gpu_backend)),)
+    omptarget = 1
 endif
 
 # Default LD=ld won't work; use CXX. Can override in make.inc or environment.
@@ -485,17 +483,22 @@ cuda_hdr := \
 hip_src := $(patsubst src/cuda/%.cu,src/hip/%.hip.cc,$(cuda_src))
 hip_hdr := $(patsubst src/cuda/%.cuh,src/hip/%.hip.hh,$(cuda_hdr))
 
-# missing gescale tzadd tzscale tzset
+# OpenMP implementations of device kernels
 omptarget_src := \
         src/omptarget/device_geadd.cc \
         src/omptarget/device_gecopy.cc \
         src/omptarget/device_genorm.cc \
+        src/omptarget/device_gescale.cc \
+        src/omptarget/device_gescale_row_col.cc \
         src/omptarget/device_geset.cc \
         src/omptarget/device_henorm.cc \
         src/omptarget/device_synorm.cc \
         src/omptarget/device_transpose.cc \
         src/omptarget/device_trnorm.cc \
+	    src/omptarget/device_tzadd.cc \
         src/omptarget/device_tzcopy.cc \
+        src/omptarget/device_tzscale.cc \
+        src/omptarget/device_tzset.cc \
         # End. Add alphabetically.
 
 omptarget_hdr := \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -96,7 +96,7 @@ HIPCCFLAGS += -std=c++11 -DTCE_HIP -fno-gpu-rdc
 force: ;
 
 # Auto-detect CUDA, HIP.
-ifneq ($(filter-out auto cuda hip none, $(gpu_backend)),)
+ifneq ($(filter-out auto cuda hip omptarget none, $(gpu_backend)),)
     $(error ERROR: gpu_backend = $(gpu_backend) is unknown)
 endif
 
@@ -121,6 +121,13 @@ ifneq ($(cuda),1)
         else ifeq ($(gpu_backend),hip)
             $(error ERROR: gpu_backend = $(gpu_backend), but HIPCC = $(HIPCC) not found)
         endif
+    endif
+endif
+
+omptarget = 0
+ifneq ($(cuda),1)
+    ifneq ($(filter auto omptarget, $(gpu_backend)),)
+	omptarget = 1
     endif
 endif
 
@@ -478,12 +485,32 @@ cuda_hdr := \
 hip_src := $(patsubst src/cuda/%.cu,src/hip/%.hip.cc,$(cuda_src))
 hip_hdr := $(patsubst src/cuda/%.cuh,src/hip/%.hip.hh,$(cuda_hdr))
 
+# missing gescale tzadd tzscale tzset
+omptarget_src := \
+        src/omptarget/device_geadd.cc \
+        src/omptarget/device_gecopy.cc \
+        src/omptarget/device_genorm.cc \
+        src/omptarget/device_geset.cc \
+        src/omptarget/device_henorm.cc \
+        src/omptarget/device_synorm.cc \
+        src/omptarget/device_transpose.cc \
+        src/omptarget/device_trnorm.cc \
+        src/omptarget/device_tzcopy.cc \
+        # End. Add alphabetically.
+
+omptarget_hdr := \
+        src/omptarget/device_util.hh
+
 ifeq ($(cuda),1)
     libslate_src += $(cuda_src)
 endif
 
 ifeq ($(hip),1)
     libslate_src += ${hip_src}
+endif
+
+ifeq ($(omptarget),1)
+    libslate_src += $(omptarget_src)
 endif
 
 # driver

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -96,7 +96,7 @@ HIPCCFLAGS += -std=c++11 -DTCE_HIP -fno-gpu-rdc
 force: ;
 
 # Auto-detect CUDA, HIP.
-ifneq ($(filter-out auto cuda hip omptarget none, $(gpu_backend)),)
+ifneq ($(filter-out auto cuda hip onemkl none, $(gpu_backend)),)
     $(error ERROR: gpu_backend = $(gpu_backend) is unknown)
 endif
 
@@ -125,7 +125,8 @@ ifneq ($(cuda),1)
 endif
 
 omptarget = 0
-ifneq ($(filter auto omptarget, $(gpu_backend)),)
+ifneq ($(filter auto onemkl, $(gpu_backend)),)
+    # enable the omptarget offload kernels in SLATE
     omptarget = 1
 endif
 

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3698,6 +3698,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
             blas::device_memcpy<scalar_t*>(
                 array_dev, bucket->second.first.data(),
                 batch_count, blas::MemcpyKind::HostToDevice, *queue);
+            queue->sync(); // blas::device_memcpy does not sync
 
             if (mb == nb) {
                 // in-place transpose
@@ -3710,6 +3711,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
                 blas::device_memcpy<scalar_t*>(
                     work_array_dev, bucket->second.second.data(),
                     batch_count, blas::MemcpyKind::HostToDevice, *queue);
+                queue->sync(); // blas::device_memcpy does not sync
 
                 device::transpose_batch(layout == Layout::ColMajor ? nb : mb,
                                         layout == Layout::ColMajor ? mb : nb,

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3698,7 +3698,6 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
             blas::device_memcpy<scalar_t*>(
                 array_dev, bucket->second.first.data(),
                 batch_count, blas::MemcpyKind::HostToDevice, *queue);
-            queue->sync(); // blas::device_memcpy does not sync
 
             if (mb == nb) {
                 // in-place transpose
@@ -3711,7 +3710,6 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
                 blas::device_memcpy<scalar_t*>(
                     work_array_dev, bucket->second.second.data(),
                     batch_count, blas::MemcpyKind::HostToDevice, *queue);
-                queue->sync(); // blas::device_memcpy does not sync
 
                 device::transpose_batch(layout == Layout::ColMajor ? nb : mb,
                                         layout == Layout::ColMajor ? mb : nb,

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -957,7 +957,6 @@ void Tile<scalar_t>::copyData(
 
         blas::device_memcpy<scalar_t>(
             dst_tile->data_, this->data_, this->size(), memcpy_kind, queue);
-        queue.sync(); // blas::device_memcpy does not sync
 
         if (! async)
             queue.sync();

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -956,7 +956,7 @@ void Tile<scalar_t>::copyData(
         trace::Block trace_block("blas::device_memcpy");
 
         blas::device_memcpy<scalar_t>(
-            dst_tile->data_, this->data_, this->size(), memcpy_kind, queue);
+            dst_tile->data_, data_, size(), memcpy_kind, queue);
 
         if (! async)
             queue.sync();

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -956,7 +956,8 @@ void Tile<scalar_t>::copyData(
         trace::Block trace_block("blas::device_memcpy");
 
         blas::device_memcpy<scalar_t>(
-            dst_tile->data_, data_, size(), memcpy_kind, queue);
+            dst_tile->data_, this->data_, this->size(), memcpy_kind, queue);
+        queue.sync(); // blas::device_memcpy does not sync
 
         if (! async)
             queue.sync();

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -744,7 +744,7 @@ void MatrixStorage<scalar_t>::allocateBatchArrays(
                 blas::Queue* queue = comm_queues_[device];
 
                 // Free host arrays.
-                blas::device_free_pinned(array_host_[i][device], *queue);
+                blas::host_free_pinned(array_host_[i][device], *queue);
 
                 // Free device arrays.
                 blas::device_free(array_dev_[i][device], *queue);
@@ -757,7 +757,7 @@ void MatrixStorage<scalar_t>::allocateBatchArrays(
 
                 // Allocate host arrays;
                 array_host_[i][device]
-                    = blas::device_malloc_pinned<scalar_t*>(batch_size*3, *queue);
+                    = blas::host_malloc_pinned<scalar_t*>(batch_size*3, *queue);
 
                 // Allocate device arrays.
                 array_dev_[i][device]
@@ -788,7 +788,7 @@ void MatrixStorage<scalar_t>::clearBatchArrays()
 
             // Free host arrays.
             if (array_host_[i][device] != nullptr) {
-                blas::device_free_pinned(array_host_[i][device], *queue);
+                blas::host_free_pinned(array_host_[i][device], *queue);
                 array_host_[i][device] = nullptr;
             }
 

--- a/include/slate/internal/device.hh
+++ b/include/slate/internal/device.hh
@@ -53,8 +53,15 @@ namespace slate {
 /// GPU device implementations of kernels.
 namespace device {
 
-// Simplify checking for GPU device support (CUDA or ROCm).
-#if defined( BLAS_HAVE_CUBLAS ) || defined( BLAS_HAVE_ROCBLAS )
+// For the present, use omptarget-kernels when OneMKL is used
+#if defined( BLAS_HAVE_ONEMKL )
+    #define SLATE_HAVE_OMPTARGET
+#endif
+
+// Simplify checking for GPU device support (CUDA / ROCm / OneMKL).
+#if defined( BLAS_HAVE_CUBLAS ) \
+    || defined( BLAS_HAVE_ROCBLAS ) \
+    || defined( SLATE_HAVE_OMPTARGET )
     #define SLATE_HAVE_DEVICE
 #endif
 

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -196,6 +196,7 @@ void* Memory::allocDeviceMemory(int device, size_t size, blas::Queue *queue)
 {
     void* dev_mem = blas::device_malloc<char>(size, *queue);
     allocated_mem_[device].push(dev_mem);
+    queue->sync(); // blas::device_malloc does not sync
 
     return dev_mem;
 }
@@ -214,6 +215,7 @@ void Memory::freeHostMemory(void* host_mem)
 void Memory::freeDeviceMemory(int device, void* dev_mem, blas::Queue *queue)
 {
     blas::device_free(dev_mem, *queue);
+    queue->sync(); // blas::device_free does not sync
 }
 
 } // namespace slate

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -102,7 +102,7 @@ void Memory::clearHostBlocks()
 ///
 void Memory::clearDeviceBlocks(int device, blas::Queue *queue)
 {
-    Debug::checkDeviceMemoryLeaks(*this, device);
+    // Debug::checkDeviceMemoryLeaks(*this, device);
 
     while (! free_blocks_[device].empty())
         free_blocks_[device].pop();
@@ -196,7 +196,6 @@ void* Memory::allocDeviceMemory(int device, size_t size, blas::Queue *queue)
 {
     void* dev_mem = blas::device_malloc<char>(size, *queue);
     allocated_mem_[device].push(dev_mem);
-    queue->sync(); // blas::device_malloc does not sync
 
     return dev_mem;
 }
@@ -215,7 +214,6 @@ void Memory::freeHostMemory(void* host_mem)
 void Memory::freeDeviceMemory(int device, void* dev_mem, blas::Queue *queue)
 {
     blas::device_free(dev_mem, *queue);
-    queue->sync(); // blas::device_free does not sync
 }
 
 } // namespace slate

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -102,7 +102,7 @@ void Memory::clearHostBlocks()
 ///
 void Memory::clearDeviceBlocks(int device, blas::Queue *queue)
 {
-    // Debug::checkDeviceMemoryLeaks(*this, device);
+    Debug::checkDeviceMemoryLeaks(*this, device);
 
     while (! free_blocks_[device].empty())
         free_blocks_[device].pop();

--- a/src/device/dev_gescale_row_col.cc
+++ b/src/device/dev_gescale_row_col.cc
@@ -44,6 +44,9 @@ void gescale_row_col_batch(
 #elif defined( BLAS_HAVE_ROCBLAS )
     typedef hipFloatComplex devFloatComplex;
     typedef hipDoubleComplex devDoubleComplex;
+#else // no std::complex mapping
+    typedef std::complex<float> devFloatComplex;
+    typedef std::complex<double> devDoubleComplex;
 #endif
 
 //----------------------------------------

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -17,6 +17,7 @@ namespace device {
 
 // CUBLAS/ROCBLAS need complex translation, others do not
 #if ! defined( SLATE_HAVE_OMPTARGET)
+
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -41,10 +42,7 @@ void geadd(
           queue);
 #endif
 }
-#endif // ! defined( SLATE_HAVE_OMPTARGET)
 
-// CUBLAS/ROCBLAS need complex translation, others do not
-#if ! defined( SLATE_HAVE_OMPTARGET)
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -69,6 +67,7 @@ void geadd(
           queue);
 #endif
 }
+
 #endif // ! defined( SLATE_HAVE_OMPTARGET)
 
 #if ! defined( SLATE_HAVE_DEVICE )
@@ -96,7 +95,8 @@ void geadd(
 namespace batch {
 
 // CUBLAS/ROCBLAS need complex translation, others do not
-#if ! defined( SLATE_HAVE_OMPTARGET)
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -121,10 +121,7 @@ void geadd(
           batch_count, queue);
 #endif
 }
-#endif // if ! defined( SLATE_HAVE_OMPTARGET)
 
-// CUBLAS/ROCBLAS need complex definitions, others do not
-#if defined( BLAS_HAVE_CUBLAS ) || defined( BLAS_HAVE_ROCBLAS )
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -149,6 +146,7 @@ void geadd(
           batch_count, queue);
 #endif
 }
+
 #endif // if ! defined( SLATE_HAVE_OMPTARGET)
 
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -361,7 +361,6 @@ void add(internal::TargetType<Target::Devices>,
                                 batch_count*2,
                                 blas::MemcpyKind::HostToDevice,
                                 *queue);
-            queue->sync(); // blas::device_memcpy does not sync
 
             for (int q = 0; q < 4; ++q) {
                 if (group_count[q] > 0) {

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -361,6 +361,7 @@ void add(internal::TargetType<Target::Devices>,
                                 batch_count*2,
                                 blas::MemcpyKind::HostToDevice,
                                 *queue);
+            queue->sync(); // blas::device_memcpy does not sync
 
             for (int q = 0; q < 4; ++q) {
                 if (group_count[q] > 0) {

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -15,6 +15,8 @@ namespace slate {
 
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET)
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -39,7 +41,10 @@ void geadd(
           queue);
 #endif
 }
+#endif // ! defined( SLATE_HAVE_OMPTARGET)
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET)
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -64,6 +69,7 @@ void geadd(
           queue);
 #endif
 }
+#endif // ! defined( SLATE_HAVE_OMPTARGET)
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.
@@ -89,6 +95,8 @@ void geadd(
 //==============================================================================
 namespace batch {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET)
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -113,7 +121,10 @@ void geadd(
           batch_count, queue);
 #endif
 }
+#endif // if ! defined( SLATE_HAVE_OMPTARGET)
 
+// CUBLAS/ROCBLAS need complex definitions, others do not
+#if defined( BLAS_HAVE_CUBLAS ) || defined( BLAS_HAVE_ROCBLAS )
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -138,6 +149,7 @@ void geadd(
           batch_count, queue);
 #endif
 }
+#endif // if ! defined( SLATE_HAVE_OMPTARGET)
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -15,6 +15,9 @@
 namespace slate {
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void gecopy(
     int64_t m, int64_t n,
@@ -98,6 +101,8 @@ void gecopy(
            batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 //---------------------------------------------------
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -311,11 +311,13 @@ void copy(internal::TargetType<Target::Devices>,
                                 batch_count,
                                 blas::MemcpyKind::HostToDevice,
                                 *queue);
+            queue->sync(); // blas::device_memcpy does not sync
 
             blas::device_memcpy<dst_scalar_t*>(b_array_dev, b_array_host,
                                 batch_count,
                                 blas::MemcpyKind::HostToDevice,
                                 *queue);
+            queue->sync(); // blas::device_memcpy does not sync
 
             for (int q = 0; q < 4; ++q) {
                 if (group_count[q] > 0) {

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -311,13 +311,11 @@ void copy(internal::TargetType<Target::Devices>,
                                 batch_count,
                                 blas::MemcpyKind::HostToDevice,
                                 *queue);
-            queue->sync(); // blas::device_memcpy does not sync
 
             blas::device_memcpy<dst_scalar_t*>(b_array_dev, b_array_host,
                                 batch_count,
                                 blas::MemcpyKind::HostToDevice,
                                 *queue);
-            queue->sync(); // blas::device_memcpy does not sync
 
             for (int q = 0; q < 4; ++q) {
                 if (group_count[q] > 0) {

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -141,6 +141,10 @@ void gemm(internal::TargetType<Target::HostNest>,
           Layout layout, int priority, int64_t queue_index,
           Options const& opts )
 {
+#ifdef SLATE_HAVE_OMPTARGET
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // check dimensions
     assert(A.nt() == 1);
     assert(B.mt() == 1);
@@ -178,6 +182,7 @@ void gemm(internal::TargetType<Target::HostNest>,
 
     if (err)
         slate_error(err_msg+", line "+std::to_string(err));
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -141,7 +141,7 @@ void gemm(internal::TargetType<Target::HostNest>,
           Layout layout, int priority, int64_t queue_index,
           Options const& opts )
 {
-#ifdef SLATE_HAVE_OMPTARGET
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
     slate_not_implemented("Target::HostNest isn't supported in this configuration.");
 #else

--- a/src/internal/internal_genorm.cc
+++ b/src/internal/internal_genorm.cc
@@ -21,6 +21,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void genorm(
     Norm in_norm, NormScope scope,
@@ -58,6 +61,8 @@ void genorm(
            values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_gescale.cc
+++ b/src/internal/internal_gescale.cc
@@ -16,6 +16,9 @@ namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device single tile routine
 template <>
 void gescale(
@@ -104,6 +107,8 @@ void gescale(
             queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_geset.cc
+++ b/src/internal/internal_geset.cc
@@ -19,6 +19,9 @@ namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device single tile routine
 template <>
 void geset(
@@ -67,6 +70,8 @@ void geset(
 #endif
 }
 
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
+
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.
 template <>
@@ -92,6 +97,9 @@ void geset(
 namespace batch {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device::batch routine
 template <>
 void geset(
@@ -139,6 +147,8 @@ void geset(
           batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_geset.cc
+++ b/src/internal/internal_geset.cc
@@ -341,6 +341,7 @@ void set(internal::TargetType<Target::Devices>,
             blas::device_memcpy<scalar_t*>(
                 a_array_dev, a_array_host, batch_count,
                 blas::MemcpyKind::HostToDevice, *queue);
+            queue->sync(); // blas::device_memcpy does not sync
 
             for (int q = 0; q < 4; ++q) {
                 if (group_count[q] > 0) {
@@ -350,6 +351,7 @@ void set(internal::TargetType<Target::Devices>,
                     a_array_dev += group_count[q];
                 }
             }
+            queue->sync(); // blas::device_memcpy does not sync
             for (int q = 4; q < 8; ++q) {
                 if (group_count[q] > 0) {
                     device::batch::geset(mb[q], nb[q],

--- a/src/internal/internal_geset.cc
+++ b/src/internal/internal_geset.cc
@@ -341,7 +341,6 @@ void set(internal::TargetType<Target::Devices>,
             blas::device_memcpy<scalar_t*>(
                 a_array_dev, a_array_host, batch_count,
                 blas::MemcpyKind::HostToDevice, *queue);
-            queue->sync(); // blas::device_memcpy does not sync
 
             for (int q = 0; q < 4; ++q) {
                 if (group_count[q] > 0) {
@@ -351,7 +350,6 @@ void set(internal::TargetType<Target::Devices>,
                     a_array_dev += group_count[q];
                 }
             }
-            queue->sync(); // blas::device_memcpy does not sync
             for (int q = 4; q < 8; ++q) {
                 if (group_count[q] > 0) {
                     device::batch::geset(mb[q], nb[q],

--- a/src/internal/internal_henorm.cc
+++ b/src/internal/internal_henorm.cc
@@ -23,6 +23,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void henorm(
     Norm in_norm, Uplo uplo,
@@ -60,6 +63,8 @@ void henorm(
            values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA.

--- a/src/internal/internal_her2k.cc
+++ b/src/internal/internal_her2k.cc
@@ -159,6 +159,10 @@ void her2k(internal::TargetType<Target::HostNest>,
 {
     using blas::conj;
 
+#ifdef SLATE_HAVE_OMPTARGET
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::her2k()
     //       to take layout param
@@ -233,6 +237,7 @@ void her2k(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_her2k.cc
+++ b/src/internal/internal_her2k.cc
@@ -159,7 +159,7 @@ void her2k(internal::TargetType<Target::HostNest>,
 {
     using blas::conj;
 
-#ifdef SLATE_HAVE_OMPTARGET
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
     slate_not_implemented("Target::HostNest isn't supported in this configuration.");
 #else

--- a/src/internal/internal_herk.cc
+++ b/src/internal/internal_herk.cc
@@ -140,6 +140,10 @@ void herk(internal::TargetType<Target::HostNest>,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>& C,
           int priority, int queue_index, Layout layout, Options const& opts)
 {
+#ifdef SLATE_HAVE_OMPTARGET
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     scalar_t alpha_ = scalar_t(alpha);
     scalar_t beta_  = scalar_t(beta);
 
@@ -208,6 +212,7 @@ void herk(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_herk.cc
+++ b/src/internal/internal_herk.cc
@@ -140,7 +140,7 @@ void herk(internal::TargetType<Target::HostNest>,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>& C,
           int priority, int queue_index, Layout layout, Options const& opts)
 {
-#ifdef SLATE_HAVE_OMPTARGET
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
     slate_not_implemented("Target::HostNest isn't supported in this configuration.");
 #else

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -656,8 +656,6 @@ void norm(internal::TargetType<Target::Devices>,
 
                 vals_dev_array = vals_dev_arrays[device];
 
-                queue->sync(); // sync after computation
-
                 blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
                                     batch_count*ldv,
                                     blas::MemcpyKind::DeviceToHost,

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -22,6 +22,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void synorm(
     Norm in_norm, Uplo uplo,
@@ -97,6 +100,8 @@ void synormOffdiag(
                   values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -619,7 +619,6 @@ void norm(internal::TargetType<Target::Devices>,
                                     batch_count,
                                     blas::MemcpyKind::HostToDevice,
                                     *queue);
-                queue->sync(); // blas::device_memcpy does not sync
 
                 // off-diagonal blocks
                 for (int q = 0; q < 4; ++q) {

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -619,6 +619,7 @@ void norm(internal::TargetType<Target::Devices>,
                                     batch_count,
                                     blas::MemcpyKind::HostToDevice,
                                     *queue);
+                queue->sync(); // blas::device_memcpy does not sync
 
                 // off-diagonal blocks
                 for (int q = 0; q < 4; ++q) {
@@ -655,6 +656,8 @@ void norm(internal::TargetType<Target::Devices>,
                 }
 
                 vals_dev_array = vals_dev_arrays[device];
+
+                queue->sync(); // sync after computation
 
                 blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
                                     batch_count*ldv,

--- a/src/internal/internal_syr2k.cc
+++ b/src/internal/internal_syr2k.cc
@@ -153,7 +153,7 @@ void syr2k(internal::TargetType<Target::HostNest>,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
            int priority, int queue_index, Layout layout, Options const& opts)
 {
-#ifdef SLATE_HAVE_OMPTARGET
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
     slate_not_implemented("Target::HostNest isn't supported in this configuration.");
 #else

--- a/src/internal/internal_syr2k.cc
+++ b/src/internal/internal_syr2k.cc
@@ -153,6 +153,10 @@ void syr2k(internal::TargetType<Target::HostNest>,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
            int priority, int queue_index, Layout layout, Options const& opts)
 {
+#ifdef SLATE_HAVE_OMPTARGET
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::syr2k()
     //       to take layout param
@@ -226,6 +230,7 @@ void syr2k(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_syrk.cc
+++ b/src/internal/internal_syrk.cc
@@ -139,7 +139,7 @@ void syrk(internal::TargetType<Target::HostNest>,
           int priority, int queue_index, Layout layout,
           Options const& opts)
 {
-#ifdef SLATE_HAVE_OMPTARGET
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
     slate_not_implemented("Target::HostNest isn't supported in this configuration.");
 #else

--- a/src/internal/internal_syrk.cc
+++ b/src/internal/internal_syrk.cc
@@ -139,6 +139,10 @@ void syrk(internal::TargetType<Target::HostNest>,
           int priority, int queue_index, Layout layout,
           Options const& opts)
 {
+#ifdef SLATE_HAVE_OMPTARGET
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::syrk()
     //       to take layout param
@@ -204,6 +208,7 @@ void syrk(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_transpose.cc
+++ b/src/internal/internal_transpose.cc
@@ -20,6 +20,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET)
+
 template <>
 void transpose(
     int64_t n,
@@ -159,6 +162,7 @@ void transpose_batch(
 #endif
 }
 
+#endif // ! defined( SLATE_HAVE_OMPTARGET)
 
 //------------------------------------------------------------------------------
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_trnorm.cc
+++ b/src/internal/internal_trnorm.cc
@@ -21,6 +21,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void trnorm(
     Norm in_norm, Uplo uplo, Diag diag,
@@ -58,6 +61,8 @@ void trnorm(
            values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_tzadd.cc
+++ b/src/internal/internal_tzadd.cc
@@ -15,6 +15,9 @@ namespace slate {
 
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void tzadd(
     Uplo uplo,
@@ -66,6 +69,8 @@ void tzadd(
           batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -15,6 +15,9 @@
 namespace slate {
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void tzcopy(
     Uplo uplo,
@@ -106,6 +109,8 @@ void tzcopy(
            batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 //---------------------------------------------------
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_tzscale.cc
+++ b/src/internal/internal_tzscale.cc
@@ -14,6 +14,9 @@
 namespace slate {
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void tzscale(
     Uplo uplo,
@@ -57,6 +60,8 @@ void tzscale(
             batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_tzset.cc
+++ b/src/internal/internal_tzset.cc
@@ -19,6 +19,9 @@ namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device single tile routine
 template <>
 void tzset(
@@ -72,6 +75,8 @@ void tzset(
         queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 //----------------------------------------

--- a/src/omptarget/device_geadd.cc
+++ b/src/omptarget/device_geadd.cc
@@ -57,7 +57,7 @@ void geadd(
         return;
 
     // Use omp target offload
-    #pragma omp target is_device_ptr(A) device(queue.device())
+    #pragma omp target is_device_ptr(A, B) device(queue.device())
     #pragma omp teams distribute parallel for schedule(static, 1)
     for (int64_t i = 0; i < m; ++i) {
         scalar_t* rowA = &A[i];

--- a/src/omptarget/device_geadd.cc
+++ b/src/omptarget/device_geadd.cc
@@ -56,6 +56,7 @@ void geadd(
     if (m == 0 || n == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(A, B) device(queue.device())
     #pragma omp teams distribute parallel for schedule(static, 1)
@@ -154,6 +155,7 @@ void geadd(
     if (batch_count == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
     #pragma omp teams distribute

--- a/src/omptarget/device_geadd.cc
+++ b/src/omptarget/device_geadd.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise tile addition.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] queue
+///     blas device queue to execute in.
+///
+template <typename scalar_t>
+void geadd(
+    int64_t m, int64_t n,
+    scalar_t alpha, scalar_t** Aarray, int64_t lda,
+    scalar_t beta, scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* tileA = Aarray[k];
+        scalar_t* tileB = Barray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for simd schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[i];
+            scalar_t* rowB = &tileB[i];
+            for (int64_t j = 0; j < n; ++j) {
+                rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geadd(
+    int64_t m, int64_t n,
+    float alpha, float** Aarray, int64_t lda,
+    float beta, float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    double alpha, double** Aarray, int64_t lda,
+    double beta, double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    std::complex<float> alpha, std::complex<float>** Aarray, int64_t lda,
+    std::complex<float> beta, std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    std::complex<double> alpha, std::complex<double>** Aarray, int64_t lda,
+    std::complex<double> beta, std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_geadd.cc
+++ b/src/omptarget/device_geadd.cc
@@ -48,8 +48,8 @@ namespace device {
 template <typename scalar_t>
 void geadd(
     int64_t m, int64_t n,
-    scalar_t alpha, scalar_t* A, int64_t lda,
-    scalar_t beta, scalar_t* B, int64_t ldb,
+    scalar_t const& alpha, scalar_t* A, int64_t lda,
+    scalar_t const& beta, scalar_t* B, int64_t ldb,
     blas::Queue &queue)
 {
     // quick return
@@ -74,29 +74,29 @@ void geadd(
 template
 void geadd(
     int64_t m, int64_t n,
-    float alpha, float* Aarray, int64_t lda,
-    float beta, float* Barray, int64_t ldb,
+    float const& alpha, float* Aarray, int64_t lda,
+    float const& beta, float* Barray, int64_t ldb,
     blas::Queue &queue);
 
 template
 void geadd(
     int64_t m, int64_t n,
-    double alpha, double* Aarray, int64_t lda,
-    double beta, double* Barray, int64_t ldb,
+    double const& alpha, double* Aarray, int64_t lda,
+    double const& beta, double* Barray, int64_t ldb,
     blas::Queue &queue);
 
 template
 void geadd(
     int64_t m, int64_t n,
-    std::complex<float> alpha, std::complex<float>* Aarray, int64_t lda,
-    std::complex<float> beta, std::complex<float>* Barray, int64_t ldb,
+    std::complex<float> const& alpha, std::complex<float>* Aarray, int64_t lda,
+    std::complex<float> const& beta, std::complex<float>* Barray, int64_t ldb,
     blas::Queue &queue);
 
 template
 void geadd(
     int64_t m, int64_t n,
-    std::complex<double> alpha, std::complex<double>* Aarray, int64_t lda,
-    std::complex<double> beta, std::complex<double>* Barray, int64_t ldb,
+    std::complex<double> const& alpha, std::complex<double>* Aarray, int64_t lda,
+    std::complex<double> const& beta, std::complex<double>* Barray, int64_t ldb,
     blas::Queue &queue);
 
 //==============================================================================
@@ -144,8 +144,8 @@ namespace batch {
 template <typename scalar_t>
 void geadd(
     int64_t m, int64_t n,
-    scalar_t alpha, scalar_t** Aarray, int64_t lda,
-    scalar_t beta, scalar_t** Barray, int64_t ldb,
+    scalar_t const& alpha, scalar_t** Aarray, int64_t lda,
+    scalar_t const& beta, scalar_t** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue)
 {
     // quick return
@@ -179,29 +179,29 @@ void geadd(
 template
 void geadd(
     int64_t m, int64_t n,
-    float alpha, float** Aarray, int64_t lda,
-    float beta, float** Barray, int64_t ldb,
+    float const& alpha, float** Aarray, int64_t lda,
+    float const& beta, float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void geadd(
     int64_t m, int64_t n,
-    double alpha, double** Aarray, int64_t lda,
-    double beta, double** Barray, int64_t ldb,
+    double const& alpha, double** Aarray, int64_t lda,
+    double const& beta, double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void geadd(
     int64_t m, int64_t n,
-    std::complex<float> alpha, std::complex<float>** Aarray, int64_t lda,
-    std::complex<float> beta, std::complex<float>** Barray, int64_t ldb,
+    std::complex<float> const& alpha, std::complex<float>** Aarray, int64_t lda,
+    std::complex<float> const& beta, std::complex<float>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void geadd(
     int64_t m, int64_t n,
-    std::complex<double> alpha, std::complex<double>** Aarray, int64_t lda,
-    std::complex<double> beta, std::complex<double>** Barray, int64_t ldb,
+    std::complex<double> const& alpha, std::complex<double>** Aarray, int64_t lda,
+    std::complex<double> const& beta, std::complex<double>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 } // namespace batch

--- a/src/omptarget/device_gecopy.cc
+++ b/src/omptarget/device_gecopy.cc
@@ -58,6 +58,7 @@ void gecopy(
     if (batch_count == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {

--- a/src/omptarget/device_gecopy.cc
+++ b/src/omptarget/device_gecopy.cc
@@ -1,0 +1,135 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <algorithm>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Routine for element-wise copy and precision conversion.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] stream
+///     Device stream to execute in.
+///
+template <typename src_scalar_t, typename dst_scalar_t>
+void gecopy(
+    int64_t m, int64_t n,
+    src_scalar_t** Aarray, int64_t lda,
+    dst_scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        src_scalar_t* tileA = Aarray[k];
+        dst_scalar_t* tileB = Barray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for simd collapse(1) schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            src_scalar_t* rowA = &tileA[i];
+            dst_scalar_t* rowB = &tileB[i];
+            for (int64_t j = 0; j < n; ++j) {
+                // todo: confirm type coversion float-complex -> double-complex
+                // todo: confirm type coversion double-complex -> float-complex
+                rowB[j*ldb] = rowA[j*lda];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float** Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float** Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double** Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double** Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<float>** Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<float>** Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<double>** Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<double>** Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_gecopy.cc
+++ b/src/omptarget/device_gecopy.cc
@@ -64,7 +64,7 @@ void gecopy(
         src_scalar_t const* tileA = Aarray[k];
         dst_scalar_t* tileB = Barray[k];
         // distribute rows (i) to threads
-        #pragma omp parallel for collapse(1) schedule(static, 1)
+        #pragma omp parallel for schedule(static, 1)
         for (int64_t i = 0; i < m; ++i) {
             src_scalar_t const* rowA = &tileA[i];
             dst_scalar_t* rowB = &tileB[i];

--- a/src/omptarget/device_genorm.cc
+++ b/src/omptarget/device_genorm.cc
@@ -1,0 +1,276 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., m-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= m.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: ldv >= m.
+///         On exit, values[k*ldv + i] = sum_{j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= i < m.
+///
+///     - Norm::Fro: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    if (scope == NormScope::Matrix) {
+
+        //---------
+        // max norm
+        if (norm == lapack::Norm::Max) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count, queue);
+            }
+            else {
+                assert(ldv == 1);
+                blas::device_memset(values, 0, batch_count, queue);
+                // Use omp target offload
+                // note: the max_nan_reduction preserves nans
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    const scalar_t* tileA = Aarray[k];
+                    #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                    for (int64_t i = 0; i < m; ++i) {
+                        const scalar_t* rowA = &tileA[i];
+                        real_t max = 0;
+                        for (int64_t j = 0; j < n; ++j) {
+                            max = max_nan(max, abs_val(rowA[j*lda]));
+                        }
+                        values[k] = max_nan(values[k], max);
+                    }
+                }
+            }
+        }
+        //---------
+        // one norm
+        else if (norm == lapack::Norm::One) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * n, queue);
+            }
+            else {
+                assert(ldv >= n);
+                // use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    // distribute cols to threads (j)
+                    #pragma omp parallel for simd schedule(static, 1)
+                    for (int64_t j = 0; j < n; ++j) {
+                        values[k*ldv + j] = 0;
+                        for (int64_t i = 0; i < m; ++i) {
+                            values[k*ldv + j] += abs_val( Aarray[k][i + j*lda] );
+                        }
+                    }
+                }
+            }
+        }
+        //---------
+        // inf norm
+        else if (norm == lapack::Norm::Inf) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * m, queue);
+            }
+            else {
+                assert(ldv >= m);
+                // use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    // distribute rows to threads (i)
+                    #pragma omp parallel for simd schedule(static, 1)
+                    for (int64_t i = 0; i < m; ++i) {
+                        values[k*ldv + i] = 0;
+                        for (int64_t j = 0; j < n; ++j) {
+                            values[k*ldv + i] += abs_val( Aarray[k][i + j*lda] );
+                        }
+                    }
+                }
+            }
+        }
+        //---------
+        // Frobenius norm
+        else if (norm == lapack::Norm::Fro) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * 2, queue);
+            }
+            else {
+                assert(ldv == 2);
+                // use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    const scalar_t* tileA = Aarray[k];
+                    values[k*2 + 0] = 0; // scale_k
+                    values[k*2 + 1] = 1; // sumsq_k
+                    // distribute rows to threads (i)
+                    #pragma omp parallel for schedule(static, 1)
+                    for (int64_t i = 0; i < m; ++i) {
+                        real_t scale_ki = 0;
+                        real_t sumsq_ki = 1;
+                        for (int64_t j = 0; j < n; ++j)
+                            add_sumsq(scale_ki, sumsq_ki, abs_val( tileA[i + j*lda] ));
+                        // accumulate the scale and sumsq for each k
+                        // todo: critical section is slow, is there a better way?
+                        #pragma omp critical
+                        {
+                            real_t scale_k = values[k*2 + 0];
+                            real_t sumsq_k = values[k*2 + 1];
+                            if (scale_k > scale_ki) {
+                                sumsq_k = sumsq_k + sumsq_ki*(scale_ki / scale_k)*(scale_ki / scale_k);
+                                // scale_k stays same
+                            }
+                            else if (scale_ki != 0) {
+                                sumsq_k = sumsq_k*(scale_k / scale_ki)*(scale_k / scale_ki) + sumsq_ki;
+                                scale_k = scale_ki;
+                            }
+                            values[k*2 + 0] = scale_k;
+                            values[k*2 + 1] = sumsq_k;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    else if (scope == NormScope::Columns) {
+
+        if (norm == Norm::Max) {
+
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * n, queue);
+            }
+            else {
+                // todo:  NOTE THIS NORM IS NOT CHECKED YET
+                assert(ldv >= n);
+                blas::device_memset(values, 0, batch_count * n, queue);
+                // Use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    const scalar_t* tileA = Aarray[k];
+                    // distribute cols to threads (j)
+                    #pragma omp parallel for simd collapse(1) schedule(static, 1)
+                    for (int64_t j = 0; j < n; ++j) {
+                        const scalar_t* colA = &tileA[j*lda];
+                        for (int64_t i = 0; i < m; ++i) {
+                            values[j*ldv] = max_nan(values[j*ldv], abs_val(colA[i]));
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            slate_not_implemented("The norm isn't yet supported");
+        }
+    }
+    else {
+        slate_not_implemented("The norm scope isn't yet supported.");
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+} // Namespace device
+} // namespace slate

--- a/src/omptarget/device_genorm.cc
+++ b/src/omptarget/device_genorm.cc
@@ -94,6 +94,7 @@ void genorm(
             else {
                 assert(ldv == 1);
                 blas::device_memset(values, 0, batch_count, queue);
+                queue.sync(); // sync queue before switching to openmp device execution
                 // Use omp target offload
                 // note: the max_nan_reduction preserves nans
                 #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
@@ -120,6 +121,7 @@ void genorm(
             }
             else {
                 assert(ldv >= n);
+                queue.sync(); // sync queue before switching to openmp device execution
                 // use omp target offload
                 #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
                 #pragma omp teams distribute
@@ -143,6 +145,7 @@ void genorm(
             }
             else {
                 assert(ldv >= m);
+                queue.sync(); // sync queue before switching to openmp device execution
                 // use omp target offload
                 #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
                 #pragma omp teams distribute
@@ -166,6 +169,7 @@ void genorm(
             }
             else {
                 assert(ldv == 2);
+                queue.sync(); // sync queue before switching to openmp device execution
                 // use omp target offload
                 #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
                 #pragma omp teams distribute
@@ -213,6 +217,7 @@ void genorm(
                 // todo:  NOTE THIS NORM IS NOT CHECKED YET
                 assert(ldv >= n);
                 blas::device_memset(values, 0, batch_count * n, queue);
+                queue.sync(); // sync queue before switching to openmp device execution
                 // Use omp target offload
                 #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
                 #pragma omp teams distribute

--- a/src/omptarget/device_genorm.cc
+++ b/src/omptarget/device_genorm.cc
@@ -125,7 +125,7 @@ void genorm(
                 #pragma omp teams distribute
                 for (int64_t k = 0; k < batch_count; ++k) {
                     // distribute cols to threads (j)
-                    #pragma omp parallel for simd schedule(static, 1)
+                    #pragma omp parallel for schedule(static, 1)
                     for (int64_t j = 0; j < n; ++j) {
                         values[k*ldv + j] = 0;
                         for (int64_t i = 0; i < m; ++i) {
@@ -148,7 +148,7 @@ void genorm(
                 #pragma omp teams distribute
                 for (int64_t k = 0; k < batch_count; ++k) {
                     // distribute rows to threads (i)
-                    #pragma omp parallel for simd schedule(static, 1)
+                    #pragma omp parallel for schedule(static, 1)
                     for (int64_t i = 0; i < m; ++i) {
                         values[k*ldv + i] = 0;
                         for (int64_t j = 0; j < n; ++j) {
@@ -219,7 +219,7 @@ void genorm(
                 for (int64_t k = 0; k < batch_count; ++k) {
                     const scalar_t* tileA = Aarray[k];
                     // distribute cols to threads (j)
-                    #pragma omp parallel for simd collapse(1) schedule(static, 1)
+                    #pragma omp parallel for collapse(1) schedule(static, 1)
                     for (int64_t j = 0; j < n; ++j) {
                         const scalar_t* colA = &tileA[j*lda];
                         for (int64_t i = 0; i < m; ++i) {
@@ -272,5 +272,5 @@ void genorm(
     double* values, int64_t ldv, int64_t batch_count,
     blas::Queue &queue);
 
-} // Namespace device
+} // namespace device
 } // namespace slate

--- a/src/omptarget/device_gescale.cc
+++ b/src/omptarget/device_gescale.cc
@@ -1,0 +1,223 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Kernel implementing element-wise tile scale.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] numer
+///     Scale value numerator.
+///
+/// @param[in] denom
+///     Scale value denominator.
+///
+/// @param[in,out] A
+///     An m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale(
+    int64_t m, int64_t n,
+    scalar_t2 numer, scalar_t2 denom,
+    scalar_t* A, int64_t lda,
+    blas::Queue& queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+
+    scalar_t2 mul = numer / denom;
+
+    // Use omp target offload
+    #pragma omp target is_device_ptr(A) device(queue.device())
+    #pragma omp teams distribute parallel for schedule(static, 1)
+    for (int64_t i = 0; i < m; ++i) {
+        scalar_t* rowA = &A[ i ];
+        for (int64_t j = 0; j < n; ++j)
+            rowA[ j*lda ] = rowA[ j*lda ] * mul;
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    float* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer, double denom,
+    double* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<float> numer, std::complex<float> denom,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer,  double denom,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<double> numer, std::complex<double> denom,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue);
+
+
+//==============================================================================
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise tile scale. Sets
+/// \[
+///     Aarray[k] *= (numer / denom).
+/// \]
+/// This does NOT currently take extra care to avoid over/underflow.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] numer
+///     Scale value numerator.
+///
+/// @param[in] denom
+///     Scale value denominator.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale(
+    int64_t m, int64_t n,
+    scalar_t2 numer, scalar_t2 denom,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    scalar_t2 mul = numer / denom;
+
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* A = Aarray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &A[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * mul;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer, double denom,
+    double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<float> numer, std::complex<float> denom,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer,  double denom,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<double> numer, std::complex<double> denom,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+} // namespace batch
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_gescale.cc
+++ b/src/omptarget/device_gescale.cc
@@ -53,6 +53,7 @@ void gescale(
 
     scalar_t2 mul = numer / denom;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(A) device(queue.device())
     #pragma omp teams distribute parallel for schedule(static, 1)
@@ -159,6 +160,7 @@ void gescale(
 
     scalar_t2 mul = numer / denom;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(Aarray) device(queue.device())
     #pragma omp teams distribute

--- a/src/omptarget/device_gescale_row_col.cc
+++ b/src/omptarget/device_gescale_row_col.cc
@@ -1,0 +1,282 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Kernel implementing row and column scaling.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale_row_col().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] Rarray
+///     Vector of length m containing row scaling factors.
+///
+/// @param[in] Carray
+///     Vector of length n containing column scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array of tiles of dimension gridDim.x,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_row_col_batch_kernel(
+    int64_t m, int64_t n,
+    scalar_t2 const* const* Rarray,
+    scalar_t2 const* const* Carray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    #pragma omp target is_device_ptr(Rarray, Carray, Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t2 const* R = Rarray[ k ];
+        scalar_t2 const* C = Carray[ k ];
+        scalar_t* tileA    = Aarray[ k ];
+        #pragma omp parallel for schedule(static, 1)
+        // thread per row
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            scalar_t2 ri = R[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * (ri * C[ j ]);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Kernel implementing column scaling.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale_row_col().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] Carray
+///     Vector of length n containing column scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array of tiles of dimension gridDim.x,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_col_batch_kernel(
+    int64_t m, int64_t n,
+    scalar_t2 const* const* Carray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    #pragma omp target is_device_ptr(Carray, Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t2 const* C = Carray[ k ];
+        scalar_t* tileA    = Aarray[ k ];
+        #pragma omp parallel for schedule(static, 1)
+        // thread per row
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * C[ j ];
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Kernel implementing row scaling.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale_row_col().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] Rarray
+///     Vector of length m containing row scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array of tiles of dimension gridDim.x,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_row_batch_kernel(
+    int64_t m, int64_t n,
+    scalar_t2 const* const* Rarray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    #pragma omp target is_device_ptr(Rarray, Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t2 const* R = Rarray[ k ];
+        scalar_t* tileA    = Aarray[ k ];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            scalar_t2 ri = R[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * ri;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Batched routine for row and column scaling.
+///
+/// @param[in] equed
+///     Form of scaling to do.
+///     - Equed::Row:  sets $ A = diag(R) A         $
+///     - Equed::Col:  sets $ A =         A diag(C) $
+///     - Equed::Both: sets $ A = diag(R) A diag(C) $
+///     for each R in Rarray, C in Carray, and A in Aarray.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Rarray
+///     Vector of length m containing row scaling factors.
+///
+/// @param[in] Carray
+///     Vector of length n containing column scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    scalar_t2 const* const* Rarray,
+    scalar_t2 const* const* Carray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    // Use omp target offload
+    if (equed == Equed::Row) {
+        gescale_row_batch_kernel(
+            m, n, Rarray, Aarray, lda, batch_count, queue );
+    }
+    else if (equed == Equed::Col) {
+        gescale_col_batch_kernel(
+            m, n, Carray, Aarray, lda, batch_count, queue );
+    }
+    else if (equed == Equed::Both) {
+        gescale_row_col_batch_kernel(
+            m, n, Rarray, Carray, Aarray, lda, batch_count, queue );
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    float const* const* Rarray,
+    float const* const* Carray,
+    float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    double const* const* Rarray,
+    double const* const* Carray,
+    double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+// real R, C
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    float const* const* Rarray,
+    float const* const* Carray,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    double const* const* Rarray,
+    double const* const* Carray,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+// complex R, C
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    std::complex<float> const* const* Rarray,
+    std::complex<float> const* const* Carray,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    std::complex<double> const* const* Rarray,
+    std::complex<double> const* const* Carray,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_gescale_row_col.cc
+++ b/src/omptarget/device_gescale_row_col.cc
@@ -46,6 +46,7 @@ void gescale_row_col_batch_kernel(
     scalar_t** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue)
 {
+    queue.sync(); // sync queue before switching to openmp device execution
     #pragma omp target is_device_ptr(Rarray, Carray, Aarray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {
@@ -98,6 +99,7 @@ void gescale_col_batch_kernel(
     scalar_t** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue)
 {
+    queue.sync(); // sync queue before switching to openmp device execution
     #pragma omp target is_device_ptr(Carray, Aarray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {
@@ -148,6 +150,7 @@ void gescale_row_batch_kernel(
     scalar_t** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue)
 {
+    queue.sync(); // sync queue before switching to openmp device execution
     #pragma omp target is_device_ptr(Rarray, Aarray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {

--- a/src/omptarget/device_geset.cc
+++ b/src/omptarget/device_geset.cc
@@ -38,7 +38,7 @@ namespace device {
 template <typename scalar_t>
 void geset(
     int64_t m, int64_t n,
-    scalar_t offdiag_value, scalar_t diag_value,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
     scalar_t* A, int64_t lda,
     blas::Queue &queue)
 {
@@ -63,28 +63,28 @@ void geset(
 template
 void geset(
     int64_t m, int64_t n,
-    float offdiag_value, float diag_value,
+    float const& offdiag_value, float const& diag_value,
     float* A, int64_t lda,
     blas::Queue &queue);
 
 template
 void geset(
     int64_t m, int64_t n,
-    double offdiag_value, double diag_value,
+    double const& offdiag_value, double const& diag_value,
     double* A, int64_t lda,
     blas::Queue &queue);
 
 template
 void geset(
     int64_t m, int64_t n,
-    std::complex<float> offdiag_value, std::complex<float> diag_value,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
     std::complex<float>* A, int64_t lda,
     blas::Queue &queue);
 
 template
 void geset(
     int64_t m, int64_t n,
-    std::complex<double> offdiag_value, std::complex<double> diag_value,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
     std::complex<double>* A, int64_t lda,
     blas::Queue &queue);
 
@@ -123,7 +123,7 @@ namespace batch {
 template <typename scalar_t>
 void geset(
     int64_t m, int64_t n,
-    scalar_t offdiag_value, scalar_t diag_value,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
     scalar_t** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue &queue)
 {
@@ -156,28 +156,28 @@ void geset(
 template
 void geset(
     int64_t m, int64_t n,
-    float offdiag_value, float diag_value,
+    float const& offdiag_value, float const& diag_value,
     float** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void geset(
     int64_t m, int64_t n,
-    double offdiag_value, double diag_value,
+    double const& offdiag_value, double const& diag_value,
     double** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void geset(
     int64_t m, int64_t n,
-    std::complex<float> offdiag_value, std::complex<float> diag_value,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
     std::complex<float>** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void geset(
     int64_t m, int64_t n,
-    std::complex<double> offdiag_value, std::complex<double> diag_value,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
     std::complex<double>** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue &queue);
 

--- a/src/omptarget/device_geset.cc
+++ b/src/omptarget/device_geset.cc
@@ -46,6 +46,7 @@ void geset(
     if (m == 0 || n == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(A) device(queue.device())
     #pragma omp teams distribute parallel for schedule(static, 1)
@@ -133,6 +134,7 @@ void geset(
     if (m == 0 || n == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(Aarray) device(queue.device())
     #pragma omp teams distribute

--- a/src/omptarget/device_geset.cc
+++ b/src/omptarget/device_geset.cc
@@ -137,12 +137,13 @@ void geset(
     #pragma omp target is_device_ptr(Aarray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {
-        #pragma omp parallel for collapse(2)
+        scalar_t* tileA = Aarray[k];
+        // distribute i to threads
+        #pragma omp parallel for schedule(static, 1)
         for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[i];
             for (int64_t j = 0; j < n; ++j) {
-                scalar_t* tileA = Aarray[k];
-                scalar_t* rowA = &tileA[i];
-                rowA[j*lda] = (j != i) ? offdiag_value : diag_value;
+                rowA[j*lda] = (j == i ? diag_value : offdiag_value);
             }
         }
     }

--- a/src/omptarget/device_geset.cc
+++ b/src/omptarget/device_geset.cc
@@ -1,0 +1,95 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise tile set.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] diag_value
+///     The value to set on the diagonal.
+///
+/// @param[in] offdiag_value
+///     The value to set outside of the diagonal.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void geset(
+    int64_t m, int64_t n,
+    scalar_t diag_value, scalar_t offdiag_value, scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        #pragma omp parallel for simd collapse(2)
+        for (int64_t i = 0; i < m; ++i) {
+            for (int64_t j = 0; j < n; ++j) {
+                scalar_t* tileA = Aarray[k];
+                scalar_t* rowA = &tileA[i];
+                rowA[j*lda] = (j != i) ? offdiag_value : diag_value;
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geset(
+    int64_t m, int64_t n,
+    float diag_value, float offdiag_value, float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    double diag_value, double offdiag_value, double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    std::complex<float> diag_value, std::complex<float> offdiag_value,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    std::complex<double> diag_value, std::complex<double> offdiag_value,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_henorm.cc
+++ b/src/omptarget/device_henorm.cc
@@ -86,6 +86,7 @@ void henorm(
         else {
             assert(ldv == 1);
             blas::device_memset(values, 0, batch_count, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
             // Use omp target offload
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute
@@ -119,6 +120,7 @@ void henorm(
         }
         else {
             assert(ldv >= n);
+            queue.sync(); // sync queue before switching to openmp device execution
             // use omp target offload
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute
@@ -160,6 +162,7 @@ void henorm(
         }
         else {
             assert(ldv == 2);
+            queue.sync(); // sync queue before switching to openmp device execution
             // use omp target offload
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute

--- a/src/omptarget/device_henorm.cc
+++ b/src/omptarget/device_henorm.cc
@@ -100,7 +100,8 @@ void henorm(
                     if (uplo == lapack::Uplo::Lower) {
                         for (int64_t j = 0; j < i && j < n; ++j)
                             max = max_nan(max, abs_val(rowA[j*lda]));
-                    } else {
+                    }
+                    else {
                         // Loop backwards (n-1 down to i)
                         for (int64_t j = n-1; j > i; --j)
                             max = max_nan(max, abs_val(rowA[j*lda]));
@@ -124,7 +125,7 @@ void henorm(
             for (int64_t k = 0; k < batch_count; ++k) {
                 const scalar_t* tileA = Aarray[k];
                 // distribute rows to threads (i)
-                #pragma omp parallel for simd schedule(static, 1)
+                #pragma omp parallel for schedule(static, 1)
                 for (int64_t idx = 0; idx < n; ++idx) {
                     // get pointer to row_i and corresponding column col_i
                     scalar_t const* row = &tileA[idx];

--- a/src/omptarget/device_henorm.cc
+++ b/src/omptarget/device_henorm.cc
@@ -1,0 +1,248 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., n-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an n-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: for symmetric, same as Norm::One
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+    ////int64_t nb = 512;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    //---------
+    // max norm
+    if (norm == lapack::Norm::Max) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count, queue);
+        }
+        else {
+            assert(ldv == 1);
+            blas::device_memset(values, 0, batch_count, queue);
+            // Use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads
+                // note: the max_nan_reduction preserves nans
+                #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    const scalar_t* rowA = &tileA[i];
+                    real_t max = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < i && j < n; ++j)
+                            max = max_nan(max, abs_val(rowA[j*lda]));
+                    } else {
+                        // Loop backwards (n-1 down to i)
+                        for (int64_t j = n-1; j > i; --j)
+                            max = max_nan(max, abs_val(rowA[j*lda]));
+                    }
+                    values[k] = max_nan(values[0], max);
+                }
+            }
+        }
+    }
+    //---------
+    // one norm or inf norm (same values)
+    else if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * n, queue);
+        }
+        else {
+            assert(ldv >= n);
+            // use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows to threads (i)
+                #pragma omp parallel for simd schedule(static, 1)
+                for (int64_t idx = 0; idx < n; ++idx) {
+                    // get pointer to row_i and corresponding column col_i
+                    scalar_t const* row = &tileA[idx];
+                    scalar_t const* column = &tileA[lda*idx];
+                    real_t sum = 0;
+                    // accumulate down row_idx and the symmetric col_idx
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < idx; ++j) // strictly lower
+                            sum += abs_val(row[j*lda]);
+                        sum += abs_val( std::real( row[idx*lda] )); // diag (real)
+                        for (int64_t i = idx + 1; i < n; ++i) // strictly lower
+                            sum += abs_val(column[i]);
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        for (int64_t j = n-1; j > idx; --j) // strictly upper
+                            sum += abs_val(row[j*lda]);
+                        sum += abs_val( std::real( row[idx*lda] )); // diag (real)
+                        for (int64_t i = 0; i < idx && i < n; ++i) // strictly upper
+                            sum += abs_val(column[i]);
+                    }
+                    values[k*ldv + idx] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // Frobenius norm
+    else if (norm == lapack::Norm::Fro) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * 2, queue);
+        }
+        else {
+            assert(ldv == 2);
+            // use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                values[k*2 + 0] = 0; // scale_k
+                values[k*2 + 1] = 1; // sumsq_k
+                // distribute rows to threads (i)
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    scalar_t const* rowI = &tileA[i];
+                    real_t scale_ki = 0;
+                    real_t sumsq_ki = 1;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < i; ++j)
+                            add_sumsq(scale_ki, sumsq_ki, abs_val( rowI[j*lda] ));
+                        sumsq_ki *= 2; // double sumsq for symmetric entries
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val( std::real( rowI[i*lda] )));
+                    }
+                    else {      // uplo == Upper
+                        // Loop backwards (n-1 down to i) to maintain coalesced reads.
+                        for (int64_t j = n-1; j > i; --j) // strictly upper
+                            add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[j*lda]));
+                        sumsq_ki *= 2; // double for symmetric entries
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val( std::real( rowI[i*lda] )));
+                    }
+                    // accumulate the scale and sumsq for each k
+                    #pragma omp critical
+                    {
+                        real_t scale_k = values[k*2 + 0];
+                        real_t sumsq_k = values[k*2 + 1];
+                        if (scale_k > scale_ki) {
+                            sumsq_k = sumsq_k + sumsq_ki*(scale_ki / scale_k)*(scale_ki / scale_k);
+                            // scale_k stays same
+                        }
+                        else if (scale_ki != 0) {
+                            sumsq_k = sumsq_k*(scale_k / scale_ki)*(scale_k / scale_ki) + sumsq_ki;
+                            scale_k = scale_ki;
+                        }
+                        values[k*2 + 0] = scale_k;
+                        values[k*2 + 1] = sumsq_k;
+
+                    }
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_henorm.cc
+++ b/src/omptarget/device_henorm.cc
@@ -99,13 +99,17 @@ void henorm(
                     const scalar_t* rowA = &tileA[i];
                     real_t max = 0;
                     if (uplo == lapack::Uplo::Lower) {
-                        for (int64_t j = 0; j < i && j < n; ++j)
+                        for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
                             max = max_nan(max, abs_val(rowA[j*lda]));
+                        int64_t j = i;
+                        max = max_nan(max, abs_val( std::real( rowA[j*lda] ))); // diag (real)
                     }
                     else {
                         // Loop backwards (n-1 down to i)
-                        for (int64_t j = n-1; j > i; --j)
+                        for (int64_t j = n-1; j > i; --j) // strictly upper
                             max = max_nan(max, abs_val(rowA[j*lda]));
+                        int64_t j = i;
+                        max = max_nan(max, abs_val( std::real( rowA[j*lda] ))); // diag (real)
                     }
                     values[k] = max_nan(values[0], max);
                 }

--- a/src/omptarget/device_synorm.cc
+++ b/src/omptarget/device_synorm.cc
@@ -122,7 +122,7 @@ void synorm(
             for (int64_t k = 0; k < batch_count; ++k) {
                 const scalar_t* tileA = Aarray[k];
                 // distribute rows to threads (i)
-                #pragma omp parallel for simd schedule(static, 1)
+                #pragma omp parallel for schedule(static, 1)
                 for (int64_t idx = 0; idx < n; ++idx) {
                     // get pointer to row_i and corresponding column col_i
                     scalar_t const* row = &tileA[idx];

--- a/src/omptarget/device_synorm.cc
+++ b/src/omptarget/device_synorm.cc
@@ -1,0 +1,379 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., n-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an n-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: for symmetric, same as Norm::One
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    //---------
+    // max norm
+    if (norm == lapack::Norm::Max) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count, queue);
+        }
+        else {
+            assert(ldv == 1);
+            blas::device_memset(values, 0, batch_count, queue);
+            // Use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads
+                // note: the max_nan_reduction preserves nans
+                #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    const scalar_t* row = &tileA[i];
+                    real_t max = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j <= i; ++j) // lower
+                            max = max_nan(max, abs_val(row[j*lda]));
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        for (int64_t j = n-1; j >= i; --j) // upper
+                            max = max_nan(max, abs_val(row[j*lda]));
+                    }
+                    values[k] = max_nan(values[k], max);
+                }
+            }
+        }
+    }
+    //---------
+    // one norm
+    else if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * n, queue);
+        }
+        else {
+            assert(ldv >= n);
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            // distribute tiles to teams
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows to threads (i)
+                #pragma omp parallel for simd schedule(static, 1)
+                for (int64_t idx = 0; idx < n; ++idx) {
+                    // get pointer to row_i and corresponding column col_i
+                    scalar_t const* row = &tileA[idx];
+                    scalar_t const* column = &tileA[lda*idx];
+                    real_t sum = 0;
+                    // accumulate down row_i and the symmetric col_i
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j <= idx; ++j) // lower
+                            sum += abs_val(row[j*lda]);
+                        for (int64_t i = idx + 1; i < n; ++i) // strictly lower
+                            sum += abs_val(column[i]);
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i) to maintain coalesced reads.
+                        for (int64_t j = n-1; j >= idx; --j) // upper
+                            sum += abs_val(row[j*lda]);
+                        for (int64_t i = 0; i < idx && i < n; ++i) // strictly upper
+                            sum += abs_val(column[i]);
+                    }
+                    values[k*ldv + idx] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // Frobenius norm
+    else if (norm == lapack::Norm::Fro) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * 2, queue);
+        }
+        else {
+            assert(ldv == 2);
+            // use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                values[k*2 + 0] = 0; // scale_k
+                values[k*2 + 1] = 1; // sumsq_k
+                // distribute rows to threads (i)
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    scalar_t const* rowI = &tileA[i];
+                    real_t scale_ki = 0;
+                    real_t sumsq_ki = 1;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < i; ++j) // strictly lower
+                            add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[j*lda]));
+                        // double sumsq for symmetric entries
+                        sumsq_ki *= 2;
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[i*lda]));
+                    }
+                    else {      // uplo == Upper
+                        // Loop backwards (n-1 down to i) to maintain coalesced reads.
+                        for (int64_t j = n-1; j > i; --j) // strictly upper
+                            add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[j*lda]));
+                        // double for symmetric entries
+                        sumsq_ki *= 2;
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[i*lda]));
+                    }
+                    // accumulate the scale and sumsq for each k
+                    // todo: try to speed this up
+                    #pragma omp critical
+                    {
+                        real_t scale_k = values[k*2 + 0];
+                        real_t sumsq_k = values[k*2 + 1];
+                        if (scale_k > scale_ki) {
+                            sumsq_k = sumsq_k + sumsq_ki * sqr(scale_ki / scale_k);
+                            // scale_k stays same
+                        }
+                        else if (scale_ki != 0) {
+                            sumsq_k = sumsq_k * sqr(scale_k / scale_ki) + sumsq_ki;
+                            scale_k = scale_ki;
+                        }
+                        values[k*2 + 0] = scale_k;
+                        values[k*2 + 1] = sumsq_k;
+
+                    }
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., n-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an n-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: for symmetric, same as Norm::One
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     GPU device to execute in.
+///
+template <typename scalar_t>
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+    //---------
+    // one norm and inf norm
+    if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
+        assert(ldv >= n+m);
+        // use openmp offload
+        #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+        #pragma omp teams distribute
+        for (int64_t k = 0; k < batch_count; ++k) {
+            const scalar_t* tileA = Aarray[k];
+            // distribute col to threads (j)
+            #pragma omp parallel for schedule(static, 1)
+            for (int64_t j = 0; j < n; ++j) {
+                real_t colsum = 0;
+                // accumulate down col
+                for (int64_t i = 0; i < m; ++i)
+                    colsum += abs_val(tileA[i + j*lda]);
+                values[k*ldv + j] = colsum;
+            }
+            // distribute rows to threads (i)
+            #pragma omp parallel for schedule(static, 1)
+            for (int64_t i = 0; i < m; ++i) {
+                real_t rowsum = 0;
+                for (int64_t j = 0; j < n; ++j)
+                    rowsum += abs_val(tileA[i + j*lda]);
+                values[k*ldv + i + n] = rowsum;
+            }
+        }
+    }
+    else {
+        slate_not_implemented("Only Norm::One and Norm::Inf is supported.");
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+//----------------------------------------
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_transpose.cc
+++ b/src/omptarget/device_transpose.cc
@@ -24,6 +24,7 @@ void transpose_sqr_batch_func(
     int n, scalar_t** Aarray, int64_t lda, int batch_count, blas::Queue& queue)
 {
     static const int ib = 16;
+    queue.sync(); // sync queue before switching to openmp device execution
     // i, j are row & column indices of top-left corner of each local block.
     #pragma omp target is_device_ptr(Aarray) device(queue.device())
     // Distribute the blocks to omp teams
@@ -92,6 +93,7 @@ void transpose_sqr_func(
     // printf("%s:%d sqr queue.device() %d\n", __FILE__, __LINE__, queue.device());
 
     static const int ib = 16;
+    queue.sync(); // sync queue before switching to openmp device execution
     // i, j are row & column indices of top-left corner of each local block.
     #pragma omp target is_device_ptr(A) device(queue.device())
     // Distribute the blocks to omp teams
@@ -158,6 +160,7 @@ void transpose_rect_batch_func(
     int batch_count, blas::Queue& queue)
 {
     static const int NB = 32;
+    queue.sync(); // sync queue before switching to openmp device execution
     // i, j are row & column indices of top-left corner of each local block.
     #pragma omp target is_device_ptr(dAarray, dATarray) device(queue.device())
     #pragma omp teams distribute collapse(2)
@@ -205,6 +208,7 @@ void transpose_rect_func(
     blas::Queue& queue)
 {
     static const int NB = 32;
+    queue.sync(); // sync queue before switching to openmp device execution
     // i, j are row & column indices of top-left corner of each local block.
     #pragma omp target is_device_ptr(dA, dAT) device(queue.device())
     #pragma omp teams distribute collapse(2)

--- a/src/omptarget/device_transpose.cc
+++ b/src/omptarget/device_transpose.cc
@@ -1,0 +1,472 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Device routine handles batches of square matrices.
+///
+/// The routine loads blocks of data into small ib x ib local storage
+/// and then writes the blocks back transposed into the correct
+/// location transposed.
+///
+template <typename scalar_t>
+void transpose_sqr_batch_func(
+    int n, scalar_t** Aarray, int64_t lda, int batch_count, blas::Queue& queue)
+{
+    static const int ib = 16;
+    // i, j are row & column indices of top-left corner of each local block.
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    // Distribute the blocks to omp teams
+    #pragma omp teams distribute collapse(2)
+    for(int k=0; k<batch_count; ++k) {
+        for(int i=0; i<n; i+=ib) {
+            for(int j=0; j<=i; j+=ib) {
+                scalar_t *A = Aarray[k];
+                // allocate local blocks for storage
+                // +1 to avoid memory bank conflicts.
+                scalar_t sA1[ ib ][ ib+1 ], sA2[ ib ][ ib+1 ];
+                // todo: make sA1, sA2 team-local, shared by threads (OpenMP > 5)
+                // #pragma omp private(sA1, sA2)
+                // #pragma omp allocate (sA1,sA2) allocator(omp_pteam_mem_alloc)
+                // ii, jj are row & column offsets within each block.
+                int max_ii = i+ib < n ? std::min(ib,n) : n-i;
+                int max_jj = j+ib < n ? std::min(ib,n) : n-j;
+                if (i==j) { // diagonal blocks
+                    // Load ibxib block from A(i,j) into sA1
+                    #pragma omp parallel for simd collapse(2)
+                    for(int ii=0; ii<max_ii; ++ii)
+                        for(int jj=0; jj<max_jj; ++jj)
+                            sA1[jj][ii] = A[i+ii + (j+jj)*lda];
+                    // Save transposed block, A(i, j) = trans(sA1).
+                    #pragma omp parallel for simd collapse(2)
+                    for(int ii=0; ii<max_ii; ++ii)
+                        for(int jj=0; jj<max_jj; ++jj)
+                            A[i+ii + (j+jj)*lda] = sA1[ii][jj];
+                }
+                else { // off-diagonal block
+                    // Load blocks A(i, j) and A(j, i) into shared memory sA1 and sA2.
+                    #pragma omp parallel for simd collapse(2)
+                    for(int ii=0; ii<max_ii; ++ii)
+                        for(int jj=0; jj<max_jj; ++jj)
+                            sA1[ii][jj] = A[i+ii + (j+jj)*lda]; // sA1(i,j)=A(i,j)
+                    #pragma omp parallel for simd collapse(2)
+                    for(int ii=0; ii<max_ii; ii+=1)
+                        for(int jj=0; jj<max_jj; jj+=1)
+                            sA2[jj][ii] = A[j+jj + (i+ii)*lda]; // sA2(j,i)=A(j,i)
+                    // Save transposed blocks, A(i, j) = trans(sA2), A(j, i) = trans(sA1).
+                    #pragma omp parallel for simd collapse(2)
+                    for(int ii=0; ii<max_ii; ii+=1)
+                        for(int jj=0; jj<max_jj; jj+=1)
+                            A[i+ii + (j+jj)*lda] = sA2[jj][ii]; // A(i,j)=trans(sA2)=sA2(i,j)
+                    #pragma omp parallel for simd collapse(2)
+                    for(int ii=0; ii<max_ii; ii+=1)
+                        for(int jj=0; jj<max_jj; jj+=1)
+                            A[j+jj + (i+ii)*lda] = sA1[ii][jj]; // A(j,i)=trans(sA1)=sA1(j,i)
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Device routine handles batches of rectangular matrices.
+///
+/// The routine loads blocks of data into small NX x NB local storage
+/// and then writes the blocks back transposed into the correct
+/// location transposed.
+///
+static const int NB = 32;
+template <typename scalar_t, int NX>
+void transpose_rect_batch_func(
+    int m, int n,
+    scalar_t** dAarray, int64_t lda,
+    scalar_t** dATarray, int64_t ldat,
+    int batch_count, blas::Queue& queue)
+{
+    // i, j are row & column indices of top-left corner of each local block.
+    #pragma omp target is_device_ptr(dAarray, dATarray) device(queue.device())
+    #pragma omp teams distribute collapse(3)
+    for(int k=0; k<batch_count; ++k) {
+        for(int i=0; i<m; i+=NX) {
+            for(int j=0; j<n; j+=NB) {
+                scalar_t *dA = dAarray[k];
+                scalar_t *dAT = dATarray[k];
+                // todo: make sA team-local, shared by threads
+                // #pragma omp private(sA)
+                // todo: allocators supported after OpenMP 5.0
+                // #if (_OPENMP > 201810)
+                // #pragma omp allocate (sA) allocator(omp_pteam_mem_alloc)
+                // #endif
+                scalar_t sA[ NX ][ NB+1 ];
+                int max_NX = i+NX < m ? std::min(NX,m) : m-i;
+                int max_NB = j+NB < n ? std::min(NB,n) : n-j;
+                // Load NXxNB block from A(i,j) so that sA(i,j) = dA(i,j)
+                #pragma omp parallel for simd collapse(2)
+                for(int ii=0; ii<max_NX; ++ii)
+                    for(int jj=0; jj<max_NB; ++jj)
+                        sA[ii][jj] = dA[i+ii + (j+jj)*lda];
+                // Save transposed block, dAT(j, i) = sA(i,j).
+                #pragma omp parallel for simd collapse(2)
+                for(int ii=0; ii<max_NX; ++ii)
+                    for(int jj=0; jj<max_NB; ++jj)
+                        dAT[j+jj + (i+ii)*ldat] = sA[ii][jj];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a square matrix in place.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in,out] A
+///     A square n-by-n matrix stored in an lda-by-n array in GPU memory.
+///     On output, A is transposed.
+///
+/// @param[in] lda
+///     Leading dimension of A. lda >= n.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void transpose(
+    int64_t n,
+    scalar_t* A, int64_t lda,
+    blas::Queue& queue)
+{
+    if (n <= 1)
+        return;
+    assert(lda >= n);
+
+    transpose_sqr_batch_func(n, &A, lda, 1, queue);
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a batch of square matrices in place.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to
+///     matrices, where each Aarray[k] is a square n-by-n matrix stored in an
+///     lda-by-n array in GPU memory.
+///     On output, each Aarray[k] is transposed.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void transpose_batch(
+    int64_t n,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    if (batch_count < 0 || n <= 1)
+        return;
+    assert(lda >= n);
+
+    transpose_sqr_batch_func(n, Aarray, lda, batch_count, queue);
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a rectangular matrix out-of-place.
+///
+/// @param[in] m
+///     Number of columns of tile. m >= 0.
+///
+/// @param[in] n
+///     Number of rows of tile. n >= 0.
+///
+/// @param[in] dA
+///     A rectangular m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of dA. lda >= m.
+///
+/// @param[out] dAT
+///     A rectangular m-by-n matrix stored in an ldat-by-m array in GPU memory.
+///     On output, dAT is the transpose of dA.
+///
+/// @param[in] ldat
+///     Leading dimension of dAT. ldat >= n.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, int NX>
+void transpose(
+    int64_t m, int64_t n,
+    scalar_t* dA,  int64_t lda,
+    scalar_t* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    if ((m <= 0) || (n <= 0))
+        return;
+    assert(lda >= m);
+    assert(ldat >= n);
+
+    transpose_rect_batch_func<scalar_t, NX>( m, n, &dA, lda, &dAT, ldat, 1, queue );
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a batch of rectangular matrices out-of-place.
+///
+/// @param[in] m
+///     Number of columns of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of rows of each tile. n >= 0.
+///
+/// @param[in] dA_array
+///     Array in GPU memory of dimension batch_count, containing pointers to
+///     matrices, where each dA_array[k] is a rectangular m-by-n matrix stored in an
+///     lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each dA_array[k] tile. lda >= m.
+///
+/// @param[out] dAT_array
+///     Array in GPU memory of dimension batch_count, containing pointers to
+///     matrices, where each dAT_array[k] is a rectangular m-by-n matrix
+///     stored in an ldat-by-m array in GPU memory.
+///     On output, each dAT_array[k] is the transpose of dA_array[k].
+///
+/// @param[in] lda
+///     Leading dimension of each dAT_array[k] tile. ldat >= n.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, int NX>
+void transpose_batch(
+    int64_t m, int64_t n,
+    scalar_t **dA_array,  int64_t lda,
+    scalar_t **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    if ((m <= 0) || (n <= 0))
+        return;
+    assert(lda >= m);
+    assert(ldat >= n);
+
+    transpose_rect_batch_func<scalar_t, NX>( m, n, dA_array, lda, dAT_array, ldat, batch_count, queue );
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+// Square matrix
+
+template
+void transpose(
+    int64_t n,
+    float* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void transpose(
+    int64_t n,
+    double* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void transpose(
+    int64_t n,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void transpose(
+    int64_t n,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue);
+
+// ----------------------------------------
+// Explicit instantiations.
+// Batch of square matrices
+
+template
+void transpose_batch(
+    int64_t n,
+    float** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+template
+void transpose_batch(
+    int64_t n,
+    double** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+template
+void transpose_batch(
+    int64_t n,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+template
+void transpose_batch(
+    int64_t n,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+
+// ----------------------------------------
+// Explicit instantiations.
+// Rectangular matrix
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    float* dA,  int64_t lda,
+    float* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<float,32>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    double* dA,  int64_t lda,
+    double* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<double,32>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    std::complex<float>* dA,  int64_t lda,
+    std::complex<float>* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<std::complex<float>,32>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    std::complex<double>* dA,  int64_t lda,
+    std::complex<double>* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<std::complex<double>,16>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+// ----------------------------------------
+// Explicit instantiations.
+// Batch of rectangular matrices
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    float **dA_array,  int64_t lda,
+    float **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<float,32>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    double **dA_array,  int64_t lda,
+    double **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<double,32>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    std::complex<float> **dA_array,  int64_t lda,
+    std::complex<float> **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<std::complex<float>,32>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    std::complex<double> **dA_array,  int64_t lda,
+    std::complex<double> **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<std::complex<double>,16>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_trnorm.cc
+++ b/src/omptarget/device_trnorm.cc
@@ -1,0 +1,331 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., m-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= m.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: ldv >= m.
+///         On exit, values[k*ldv + i] = sum_{j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= i < m.
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    //---------
+    // max norm
+    if (norm == lapack::Norm::Max) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count, queue);
+        }
+        else {
+            assert(ldv == 1);
+            // use omp offload
+            blas::device_memset(values, 0, batch_count, queue);
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads, each thread computes 1 column max
+                // nan-preserving max reduction operation
+                #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                for (int64_t i = 0; i < m; ++i) {
+                    const scalar_t* row = &tileA[i];
+                    real_t max = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // unit diag
+                                max = 1;
+                            for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                        else { // non-unit
+                            for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                    }
+                    else { // Upper
+                        // Loop backwards (n-1 down to i)
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                max = 1;
+                            for (int64_t j = n-1; j > i; --j) // strictly upper
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                        else { // non-unit
+                            for (int64_t j = n-1; j >= i; --j) // upper
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                    }
+                    values[k] = max_nan(values[k], max);
+                }
+            }
+        }
+    }
+    //---------
+    // one norm
+    else if (norm == lapack::Norm::One) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count * n, queue);
+        }
+        else {
+            assert(ldv >= n);
+            blas::device_memset(values, 0, batch_count * n, queue);
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute cols (j) to threads
+                // each thread computes one column sum
+                #pragma omp parallel for simd schedule(static, 1)
+                for (int64_t j = 0; j < n; ++j) {
+                    const scalar_t* column = &tileA[lda*j];
+                    real_t sum = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (j < m) // diag
+                                sum += 1;
+                            for (int64_t i = j+1; i < m; ++i) // strictly lower
+                                sum += abs_val(column[i]);
+                        }
+                        else { // diag == non-unit
+                            for (int64_t i = j; i < m; ++i) // lower
+                                sum += abs_val(column[i]);
+                        }
+                    }
+                    else { // uplo = upper
+                        if (diag == lapack::Diag::Unit) {
+                            if (j < m) // diag
+                                sum += 1;
+                            for (int64_t i = 0; i < j && i < m; ++i) // strictly upper
+                                sum += abs_val(column[i]);
+                        }
+                        else {
+                            for (int64_t i = 0; i <= j && i < m; ++i) // upper
+                                sum += abs_val(column[i]);
+                        }
+                    }
+                    values[k*ldv + j] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // inf norm
+    else if (norm == lapack::Norm::Inf) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count * m, queue);
+        }
+        else {
+            assert(ldv >= m);
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute i to threads, each thread sums one row
+                #pragma omp parallel for simd schedule(static, 1)
+                for (int64_t i = 0; i < m; ++i) {
+                    scalar_t const* row = &tileA[i];
+                    real_t sum = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                sum += 1;
+                            for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                                sum += abs_val(row[j*lda]);
+                        }
+                        else {
+                            for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                                sum += abs_val(row[j*lda]);
+                        }
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                sum += 1;
+                            for (int64_t j = n-1; j > i; --j) // strictly upper
+                                sum += abs_val(row[j*lda]);
+                        }
+                        else {
+                            for (int64_t j = n-1; j >= i; --j) // upper
+                                sum += abs_val(row[j*lda]);
+                        }
+                    }
+                    values[k*ldv + i] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // Frobenius norm
+    else if (norm == lapack::Norm::Fro) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count * 2, queue);
+        }
+        else {
+            assert(ldv == 2);
+            blas::device_memset(values, 0, batch_count * 2, queue);
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            // distribute each batch array to a team
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < m; ++i) {
+                    const scalar_t* row = &tileA[i];
+                    real_t scale = 0;
+                    real_t sumsq = 1;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                add_sumsq(scale, sumsq, real_t(1));
+                            for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                        else { // diag == non-unit
+                            for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                    }
+                    else { // uplo == upper
+                        // Loop backwards (n-1 down to i)
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                add_sumsq(scale, sumsq, real_t(1));
+                            for (int64_t j = n-1; j > i; --j) // strictly upper
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                        else { // diag == non-unit
+                            for (int64_t j = n-1; j >= i; --j) // upper
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                    }
+                    // accumulate the scale and sumsq for each k
+                    // todo: this is slow; (reduction with 2 values? two-reductions?)
+                    #pragma omp critical
+                    {
+                        real_t scale_k = values[k*2 + 0];
+                        real_t sumsq_k = values[k*2 + 1];
+                        if (scale_k > scale) {
+                            sumsq_k = sumsq_k + sumsq*(scale / scale_k)*(scale / scale_k);
+                            // scale_k stays same
+                        }
+                        else if (scale != 0) {
+                            sumsq_k = sumsq_k*(scale_k / scale)*(scale_k / scale) + sumsq;
+                            scale_k = scale;
+                        }
+                        values[k*2 + 0] = scale_k;
+                        values[k*2 + 1] = sumsq_k;
+                    }
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_trnorm.cc
+++ b/src/omptarget/device_trnorm.cc
@@ -145,7 +145,7 @@ void trnorm(
                 const scalar_t* tileA = Aarray[k];
                 // distribute cols (j) to threads
                 // each thread computes one column sum
-                #pragma omp parallel for simd schedule(static, 1)
+                #pragma omp parallel for schedule(static, 1)
                 for (int64_t j = 0; j < n; ++j) {
                     const scalar_t* column = &tileA[lda*j];
                     real_t sum = 0;
@@ -191,7 +191,7 @@ void trnorm(
             for (int64_t k = 0; k < batch_count; ++k) {
                 const scalar_t* tileA = Aarray[k];
                 // distribute i to threads, each thread sums one row
-                #pragma omp parallel for simd schedule(static, 1)
+                #pragma omp parallel for schedule(static, 1)
                 for (int64_t i = 0; i < m; ++i) {
                     scalar_t const* row = &tileA[i];
                     real_t sum = 0;

--- a/src/omptarget/device_trnorm.cc
+++ b/src/omptarget/device_trnorm.cc
@@ -90,6 +90,7 @@ void trnorm(
             assert(ldv == 1);
             // use omp offload
             blas::device_memset(values, 0, batch_count, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute
             for (int64_t k = 0; k < batch_count; ++k) {
@@ -139,6 +140,7 @@ void trnorm(
         else {
             assert(ldv >= n);
             blas::device_memset(values, 0, batch_count * n, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute
             for (int64_t k = 0; k < batch_count; ++k) {
@@ -186,6 +188,7 @@ void trnorm(
         }
         else {
             assert(ldv >= m);
+            queue.sync(); // sync queue before switching to openmp device execution
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute
             for (int64_t k = 0; k < batch_count; ++k) {
@@ -234,6 +237,7 @@ void trnorm(
         else {
             assert(ldv == 2);
             blas::device_memset(values, 0, batch_count * 2, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
             #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
             #pragma omp teams distribute
             // distribute each batch array to a team

--- a/src/omptarget/device_tzadd.cc
+++ b/src/omptarget/device_tzadd.cc
@@ -70,6 +70,7 @@ void tzadd(
     if (batch_count == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {

--- a/src/omptarget/device_tzadd.cc
+++ b/src/omptarget/device_tzadd.cc
@@ -62,8 +62,8 @@ template <typename scalar_t>
 void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    scalar_t alpha, scalar_t** Aarray, int64_t lda,
-    scalar_t beta, scalar_t** Barray, int64_t ldb,
+    scalar_t const& alpha, scalar_t** Aarray, int64_t lda,
+    scalar_t const& beta, scalar_t** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue)
 {
     // quick return
@@ -102,32 +102,32 @@ template
 void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    float alpha, float** Aarray, int64_t lda,
-    float beta, float** Barray, int64_t ldb,
+    float const& alpha, float** Aarray, int64_t lda,
+    float const& beta, float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    double alpha, double** Aarray, int64_t lda,
-    double beta, double** Barray, int64_t ldb,
+    double const& alpha, double** Aarray, int64_t lda,
+    double const& beta, double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    std::complex<float> alpha, std::complex<float>** Aarray, int64_t lda,
-    std::complex<float> beta, std::complex<float>** Barray, int64_t ldb,
+    std::complex<float> const& alpha, std::complex<float>** Aarray, int64_t lda,
+    std::complex<float> const& beta, std::complex<float>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
 void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    std::complex<double> alpha, std::complex<double>** Aarray, int64_t lda,
-    std::complex<double> beta, std::complex<double>** Barray, int64_t ldb,
+    std::complex<double> const& alpha, std::complex<double>** Aarray, int64_t lda,
+    std::complex<double> const& beta, std::complex<double>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 } // namespace device

--- a/src/omptarget/device_tzadd.cc
+++ b/src/omptarget/device_tzadd.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
@@ -6,19 +6,34 @@
 #include "slate/Exception.hh"
 #include "slate/internal/device.hh"
 
+#include "device_util.hh"
+
 #include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <complex>
 
 namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
-/// Batched routine for element-wise copy and precision conversion.
+/// Batched routine for element-wise trapezoidal tile addition.
+/// Sets upper or lower part of
+/// \[
+///     Barray[k] = \alpha Aarray[k] + \beta Barray[k].
+/// \]
+///
+/// @param[in] uplo
+///     Whether each Aarray[k] is upper or lower trapezoidal.
 ///
 /// @param[in] m
 ///     Number of rows of each tile. m >= 0.
 ///
 /// @param[in] n
 ///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] alpha
+///     The scalar alpha.
 ///
 /// @param[in] Aarray
 ///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
@@ -27,7 +42,10 @@ namespace device {
 /// @param[in] lda
 ///     Leading dimension of each tile in A. lda >= m.
 ///
-/// @param[out] Barray
+/// @param[in] beta
+///     The scalar beta.
+///
+/// @param[in,out] Barray
 ///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
 ///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
 ///
@@ -37,15 +55,15 @@ namespace device {
 /// @param[in] batch_count
 ///     Size of Aarray and Barray. batch_count >= 0.
 ///
-/// @param[in] stream
-///     Device to execute in.
+/// @param[in] queue
+///     BLAS++ queue to execute in.
 ///
-template <typename src_scalar_t, typename dst_scalar_t>
-void tzcopy(
+template <typename scalar_t>
+void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    src_scalar_t const* const* Aarray, int64_t lda,
-    dst_scalar_t** Barray, int64_t ldb,
+    scalar_t alpha, scalar_t** Aarray, int64_t lda,
+    scalar_t beta, scalar_t** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue)
 {
     // quick return
@@ -55,20 +73,23 @@ void tzcopy(
     #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {
-        src_scalar_t const* tileA = Aarray[k];
-        dst_scalar_t* tileB = Barray[k];
-        // distribute rows (i) to threads
-        #pragma omp parallel for schedule(static, 1)
+        scalar_t* tileA = Aarray[ k ];
+        scalar_t* tileB = Barray[ k ];
+        // distribute rows (i) to thread
+        #pragma omp parallel for collapse(1) schedule(static, 1)
         for (int64_t i = 0; i < m; ++i) {
-            src_scalar_t const* rowA = &tileA[i];
-            dst_scalar_t* rowB = &tileB[i];
+            scalar_t* rowA = &tileA[ i ];
+            scalar_t* rowB = &tileB[ i ];
+            // add lower/upper
             if (uplo == lapack::Uplo::Lower) {
-                for (int64_t j = 0; j <= i && j < n; ++j) // lower
-                    rowB[j*ldb] = rowA[j*lda];
+                for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                    rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+                }
             }
             else {
-                for (int64_t j = n-1; j >= i; --j) // upper
-                    rowB[j*ldb] = rowA[j*lda];
+                for (int64_t j = n-1; j >= i; --j) { // upper
+                    rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+                }
             }
         }
     }
@@ -77,67 +98,35 @@ void tzcopy(
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template
-void tzcopy(
+void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    float const* const* Aarray, int64_t lda,
-    float** Barray, int64_t ldb,
+    float alpha, float** Aarray, int64_t lda,
+    float beta, float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
-void tzcopy(
+void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    float const* const* Aarray, int64_t lda,
-    double** Barray, int64_t ldb,
+    double alpha, double** Aarray, int64_t lda,
+    double beta, double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
-void tzcopy(
+void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    double const* const* Aarray, int64_t lda,
-    double** Barray, int64_t ldb,
+    std::complex<float> alpha, std::complex<float>** Aarray, int64_t lda,
+    std::complex<float> beta, std::complex<float>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 template
-void tzcopy(
+void tzadd(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    double const* const* Aarray, int64_t lda,
-    float** Barray, int64_t ldb,
-    int64_t batch_count, blas::Queue &queue);
-
-template
-void tzcopy(
-    lapack::Uplo uplo,
-    int64_t m, int64_t n,
-    std::complex<float> const* const* Aarray, int64_t lda,
-    std::complex<float>** Barray, int64_t ldb,
-    int64_t batch_count, blas::Queue &queue);
-
-template
-void tzcopy(
-    lapack::Uplo uplo,
-    int64_t m, int64_t n,
-    std::complex<float> const* const* Aarray, int64_t lda,
-    std::complex<double>** Barray, int64_t ldb,
-    int64_t batch_count, blas::Queue &queue);
-
-template
-void tzcopy(
-    lapack::Uplo uplo,
-    int64_t m, int64_t n,
-    std::complex<double> const* const* Aarray, int64_t lda,
-    std::complex<double>** Barray, int64_t ldb,
-    int64_t batch_count, blas::Queue &queue);
-
-template
-void tzcopy(
-    lapack::Uplo uplo,
-    int64_t m, int64_t n,
-    std::complex<double> const* const* Aarray, int64_t lda,
-    std::complex<float>** Barray, int64_t ldb,
+    std::complex<double> alpha, std::complex<double>** Aarray, int64_t lda,
+    std::complex<double> beta, std::complex<double>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 } // namespace device

--- a/src/omptarget/device_tzcopy.cc
+++ b/src/omptarget/device_tzcopy.cc
@@ -52,6 +52,7 @@ void tzcopy(
     if (batch_count == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
     #pragma omp teams distribute
     for (int64_t k = 0; k < batch_count; ++k) {

--- a/src/omptarget/device_tzcopy.cc
+++ b/src/omptarget/device_tzcopy.cc
@@ -1,0 +1,144 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise copy and precision conversion.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] stream
+///     Device to execute in.
+///
+template <typename src_scalar_t, typename dst_scalar_t>
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    src_scalar_t** Aarray, int64_t lda,
+    dst_scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        src_scalar_t* tileA = Aarray[k];
+        dst_scalar_t* tileB = Barray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for simd schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            src_scalar_t* rowA = &tileA[i];
+            dst_scalar_t* rowB = &tileB[i];
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                    rowB[j*ldb] = rowA[j*lda];
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) // upper
+                    rowB[j*ldb] = rowA[j*lda];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float** Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float** Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double** Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double** Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float>** Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float>** Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double>** Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double>** Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_tzscale.cc
+++ b/src/omptarget/device_tzscale.cc
@@ -63,6 +63,7 @@ void tzscale(
 
     blas::real_type<scalar_t> mul = numer / denom;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(Aarray) device(queue.device())
     #pragma omp teams distribute

--- a/src/omptarget/device_tzscale.cc
+++ b/src/omptarget/device_tzscale.cc
@@ -1,0 +1,122 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise trapezoidal tile scale.
+/// Sets upper or lower part of
+/// \[
+///     Aarray[k] *= (numer / denom).
+/// \]
+/// This does NOT currently take extra care to avoid over/underflow.
+///
+/// @param[in] uplo
+///     Whether each Aarray[k] is upper or lower trapezoidal.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] numer
+///     Scale value numerator.
+///
+/// @param[in] denom
+///     Scale value denominator.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    blas::real_type<scalar_t> numer, blas::real_type<scalar_t> denom,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    blas::real_type<scalar_t> mul = numer / denom;
+
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* tileA = Aarray[ k ];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            // lower or upper
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                    rowA[j*lda] = rowA[j*lda] * mul;
+                }
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) // upper
+                    rowA[j*lda] = rowA[j*lda] * mul;
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float numer, float denom, float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double numer, double denom, double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float numer, float denom,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double numer, double denom,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_tzset.cc
+++ b/src/omptarget/device_tzset.cc
@@ -52,6 +52,7 @@ void tzset(
     scalar_t* A, int64_t lda,
     blas::Queue& queue )
 {
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(A) device(queue.device())
     // distribute rows (i) to threads
@@ -152,6 +153,7 @@ void tzset(
     if (batch_count == 0)
         return;
 
+    queue.sync(); // sync queue before switching to openmp device execution
     // Use omp target offload
     #pragma omp target is_device_ptr(Aarray) device(queue.device())
     #pragma omp teams distribute

--- a/src/omptarget/device_tzset.cc
+++ b/src/omptarget/device_tzset.cc
@@ -48,7 +48,7 @@ template <typename scalar_t>
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    scalar_t offdiag_value, scalar_t diag_value,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
     scalar_t* A, int64_t lda,
     blas::Queue& queue )
 {
@@ -79,7 +79,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    float offdiag_value, float diag_value,
+    float const& offdiag_value, float const& diag_value,
     float* A, int64_t lda,
     blas::Queue& queue );
 
@@ -87,7 +87,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    double offdiag_value, double diag_value,
+    double const& offdiag_value, double const& diag_value,
     double* A, int64_t lda,
     blas::Queue& queue );
 
@@ -95,7 +95,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    std::complex<float> offdiag_value, std::complex<float> diag_value,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
     std::complex<float>* A, int64_t lda,
     blas::Queue& queue );
 
@@ -103,7 +103,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    std::complex<double> offdiag_value, std::complex<double> diag_value,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
     std::complex<double>* A, int64_t lda,
     blas::Queue& queue );
 
@@ -145,7 +145,7 @@ template <typename scalar_t>
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    scalar_t offdiag_value, scalar_t diag_value,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
     scalar_t** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue )
 {
@@ -184,7 +184,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    float offdiag_value, float diag_value,
+    float const& offdiag_value, float const& diag_value,
     float** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue );
 
@@ -192,7 +192,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    double offdiag_value, double diag_value,
+    double const& offdiag_value, double const& diag_value,
     double** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue );
 
@@ -200,7 +200,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    std::complex<float> offdiag_value, std::complex<float> diag_value,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
     std::complex<float>** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue );
 
@@ -208,7 +208,7 @@ template
 void tzset(
     lapack::Uplo uplo,
     int64_t m, int64_t n,
-    std::complex<double> offdiag_value, std::complex<double> diag_value,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
     std::complex<double>** Aarray, int64_t lda,
     int64_t batch_count, blas::Queue& queue );
 

--- a/src/omptarget/device_tzset.cc
+++ b/src/omptarget/device_tzset.cc
@@ -1,18 +1,27 @@
-// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+#include "slate/Exception.hh"
 #include "slate/internal/device.hh"
 
 #include <cstdio>
+#include <cmath>
+#include <complex>
+
+#include "device_util.hh"
 
 namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
-/// Element-wise m-by-n matrix A
-/// to diag_value on the diagonal and offdiag_value on the off-diagonals.
+/// Element-wise trapezoidal tile set.
+/// Sets upper or lower part of Aarray[k] to
+/// diag_value on the diagonal and offdiag_value on the off-diagonals.
+///
+/// @param[in] uplo
+///     Whether each Aarray[k] is upper or lower trapezoidal.
 ///
 /// @param[in] m
 ///     Number of rows of A. m >= 0.
@@ -21,10 +30,10 @@ namespace device {
 ///     Number of columns of A. n >= 0.
 ///
 /// @param[in] offdiag_value
-///     The value to set outside of the diagonal.
+///     Constant to set offdiagonal entries to.
 ///
 /// @param[in] diag_value
-///     The value to set on the diagonal.
+///     Constant to set diagonal entries to.
 ///
 /// @param[out] A
 ///     An m-by-n matrix stored in an lda-by-n array in GPU memory.
@@ -36,113 +45,28 @@ namespace device {
 ///     BLAS++ queue to execute in.
 ///
 template <typename scalar_t>
-void geset(
+void tzset(
+    lapack::Uplo uplo,
     int64_t m, int64_t n,
     scalar_t offdiag_value, scalar_t diag_value,
     scalar_t* A, int64_t lda,
-    blas::Queue &queue)
+    blas::Queue& queue )
 {
-    // quick return
-    if (m == 0 || n == 0)
-        return;
-
     // Use omp target offload
     #pragma omp target is_device_ptr(A) device(queue.device())
+    // distribute rows (i) to threads
     #pragma omp teams distribute parallel for schedule(static, 1)
     for (int64_t i = 0; i < m; ++i) {
-        scalar_t* rowA = &A[i];
-        for (int64_t j = 0; j < n; ++j) {
-            rowA[j*lda] = (j != i) ? offdiag_value : diag_value;
+        scalar_t* rowA = &A[ i ];
+        // lower or upper
+        if (uplo == lapack::Uplo::Lower) {
+            for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+            }
         }
-    }
-}
-
-//------------------------------------------------------------------------------
-// Explicit instantiations.
-template
-void geset(
-    int64_t m, int64_t n,
-    float offdiag_value, float diag_value,
-    float* A, int64_t lda,
-    blas::Queue &queue);
-
-template
-void geset(
-    int64_t m, int64_t n,
-    double offdiag_value, double diag_value,
-    double* A, int64_t lda,
-    blas::Queue &queue);
-
-template
-void geset(
-    int64_t m, int64_t n,
-    std::complex<float> offdiag_value, std::complex<float> diag_value,
-    std::complex<float>* A, int64_t lda,
-    blas::Queue &queue);
-
-template
-void geset(
-    int64_t m, int64_t n,
-    std::complex<double> offdiag_value, std::complex<double> diag_value,
-    std::complex<double>* A, int64_t lda,
-    blas::Queue &queue);
-
-//==============================================================================
-namespace batch {
-
-//------------------------------------------------------------------------------
-/// Initializes a batch of m-by-n matrices Aarray[k]
-/// to diag_value on the diagonal and offdiag_value on the off-diagonals.
-///
-/// @param[in] m
-///     Number of rows of each tile. m >= 0.
-///
-/// @param[in] n
-///     Number of columns of each tile. n >= 0.
-///
-/// @param[in] offdiag_value
-///     The value to set outside of the diagonal.
-///
-/// @param[in] diag_value
-///     The value to set on the diagonal.
-///
-/// @param[in] Aarray
-///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
-///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
-///
-/// @param[in] lda
-///     Leading dimension of each tile in A. lda >= m.
-///
-/// @param[in] batch_count
-///     Size of Aarray. batch_count >= 0.
-///
-/// @param[in] queue
-///     BLAS++ queue to execute in.
-///
-template <typename scalar_t>
-void geset(
-    int64_t m, int64_t n,
-    scalar_t offdiag_value, scalar_t diag_value,
-    scalar_t** Aarray, int64_t lda,
-    int64_t batch_count, blas::Queue &queue)
-{
-    // quick return
-    if (batch_count == 0)
-        return;
-    // quick return
-    if (m == 0 || n == 0)
-        return;
-
-    // Use omp target offload
-    #pragma omp target is_device_ptr(Aarray) device(queue.device())
-    #pragma omp teams distribute
-    for (int64_t k = 0; k < batch_count; ++k) {
-        #pragma omp parallel for collapse(2)
-        for (int64_t i = 0; i < m; ++i) {
-            for (int64_t j = 0; j < n; ++j) {
-                scalar_t* tileA = Aarray[k];
-                scalar_t* rowA = &tileA[i];
-                rowA[j*lda] = (j != i) ? offdiag_value : diag_value;
+        else {
+            for (int64_t j = n-1; j >= i; --j) { // upper
+                rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
             }
         }
     }
@@ -151,32 +75,140 @@ void geset(
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template
-void geset(
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float offdiag_value, float diag_value,
+    float* A, int64_t lda,
+    blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double offdiag_value, double diag_value,
+    double* A, int64_t lda,
+    blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> offdiag_value, std::complex<float> diag_value,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> offdiag_value, std::complex<double> diag_value,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue );
+
+//==============================================================================
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise trapezoidal tile set.
+/// Sets upper or lower part of Aarray[k] to
+/// diag_value on the diagonal and offdiag_value on the off-diagonals.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] offdiag_value
+///     Constant to set offdiagonal entries to.
+///
+/// @param[in] diag_value
+///     Constant to set diagonal entries to.
+///
+/// @param[out] Aarray
+///     Array in GPU memory of dimension batch_count, containing
+///     pointers to tiles, where each Aarray[k] is an m-by-n matrix
+///     stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    scalar_t offdiag_value, scalar_t diag_value,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue )
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* A = Aarray[ k ];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &A[ i ];
+            // lower or upper
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                    rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+                }
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) { // upper
+                    rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzset(
+    lapack::Uplo uplo,
     int64_t m, int64_t n,
     float offdiag_value, float diag_value,
     float** Aarray, int64_t lda,
-    int64_t batch_count, blas::Queue &queue);
+    int64_t batch_count, blas::Queue& queue );
 
 template
-void geset(
+void tzset(
+    lapack::Uplo uplo,
     int64_t m, int64_t n,
     double offdiag_value, double diag_value,
     double** Aarray, int64_t lda,
-    int64_t batch_count, blas::Queue &queue);
+    int64_t batch_count, blas::Queue& queue );
 
 template
-void geset(
+void tzset(
+    lapack::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<float> offdiag_value, std::complex<float> diag_value,
     std::complex<float>** Aarray, int64_t lda,
-    int64_t batch_count, blas::Queue &queue);
+    int64_t batch_count, blas::Queue& queue );
 
 template
-void geset(
+void tzset(
+    lapack::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<double> offdiag_value, std::complex<double> diag_value,
     std::complex<double>** Aarray, int64_t lda,
-    int64_t batch_count, blas::Queue &queue);
+    int64_t batch_count, blas::Queue& queue );
 
 } // namespace batch
 } // namespace device

--- a/src/omptarget/device_util.hh
+++ b/src/omptarget/device_util.hh
@@ -6,6 +6,8 @@
 #ifndef SLATE_OMPTARGET_UTIL_HH
 #define SLATE_OMPTARGET_UTIL_HH
 
+#include <math.h>
+
 namespace slate {
 namespace device {
 

--- a/src/omptarget/device_util.hh
+++ b/src/omptarget/device_util.hh
@@ -38,6 +38,27 @@ inline scalar_t sqr(scalar_t x)
 #pragma omp end declare target
 
 //------------------------------------------------------------------------------
+/// Adds two scaled, sum-of-squares representations.
+/// On exit, scale1 and sumsq1 are updated such that:
+///     scale1^2 sumsq1 := scale1^2 sumsq1 + scale2^2 sumsq2.
+#pragma omp declare target
+template <typename real_t>
+void combine_sumsq(
+    real_t& scale1, real_t& sumsq1,
+    real_t  scale2, real_t  sumsq2 )
+{
+    if (scale1 > scale2) {
+        sumsq1 = sumsq1 + sumsq2*sqr(scale2 / scale1);
+        // scale1 stays same
+    }
+    else if (scale2 != 0) {
+        sumsq1 = sumsq1*sqr(scale1 / scale2) + sumsq2;
+        scale1 = scale2;
+    }
+}
+#pragma omp end declare target
+
+//------------------------------------------------------------------------------
 /// Adds new value to scaled, sum-of-squares representation.
 /// On exit, scale and sumsq are updated such that:
 ///     scale^2 sumsq := scale^2 sumsq + (absx)^2

--- a/src/omptarget/device_util.hh
+++ b/src/omptarget/device_util.hh
@@ -1,0 +1,137 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef SLATE_OMPTARGET_UTIL_HH
+#define SLATE_OMPTARGET_UTIL_HH
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// max that propogates nan consistently:
+///     max_nan( 1,   nan ) = nan
+///     max_nan( nan, 1   ) = nan
+#pragma omp declare target
+template <typename real_t>
+inline real_t max_nan(real_t x, real_t y)
+{
+    return (isnan(y) || (y) >= (x) ? (y) : (x));
+}
+#pragma omp end declare target
+
+// OpenMP reduction operation that allows for the nan propogation
+#pragma omp declare reduction(max_nan_reduction: float, double: omp_out = max_nan(omp_out, omp_in))
+
+//------------------------------------------------------------------------------
+/// Square of number.
+/// @return x^2
+#pragma omp declare target
+template <typename scalar_t>
+inline scalar_t sqr(scalar_t x)
+{
+    return x*x;
+}
+#pragma omp end declare target
+
+//------------------------------------------------------------------------------
+/// Adds new value to scaled, sum-of-squares representation.
+/// On exit, scale and sumsq are updated such that:
+///     scale^2 sumsq := scale^2 sumsq + (absx)^2
+#pragma omp declare target
+template <typename real_t>
+inline void add_sumsq(
+    real_t& scale, real_t& sumsq,
+    real_t absx)
+{
+    if (scale < absx) {
+        sumsq = 1 + sumsq * sqr(scale / absx);
+        scale = absx;
+    }
+    else if (scale != 0) {
+        sumsq = sumsq + sqr(absx / scale);
+    }
+}
+#pragma omp end declare target
+
+//------------------------------------------------------------------------------
+/// Overloaded versions of absolute value on device.
+#pragma omp declare target
+inline float abs_val(float x)
+{
+    return fabsf(x);
+}
+
+inline double abs_val(double x)
+{
+    return fabs(x);
+}
+
+inline float abs_val(std::complex<float> x)
+{
+    // use our implementation that scales per LAPACK.
+    // todo try std::abs(x)
+    // todo try device specific abs eg for cuda
+    float a = std::real(x);
+    float b = std::imag(x);
+    float z, w, t;
+    if (isnan( a )) {
+        return a;
+    }
+    else if (isnan( b )) {
+        return b;
+    }
+    else {
+        a = fabsf(a);
+        b = fabsf(b);
+        w = std::max(a, b);
+        z = std::min(a, b);
+        if (z == 0) {
+            t = w;
+        }
+        else {
+            t = z/w;
+            t = 1 + t*t;
+            t = w * sqrtf(t);
+        }
+        return t;
+    }
+}
+
+inline double abs_val(std::complex<double> x)
+{
+    // use our implementation that scales per LAPACK.
+    // todo try std::abs(x)
+    // todo try device specific abs eg for cuda
+    double a = std::real(x);
+    double b = std::imag(x);
+    double z, w, t;
+    if (isnan( a )) {
+        return a;
+    }
+    else if (isnan( b )) {
+        return b;
+    }
+    else {
+        a = fabs(a);
+        b = fabs(b);
+        w = std::max(a, b);
+        z = std::min(a, b);
+        if (z == 0) {
+            t = w;
+        }
+        else {
+            t = z/w;
+            t = 1.0 + t*t;
+            t = w * sqrt(t);
+        }
+        return t;
+    }
+}
+#pragma omp end declare target
+
+} // namespace device
+} // namespace slate
+
+#endif // SLATE_OMPTARGET_UTIL_HH

--- a/src/print.cc
+++ b/src/print.cc
@@ -155,7 +155,7 @@ void print(
         lda = mb;
         data_vector.resize( lda * nb );
         data = data_vector.data();
-        blas::device_getmatrix(
+        blas::device_copy_matrix(
             mb, nb,
             A.data(), A.stride(),
             data, lda, queue );

--- a/test/scalapack_copy.hh
+++ b/test/scalapack_copy.hh
@@ -73,7 +73,7 @@ void copyTile(
             // Copy from device tile, if it exists, to ScaLAPACK.
             auto Aij = A(i, j, dev);
             blas::Queue queue(dev, 0);
-            blas::device_getmatrix(
+            blas::device_copy_matrix(
                 Aij.mb(), Aij.nb(),
                 Aij.data(), Aij.stride(),
                 &B[ ii_local + jj_local*ldb ], ldb, queue);
@@ -123,7 +123,7 @@ void copyTile(
             A.tileGetForWriting(i, j, dev, slate::LayoutConvert::ColMajor);
             auto Aij = A(i, j, dev);
             blas::Queue queue(dev, 0);
-            blas::device_setmatrix(
+            blas::device_copy_matrix(
                 Aij.mb(), Aij.nb(),
                 &B[ ii_local + jj_local*ldb ], ldb,
                 Aij.data(), Aij.stride(), queue);

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -436,6 +436,7 @@ void test_Matrix_fromDevices()
         int64_t len = std::max(lda * n_dev, 1);
         Aarray[dev] = blas::device_malloc<double>(len, *dev_queues[dev]);
         assert(Aarray[dev] != nullptr);
+        dev_queues[dev]->sync();
     }
 
     auto A = slate::Matrix<double>::fromDevices(
@@ -454,6 +455,7 @@ void test_Matrix_fromDevices()
 
     for (int dev = 0; dev < num_devices; ++dev) {
         blas::device_free(Aarray[dev], *dev_queues[dev]);
+        dev_queues[dev]->sync();
     }
     delete[] Aarray;
 
@@ -1829,7 +1831,7 @@ void test_Matrix_MOSI()
 /// Test tileLayoutConvert.
 void test_Matrix_tileLayoutConvert()
 {
-    int lda = roundup(m, nb);
+    int lda = roundup(m, mb);
     std::vector<double> Ad( lda*n );
 
     int64_t iseed[4] = { 0, 1, 2, 3 };

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -436,7 +436,6 @@ void test_Matrix_fromDevices()
         int64_t len = std::max(lda * n_dev, 1);
         Aarray[dev] = blas::device_malloc<double>(len, *dev_queues[dev]);
         assert(Aarray[dev] != nullptr);
-        dev_queues[dev]->sync();
     }
 
     auto A = slate::Matrix<double>::fromDevices(
@@ -455,7 +454,6 @@ void test_Matrix_fromDevices()
 
     for (int dev = 0; dev < num_devices; ++dev) {
         blas::device_free(Aarray[dev], *dev_queues[dev]);
-        dev_queues[dev]->sync();
     }
     delete[] Aarray;
 

--- a/unit_test/test_Memory.cc
+++ b/unit_test/test_Memory.cc
@@ -177,6 +177,7 @@ void test_alloc_device()
             blas::device_memcpy<double>(dx[i], hx, nb * nb,
                                         blas::MemcpyKind::HostToDevice,
                                         *dev_queues[dev]);
+            dev_queues[dev]->sync(); // blas::device_memcpy does not sync
         }
 
         // Free some.

--- a/unit_test/test_Memory.cc
+++ b/unit_test/test_Memory.cc
@@ -177,7 +177,6 @@ void test_alloc_device()
             blas::device_memcpy<double>(dx[i], hx, nb * nb,
                                         blas::MemcpyKind::HostToDevice,
                                         *dev_queues[dev]);
-            dev_queues[dev]->sync(); // blas::device_memcpy does not sync
         }
 
         // Free some.
@@ -202,7 +201,6 @@ void test_alloc_device()
     mem.clearHostBlocks();
     for (int dev = 0; dev < mem.num_devices_; ++dev) {
         mem.clearDeviceBlocks(dev, dev_queues[dev] );
-        dev_queues[dev]->sync();
     }
 
     // free the device specific queues
@@ -277,7 +275,6 @@ void test_clearDeviceBlocks()
     // deallocate/clear memory before the slate::Memory destructer
     mem.clearHostBlocks();
     for (int dev = 0; dev < mem.num_devices_; ++dev) {
-       dev_queues[dev]->sync();
         mem.clearDeviceBlocks(dev, dev_queues[dev] );
         dev_queues[dev]->sync();
     }

--- a/unit_test/test_Tile.cc
+++ b/unit_test/test_Tile.cc
@@ -659,8 +659,7 @@ void test_copyData(int align_host, int align_dev)
     setup_data(B);
     clear_data(B);
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 

--- a/unit_test/test_Tile_kernels.cc
+++ b/unit_test/test_Tile_kernels.cc
@@ -1021,7 +1021,6 @@ void test_device_convert_layout(int m, int n)
                         Adata.size(),
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     scalar_t* Adata_dev_ext;
     Adata_dev_ext = blas::device_malloc<scalar_t>(Adata.size(), queue);
@@ -1042,7 +1041,6 @@ void test_device_convert_layout(int m, int n)
                         Aarray.size(),
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     // Allocate Aarray_dev_ext[] on device and copy Aarray[] to it
     scalar_t** Aarray_dev_ext;
@@ -1051,7 +1049,6 @@ void test_device_convert_layout(int m, int n)
                         Aarray_ext.size(),
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     if (verbose > 1) {
         printf("A = [\n");
@@ -1091,7 +1088,6 @@ void test_device_convert_layout(int m, int n)
     // copy transposed data Adata_dev/Adata_dev_ext from device to Adata (cpu)
     blas::device_memcpy<scalar_t>(
         Adata.data(), (m == n ? Adata_dev : Adata_dev_ext), Adata.size(), queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     //-----------------------------------------
     // Run kernel.
@@ -1150,7 +1146,7 @@ void test_device_convert_layout(int m, int n)
                         Adata.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
+    queue.sync(); // sync before looking at data
 
     if (verbose > 1) {
         printf("AT = [\n");

--- a/unit_test/test_Tile_kernels.cc
+++ b/unit_test/test_Tile_kernels.cc
@@ -999,7 +999,7 @@ void test_device_convert_layout(int m, int n)
     int repeat = 1;
     int device = 0;
 
-    // setup batch A and copy B on CPU
+    // setup batch A (Adata, Atiles) and copy B=A (Bdata, Btiles) on CPU
     int64_t iseed[4] = { 0, 1, 2, 3 };
     std::vector< scalar_t > Adata( lda * n * batch_count );
     lapack::larnv( 1, iseed, Adata.size(), Adata.data() );
@@ -1011,7 +1011,7 @@ void test_device_convert_layout(int m, int n)
         Btiles[k] = slate::Tile<scalar_t>( m, n, &Bdata[ k*lda*n ], lda, HostNum, slate::TileKind::UserOwned );
     }
 
-    // copy batch A to GPU
+    // copy batch A to GPU (Adata_dev)
     scalar_t* Adata_dev;
     const int batch_arrays_index = 0;
     blas::Queue queue(device, batch_arrays_index);
@@ -1021,10 +1021,12 @@ void test_device_convert_layout(int m, int n)
                         Adata.size(),
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     scalar_t* Adata_dev_ext;
     Adata_dev_ext = blas::device_malloc<scalar_t>(Adata.size(), queue);
 
+    // Setup Atiles_dev[], Aarray[], Aarray_ext[] on CPU with pointers to Adata_dev[]
     std::vector< slate::Tile<scalar_t> > Atiles_dev( batch_count );
     std::vector< scalar_t* > Aarray( batch_count );
     std::vector< scalar_t* > Aarray_ext( batch_count );
@@ -1033,19 +1035,23 @@ void test_device_convert_layout(int m, int n)
         Aarray[k] = &Adata_dev[ k*lda*n ];
         Aarray_ext[k] = &Adata_dev_ext[ k*lda*n ];
     }
+    // Allocate Aarray_dev[] on device and copy Aarray to it
     scalar_t** Aarray_dev;
     Aarray_dev = blas::device_malloc<scalar_t*>(Aarray.size(), queue);
     blas::device_memcpy<scalar_t*>(Aarray_dev, Aarray.data(),
                         Aarray.size(),
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
+    // Allocate Aarray_dev_ext[] on device and copy Aarray[] to it
     scalar_t** Aarray_dev_ext;
     Aarray_dev_ext = blas::device_malloc<scalar_t*>(Aarray_ext.size(), queue);
     blas::device_memcpy<scalar_t*>(Aarray_dev_ext, Aarray_ext.data(),
                         Aarray_ext.size(),
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     if (verbose > 1) {
         printf("A = [\n");
@@ -1081,11 +1087,11 @@ void test_device_convert_layout(int m, int n)
     }
     if (verbose)
         printf( "\n" );
-    blas::device_memcpy<scalar_t>(Adata.data(),
-                        (m == n ? Adata_dev : Adata_dev_ext),
-                        Adata.size(),
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+
+    // copy transposed data Adata_dev/Adata_dev_ext from device to Adata (cpu)
+    blas::device_memcpy<scalar_t>(
+        Adata.data(), (m == n ? Adata_dev : Adata_dev_ext), Adata.size(), queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     //-----------------------------------------
     // Run kernel.
@@ -1137,11 +1143,14 @@ void test_device_convert_layout(int m, int n)
     }
     if (verbose)
         printf( "\n" );
+
+    // fetch Adata_dev/Adata_dev_ext from device to Adata (cpu)
     blas::device_memcpy<scalar_t>(Adata.data(),
                         (m == n ? Adata_dev : Adata_dev_ext),
                         Adata.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     if (verbose > 1) {
         printf("AT = [\n");
@@ -1166,11 +1175,7 @@ void test_device_convert_layout(int m, int n)
             for (int i = 0; i < m; ++i) {
                 // A(i, j) takes col/row-major into account.
                 // Check that actual data is transposed.
-                int Adata_lda;
-                if (m == n)
-                    Adata_lda = lda;
-                else
-                    Adata_lda = ldat;
+                int Adata_lda = ( m == n ? lda : ldat );
                 if (Adata[ j + i*Adata_lda + k*lda*n ] != Bdata[ i + j*lda + k*lda*n ]) {
                     printf( "Adata[ j(%d) + i(%d)*lda + k(%d)*lda*n ] %5.2f\n"
                             "Bdata[ i(%d) + j(%d)*lda + k(%d)*lda*n ] %5.2f\n",
@@ -1190,13 +1195,13 @@ void test_device_convert_layout(int m, int n)
 
 void test_device_convert_layout()
 {
-    int m = 256, n = 256;
+    int m = 256, n = m; // square tiles
     test_device_convert_layout< float  >(m, n);
     test_device_convert_layout< double >(m, n);
     test_device_convert_layout< std::complex<float>  >(m, n);
     test_device_convert_layout< std::complex<double> >(m, n);
 
-    m = 128;
+    m = 128; n = 256; // rectangular tiles
     test_device_convert_layout< float  >(m, n);
     test_device_convert_layout< double >(m, n);
     test_device_convert_layout< std::complex<float>  >(m, n);

--- a/unit_test/test_geadd.cc
+++ b/unit_test/test_geadd.cc
@@ -353,7 +353,6 @@ void test_geadd_batch_dev_worker(
     }
     blas::device_memcpy<scalar_t*>(
         dAarray, Aarray, batch_count, blas::MemcpyKind::HostToDevice, queue );
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     // Create batch array of dB
     scalar_t** Barray = new scalar_t*[ batch_count ];
@@ -366,7 +365,6 @@ void test_geadd_batch_dev_worker(
     }
     blas::device_memcpy<scalar_t*>(
         dBarray, Barray, batch_count, blas::MemcpyKind::HostToDevice, queue );
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     // Add: B[k] = \alpha * A[k] + \beta * B[k]
     slate::device::batch::geadd( m, n,
@@ -527,7 +525,7 @@ void test_geadd_batch_dev()
               { 2.718281828459045e7, 1.732050807568877 } },
         };
 
-    std::list< int > batch_count_list{ 1, 2, 3, 4, 5, 10, 20, 100 };
+    std::list< int > batch_count_list{ 1, 2, 3, 4, 5, 10, 20 };
 
     for (auto dims : dims_list) {
         int mA  = std::get<0>( dims );

--- a/unit_test/test_geadd.cc
+++ b/unit_test/test_geadd.cc
@@ -65,8 +65,7 @@ void test_geadd_dev_worker(
         slate::HostNum, slate::TileKind::UserOwned );
 
     // Create the queue
-    int device_idx;
-    blas::get_device( &device_idx );
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue( device_idx, batch_arrays_index );
 
@@ -317,15 +316,14 @@ void test_geadd_batch_dev_worker(
     }
 
     // Create the queue
-    int device_idx;
-    blas::get_device( &device_idx );
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue( device_idx, batch_arrays_index );
 
     // Create list of A on device and copy data
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         scalar_t* dtmp_data;
-        dtmp_data = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ) );
+        dtmp_data = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ), queue );
         test_assert( dtmp_data != nullptr );
         list_dA.push_back(
             slate::Tile<scalar_t>( m, n, dtmp_data, lda,
@@ -336,7 +334,7 @@ void test_geadd_batch_dev_worker(
     // Create B on device and copy data
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         scalar_t* dtmp_data;
-        dtmp_data = blas::device_malloc<scalar_t>( blas::max( ldb * n, 1 ) );
+        dtmp_data = blas::device_malloc<scalar_t>( blas::max( ldb * n, 1 ), queue );
         test_assert( dtmp_data != nullptr );
         list_dB.push_back(
             slate::Tile<scalar_t>( m, n, dtmp_data, ldb,
@@ -347,7 +345,7 @@ void test_geadd_batch_dev_worker(
     // Create batch array of dA
     scalar_t** Aarray = new scalar_t*[ batch_count ];
     scalar_t** dAarray;
-    dAarray = blas::device_malloc<scalar_t*>( batch_count );
+    dAarray = blas::device_malloc<scalar_t*>( batch_count, queue );
     test_assert( dAarray != nullptr );
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         auto dA = list_dA[ m_i ];
@@ -361,7 +359,7 @@ void test_geadd_batch_dev_worker(
     // Create batch array of dB
     scalar_t** Barray = new scalar_t*[ batch_count ];
     scalar_t** dBarray;
-    dBarray = blas::device_malloc<scalar_t*>( batch_count );
+    dBarray = blas::device_malloc<scalar_t*>( batch_count, queue );
     test_assert( dAarray != nullptr );
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         auto dB = list_dB[ m_i ];
@@ -463,7 +461,7 @@ void test_geadd_batch_dev_worker(
             }
         }
 
-        blas::device_free( dA.data() );
+        blas::device_free( dA.data(), queue );
         delete[] Adata;
         delete[] Bdata;
         delete[] list_B0[ m_i ].data();
@@ -472,8 +470,8 @@ void test_geadd_batch_dev_worker(
         test_assert( result < 3*eps );
     }
 
-    blas::device_free(dAarray);
-    blas::device_free(dBarray);
+    blas::device_free(dAarray, queue);
+    blas::device_free(dBarray, queue);
     delete[] Aarray;
     delete[] Barray;
 }

--- a/unit_test/test_geadd.cc
+++ b/unit_test/test_geadd.cc
@@ -351,10 +351,9 @@ void test_geadd_batch_dev_worker(
         auto dA = list_dA[ m_i ];
         Aarray[ m_i ] = dA.data();
     }
-    blas::device_memcpy<scalar_t*>( dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue );
+    blas::device_memcpy<scalar_t*>(
+        dAarray, Aarray, batch_count, blas::MemcpyKind::HostToDevice, queue );
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     // Create batch array of dB
     scalar_t** Barray = new scalar_t*[ batch_count ];
@@ -365,18 +364,15 @@ void test_geadd_batch_dev_worker(
         auto dB = list_dB[ m_i ];
         Barray[ m_i ] = dB.data();
     }
-    blas::device_memcpy<scalar_t*>( dBarray, Barray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue );
+    blas::device_memcpy<scalar_t*>(
+        dBarray, Barray, batch_count, blas::MemcpyKind::HostToDevice, queue );
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     // Add: B[k] = \alpha * A[k] + \beta * B[k]
     slate::device::batch::geadd( m, n,
                           alpha, dAarray, lda,
                           beta,  dBarray, ldb,
                           batch_count, queue );
-
-    queue.sync();
 
     // Copy the result back to the Host
     for (int m_i = 0; m_i < batch_count; ++m_i) {

--- a/unit_test/test_gecopy.cc
+++ b/unit_test/test_gecopy.cc
@@ -73,7 +73,6 @@ void test_gecopy_dev()
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync
 
     double* Barray[batch_count];
     double** dBarray;
@@ -84,7 +83,6 @@ void test_gecopy_dev()
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync
 
     slate::device::gecopy( m, n,
                            dAarray, lda,
@@ -97,7 +95,7 @@ void test_gecopy_dev()
                         batch_count,
                         blas::MemcpyKind::DeviceToHost,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync
+    queue.sync(); // sync before looking at data
 
     dB.copyData(&B, queue);
 

--- a/unit_test/test_gecopy.cc
+++ b/unit_test/test_gecopy.cc
@@ -46,8 +46,7 @@ void test_gecopy_dev()
     slate::Tile<double> B(m, n, Bdata, ldb, -1, slate::TileKind::UserOwned);
     //gecopy( A, B );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 

--- a/unit_test/test_gescale.cc
+++ b/unit_test/test_gescale.cc
@@ -478,7 +478,7 @@ void test_gescale_batch_dev()
           { -2.0, -2.0 } },
       };
 
-    std::list< int > batch_count_list{ 1, 2, 3, 4, 5, 10, 20, 100 };
+    std::list< int > batch_count_list{ 1, 2, 3, 4, 5, 10, 20, 30 };
 
     // Create the queue
     int device_idx;

--- a/unit_test/test_gescale.cc
+++ b/unit_test/test_gescale.cc
@@ -242,8 +242,7 @@ void test_gescale_dev()
           { -2.0, -2.0 } },
       };
 
-    int device_idx;
-    blas::get_device( &device_idx );
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue( device_idx, batch_arrays_index );
 
@@ -481,8 +480,7 @@ void test_gescale_batch_dev()
     std::list< int > batch_count_list{ 1, 2, 3, 4, 5, 10, 20, 30 };
 
     // Create the queue
-    int device_idx;
-    blas::get_device( &device_idx );
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue( device_idx, batch_arrays_index );
 

--- a/unit_test/test_gescale.cc
+++ b/unit_test/test_gescale.cc
@@ -94,7 +94,7 @@ void test_gescale_dev_worker(
         slate::HostNum, slate::TileKind::UserOwned );
 
     scalar_t* dAdata;
-    dAdata = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ) );
+    dAdata = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ), queue );
     test_assert( dAdata != nullptr );
     slate::Tile<scalar_t> dA( m, n, dAdata, lda,
         device_idx, slate::TileKind::UserOwned );
@@ -149,7 +149,7 @@ void test_gescale_dev_worker(
             result );
     }
 
-    blas::device_free( dAdata );
+    blas::device_free( dAdata, queue );
     delete[] Adata;
     delete[] Bdata;
 
@@ -314,7 +314,7 @@ void test_gescale_batch_dev_worker(
     // Create the dA matrices on the device
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         scalar_t* dtmp_data;
-        dtmp_data = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ) );
+        dtmp_data = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ), queue );
         test_assert( dtmp_data != nullptr );
         list_dA.push_back( slate::Tile<scalar_t>( m, n, dtmp_data, lda,
             device_idx, slate::TileKind::UserOwned ) );
@@ -322,7 +322,7 @@ void test_gescale_batch_dev_worker(
 
     scalar_t** Aarray = new scalar_t*[ batch_count ];
     scalar_t** dAarray;
-    dAarray = blas::device_malloc<scalar_t*>( batch_count );
+    dAarray = blas::device_malloc<scalar_t*>( batch_count, queue );
     test_assert( dAarray != nullptr );
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         auto A  = list_A[ m_i ];
@@ -402,12 +402,12 @@ void test_gescale_batch_dev_worker(
                         m_i, result );
         }
 
-        blas::device_free( dA.data() );
+        blas::device_free( dA.data(), queue );
         delete[] A.data();
 
         test_assert( result < 3*eps );
     }
-    blas::device_free( dAarray );
+    blas::device_free( dAarray, queue );
     delete[] Bdata;
 
 }
@@ -557,4 +557,3 @@ int main(int argc, char** argv)
     MPI_Finalize();
     return err;
 }
-

--- a/unit_test/test_geset.cc
+++ b/unit_test/test_geset.cc
@@ -213,7 +213,7 @@ void test_geset_batch_dev_worker(
 
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         scalar_t* dtmp_data;
-        dtmp_data = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ) );
+        dtmp_data = blas::device_malloc<scalar_t>( blas::max( lda * n, 1 ), queue );
         test_assert( dtmp_data != nullptr );
         list_dA.push_back( slate::Tile<scalar_t>( m, n, dtmp_data, lda,
             device_idx, slate::TileKind::UserOwned ) );
@@ -221,7 +221,7 @@ void test_geset_batch_dev_worker(
 
     scalar_t** Aarray = new scalar_t*[ batch_count ];
     scalar_t** dAarray;
-    dAarray = blas::device_malloc<scalar_t*>( batch_count );
+    dAarray = blas::device_malloc<scalar_t*>( batch_count, queue );
     test_assert( dAarray != nullptr );
     for (int m_i = 0; m_i < batch_count; ++m_i) {
         auto dA = list_dA[ m_i ];
@@ -282,12 +282,12 @@ void test_geset_batch_dev_worker(
                 printf( "\n\t[%d] error %.2e ", m_i, result );
         }
 
-        blas::device_free( dA.data() );
+        blas::device_free( dA.data(), queue );
         delete[] A.data();
 
         test_assert( result < 3*eps );
     }
-    blas::device_free( dAarray );
+    blas::device_free( dAarray, queue );
     delete[] Bdata;
     delete[] Aarray;
 

--- a/unit_test/test_geset.cc
+++ b/unit_test/test_geset.cc
@@ -156,8 +156,7 @@ void test_geset_dev()
               { 2.718281828459045, -1.732050807568877 } },
         };
 
-    int device_idx;
-    blas::get_device( &device_idx );
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue( device_idx, batch_arrays_index );
 
@@ -349,8 +348,7 @@ void test_geset_batch_dev()
 
     std::list< int > batch_count_list{ 1, 2, 3, 4, 5, 10, 20, 100 };
 
-    int device_idx;
-    blas::get_device( &device_idx );
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue( device_idx, batch_arrays_index );
 

--- a/unit_test/test_internal_blas.cc
+++ b/unit_test/test_internal_blas.cc
@@ -34,9 +34,12 @@ blas::Diag diags[] = {
 
 slate::Target targets[] = {
     slate::Target::HostTask,
-    slate::Target::HostNest,
-    slate::Target::HostBatch,
     slate::Target::Devices,
+    slate::Target::HostBatch,
+#if not defined SLATE_HAVE_OMPTARGET
+    // OMPTARGET does not support HostNest
+    slate::Target::HostNest,
+#endif
 };
 
 // -----------------------------------------------------------------------------

--- a/unit_test/test_internal_blas.cc
+++ b/unit_test/test_internal_blas.cc
@@ -841,20 +841,21 @@ int main(int argc, char** argv)
     }
 
     // run tests
+    int numtargets = sizeof(targets)/sizeof(targets[0]);
     if (do_all || do_gemm) {
-        for (int it = 0; it < 4; ++it) {
+        for (int it = 0; it < numtargets; ++it) {
             test_gemm<double>(targets[it]);
             test_gemm< std::complex<double> >(targets[it]);
         }
     }
     if (do_all || do_syrk) {
-        for (int it = 0; it < 4; ++it) {
+        for (int it = 0; it < numtargets; ++it) {
             test_syrk<double>(targets[it]);
             test_syrk< std::complex<double> >(targets[it]);
         }
     }
     if (do_all || do_herk) {
-        for (int it = 0; it < 4; ++it) {
+        for (int it = 0; it < numtargets; ++it) {
             test_herk<double>(targets[it]);
             test_herk< std::complex<double> >(targets[it]);
         }

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -185,7 +185,6 @@ void test_genorm_dev(Norm norm)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -210,7 +209,7 @@ void test_genorm_dev(Norm norm)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {
@@ -408,7 +407,6 @@ void test_synorm_dev(Norm norm, Uplo uplo)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -431,7 +429,7 @@ void test_synorm_dev(Norm norm, Uplo uplo)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -578,7 +576,6 @@ void test_synorm_offdiag_dev(Norm norm)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     int ldv = n + m;
     std::vector<double> values( ldv );
@@ -595,7 +592,7 @@ void test_synorm_offdiag_dev(Norm norm)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -826,7 +823,6 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -851,7 +847,7 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
-    queue.sync(); // blas::device_memcpy does not sync by default
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -165,8 +165,7 @@ void test_genorm_dev(Norm norm)
     int64_t iseed[4] = { 1, 0, 2, 3 };
     lapack::larnv( idist, iseed, lda * n, A.data() );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -387,8 +386,7 @@ void test_synorm_dev(Norm norm, Uplo uplo)
     setup_data(A);
     A.uplo( uplo );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -556,8 +554,7 @@ void test_synorm_offdiag_dev(Norm norm)
     slate::Tile<double> A(m, n, Adata, lda, -1, slate::TileKind::UserOwned);
     setup_data(A);
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -802,8 +799,7 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
     setup_data(A);
     A.uplo( uplo );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -185,6 +185,7 @@ void test_genorm_dev(Norm norm)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -209,6 +210,7 @@ void test_genorm_dev(Norm norm)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {
@@ -406,6 +408,7 @@ void test_synorm_dev(Norm norm, Uplo uplo)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -428,6 +431,7 @@ void test_synorm_dev(Norm norm, Uplo uplo)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -574,6 +578,7 @@ void test_synorm_offdiag_dev(Norm norm)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     int ldv = n + m;
     std::vector<double> values( ldv );
@@ -590,6 +595,7 @@ void test_synorm_offdiag_dev(Norm norm)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -820,6 +826,7 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
                         batch_count,
                         blas::MemcpyKind::HostToDevice,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -844,6 +851,7 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // blas::device_memcpy does not sync by default
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {

--- a/unit_test/unit_test.cc
+++ b/unit_test/unit_test.cc
@@ -142,10 +142,10 @@ void printf_gather(int root, MPI_Comm comm, const std::string& str)
                 // todo: guard against buffer overflow
                 assert(bufsize < int(sizeof(buf)));
                 MPI_Recv(buf, bufsize, MPI_CHAR, rank, 0, comm, &status);
-                printf(buf);
+                printf("%s", buf);
             }
             else {
-                printf(str.c_str());
+                printf("%s", str.c_str());
             }
         }
     }
@@ -174,35 +174,35 @@ void printf_gather(int root, MPI_Comm comm, const char* format, ...)
 /// Catches and reports all exceptions.
 void run_test(test_function* func, const char* name)
 {
-    printf(output_test(name).c_str());
+    printf("%s", output_test(name).c_str());
     fflush(stdout);
     ++g_total;
 
     try {
         // run function
         func();
-        printf(output_pass().c_str());
+        printf("%s", output_pass().c_str());
         ++g_pass;
     }
     catch (SkipException& e) {
-        printf(output_skip(e).c_str());
+        printf("%s", output_skip(e).c_str());
         --g_total;
         ++g_skip;
     }
     catch (AssertError& e) {
-        printf(output_fail(e).c_str());
+        printf("%s", output_fail(e).c_str());
         ++g_fail;
     }
     catch (std::exception& e) {
         AssertError err("unexpected exception: " + std::string(e.what()),
                         __FILE__, __LINE__);
-        printf(output_fail(err).c_str());
+        printf("%s", output_fail(err).c_str());
         ++g_fail;
     }
     catch (...) {
         AssertError err("unexpected exception: (unknown type)",
                         __FILE__, __LINE__);
-        printf(output_fail(err).c_str());
+        printf("%s", output_fail(err).c_str());
         ++g_fail;
     }
 }

--- a/unit_test/unit_test.hh
+++ b/unit_test/unit_test.hh
@@ -198,7 +198,7 @@ void run_test(test_tpl_function<scalar_t> func, const char* name)
     try {
         // run function
         func();
-        printf( output_pass().c_str() );
+        printf( "%s", output_pass().c_str() );
         ++g_pass;
     }
     catch (SkipException& e) {

--- a/unit_test/unit_test.hh
+++ b/unit_test/unit_test.hh
@@ -190,7 +190,7 @@ std::string output_skip(SkipException& e);
 template <typename scalar_t>
 void run_test(test_tpl_function<scalar_t> func, const char* name)
 {
-    printf( output_test(
+    printf( "%s", output_test(
           std::string( name ) + " - " + type_name<scalar_t>() ).c_str() );
     fflush( stdout );
     ++g_total;
@@ -202,24 +202,24 @@ void run_test(test_tpl_function<scalar_t> func, const char* name)
         ++g_pass;
     }
     catch (SkipException& e) {
-        printf( output_skip(e).c_str() );
+        printf( "%s", output_skip(e).c_str() );
         --g_total;
         ++g_skip;
     }
     catch (AssertError& e) {
-        printf( output_fail(e).c_str() );
+        printf( "%s", output_fail(e).c_str() );
         ++g_fail;
     }
     catch (std::exception& e) {
         AssertError err( "unexpected exception: " + std::string( e.what() ),
                         __FILE__, __LINE__ );
-        printf( output_fail( err ).c_str() );
+        printf( "%s", output_fail( err ).c_str() );
         ++g_fail;
     }
     catch (...) {
         AssertError err( "unexpected exception: (unknown type)",
                         __FILE__, __LINE__ );
-        printf( output_fail( err ).c_str() );
+        printf( "%s", output_fail( err ).c_str() );
         ++g_fail;
     }
 }


### PR DESCRIPTION
Add initial support for SYCL, OneMKL and SLATE using internal src/omptarget kernel routines. 
Currently unit testing has a few problems.
```
qsub -t 30 -n 1 -q arcticus -I
cd slate-dev/unit_test
env OMP_NUM_THREADS=5 ./run_tests.py
3 unit tests FAILED: test_Tile_kernels, test_geset, test_norm

./test_Tile_kernels
rank  0, device_convert_layout                              FAILED:
    Adata[ j + i*Adata_lda + k*lda*n ] == Bdata[ i + j*lda + k*lda*n ] at unit_test/test_Tile_kernels.cc:1181

 ./test_geset
geset_batch_dev - float                                     FAILED:
    result < 3*eps at unit_test/test_geset.cc:285
geset_batch_dev - double                                    FAILED:
    result < 3*eps at unit_test/test_geset.cc:285

 ./test_norm
 synorm_dev( fro, lower )                                    FAILED:
    error < 5*eps at unit_test/test_norm.cc:481
```

The general tests using 2 nodes with 2 GPUs per node
```
qsub -t 30 -n 2 -q arcticus -I
cd slate-dev/test/
env OMP_NUM_THREADS=5 ./run_tests.py --small --target d gemm
SLATE version 2022.07.00, id 7cdb276e
2023-02-02 19:22:09, MPI size 1, OpenMP threads 5, GPU devices available 2
All tests passed: gemm
env OMP_NUM_THREADS=5 ./run_tests.py --small --target d potrf
All tests passed: potrf
./run_tests.py --small --target d getrf
All tests passed: getrf

Generate a few small test commands using:
env OMP_NUM_THREADS=56 ./run_tests.py -t "mpirun -n 2 ./tester " --target d --check y --dim 4000,10000:40000:10000 --nb 832 --origin s --type s --transA n --transB n  --kl 20 --ku 20 --dry-run
This small vesion of the tests passed for: 
gbmm gemmA hemm potrf getrf potrs add tzadd scale set genorm
henorm  (small numerical error) synorm synorm
2 tests FAILED: copy
2 tests FAILED: geqrf
Other routines were not yet run through testing.
```