### PR TITLE
Install pkg-config, update examples and add as smoke test

### DIFF
--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -34,8 +34,6 @@ shopt -s expand_aliases
 
 
 print "======================================== Load compiler"
-quiet module avail
-
 quiet module load gcc@7.3.0
 quiet which g++
 g++ --version

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -16,6 +16,7 @@ export ROCR_VISIBLE_DEVICES=0
 
 print "======================================== Unit tests"
 cd unit_test
+
 ./run_tests.py --timeout 300 --xml ${top}/report-unit-${maker}.xml
 (( err += $? ))
 
@@ -41,6 +42,24 @@ fi
 ./run_tests.py --timeout 1200 --origin ${origin} --target ${target} --quick \
                --xml ${top}/report-${maker}.xml ${tests}
 (( err += $? ))
+
+print "======================================== Smoke tests"
+cd ${top}/examples
+
+if [ "${maker}" = "make" ]; then
+    export PKG_CONFIG_PATH=${top}/install/lib/pkgconfig
+    make clean
+    make -j8 || exit 20
+    ./run_tests.py
+    (( err += $? ))
+fi
+if [ "${maker}" = "cmake" ]; then
+    rm -rf build && mkdir build && cd build
+    cmake "-DCMAKE_PREFIX_PATH=${top}/install" ..
+    make -j8 || exit 21
+    make test
+    (( err += $? ))
+fi
 
 print "======================================== Check HIP files are up-to-date"
 if [ "${maker}" = "make" ]; then

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -47,16 +47,16 @@ print "======================================== Smoke tests"
 cd ${top}/examples
 
 if [ "${maker}" = "make" ]; then
-    export PKG_CONFIG_PATH=${top}/install/lib/pkgconfig
-    make clean
-    make -j8 || exit 20
+    export PKG_CONFIG_PATH+=:${top}/install/lib/pkgconfig
+    make clean || exit 20
+    make -j8   || exit 21
     ./run_tests.py
     (( err += $? ))
-fi
-if [ "${maker}" = "cmake" ]; then
+
+elif [ "${maker}" = "cmake" ]; then
     rm -rf build && mkdir build && cd build
-    cmake "-DCMAKE_PREFIX_PATH=${top}/install" ..
-    make -j8 || exit 21
+    cmake "-DCMAKE_PREFIX_PATH=${top}/install" .. || exit 22
+    make -j8 || exit 23
     make test
     (( err += $? ))
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option( use_mpi "Use MPI, if available" true )
 option( use_openmp "Use OpenMP, if available" true )
 option( c_api "Build C API" false )
 # todo: option( fortran_api "Build Fortran API. Requires C API." false )
+option( gpu_aware_mpi "Whether MPI can transfer from GPU memory" false )
 
 set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
@@ -339,6 +340,10 @@ if (MPI_FOUND)
     message( DEBUG "mpi_cxx_defines = '${mpi_cxx_defines}'" )
     set_target_properties( MPI::MPI_CXX PROPERTIES INTERFACE_COMPILE_OPTIONS
                            "${mpi_cxx_defines}" )
+
+    if (gpu_aware_mpi)
+        target_compile_definitions( slate PUBLIC "-DSLATE_HAVE_GPU_AWARE_MPI" )
+    endif()
 else()
     message( STATUS "No MPI support in SLATE" )
     target_sources(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,19 +56,6 @@ set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
               auto cuda hip none )
 
-set( use_cuda "" CACHE STRING "Use CUDA, if available [deprecated: use gpu_backend]" )
-set( use_hip  "" CACHE STRING "Use HIP, if available [deprecated: use gpu_backend]" )
-
-if (use_cuda)
-    message( DEPRECATION "WARNING: Variable `use_cuda=$(use_cuda)` is deprecated; setting `gpu_backend = cuda`" )
-    set( gpu_backend "cuda" CACHE STRING "" )
-endif()
-
-if (use_hip)
-    message( DEPRECATION "WARNING: Variable `use_hip=$(use_hip)` is deprecated; setting `gpu_backend = hip`" )
-    set( gpu_backend "hip" CACHE STRING "" )
-endif()
-
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
     AND slate_is_project)
@@ -132,8 +119,6 @@ BUILD_SHARED_LIBS      = ${BUILD_SHARED_LIBS}
 build_tests            = ${build_tests}
 color                  = ${color}
 gpu_backend            = ${gpu_backend}
-use_cuda               = ${use_cuda}
-use_hip                = ${use_hip}
 use_mpi                = ${use_mpi}
 use_openmp             = ${use_openmp}
 c_api                  = ${c_api}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,6 +69,8 @@ md5sum          ?= tools/md5sum.pl
 
 gpu_backend     ?= auto
 
+python          ?= python3
+
 # Strip whitespace from variables, in case make.inc had trailing spaces.
 mpi             := $(strip $(mpi))
 blas            := $(strip $(blas))
@@ -866,15 +868,15 @@ docs:
 # C API
 ifeq ($(c_api),1)
     include/slate/c_api/wrappers.h: src/c_api/wrappers.cc
-		python tools/c_api/generate_wrappers.py $< $@ \
+		${python} tools/c_api/generate_wrappers.py $< $@ \
 			src/c_api/wrappers_precisions.cc
 
     include/slate/c_api/matrix.h: include/slate/Tile.hh
-		python tools/c_api/generate_matrix.py $< $@ \
+		${python} tools/c_api/generate_matrix.py $< $@ \
 			src/c_api/matrix.cc
 
     include/slate/c_api/util.hh: include/slate/c_api/types.h
-		python tools/c_api/generate_util.py $< $@ \
+		${python} tools/c_api/generate_util.py $< $@ \
 			src/c_api/util.cc
 
     src/c_api/wrappers_precisions.cc: include/slate/c_api/wrappers.h
@@ -893,7 +895,7 @@ ifeq ($(fortran_api),1)
     src/fortran/slate_module.f90: include/slate/c_api/wrappers.h \
                                   include/slate/c_api/types.h \
                                   include/slate/c_api/matrix.h
-		python tools/fortran/generate_fortran_module.py $^ --output $@
+		${python} tools/fortran/generate_fortran_module.py $^ --output $@
 
     generate: src/fortran/slate_module.f90
 endif
@@ -995,8 +997,8 @@ test/check: check
 unit_test/check: check
 
 check: test unit_test
-	cd test; python run_tests.py --quick gesv posv gels heev gesvd
-	cd unit_test; python run_tests.py
+	cd test; ${python} run_tests.py --quick gesv posv gels heev gesvd
+	cd unit_test; ${python} run_tests.py
 
 #-------------------------------------------------------------------------------
 # unit testers

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,6 +68,7 @@ hipify          ?= hipify-perl
 md5sum          ?= tools/md5sum.pl
 
 gpu_backend     ?= auto
+gpu_aware_mpi   ?= 0
 
 python          ?= python3
 
@@ -196,6 +197,10 @@ else
     FLAGS += -DSLATE_NO_MPI
     libslate_src += src/stubs/mpi_stubs.cc
     fortran_api = 0
+endif
+
+ifeq (${gpu_aware_mpi},1)
+    FLAGS += -DSLATE_HAVE_GPU_AWARE_MPI
 endif
 
 #-------------------------------------------------------------------------------

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -379,7 +379,7 @@ ifeq ($(hip),1)
     # Generate hipcc target options for all gfx in hip_arch_.
     amdgpu_targets = $(foreach arch, $(gfx),--amdgpu-target=$(arch))
     HIPCCFLAGS += $(amdgpu_targets)
-    FLAGS += -D__HIP_PLATFORM_HCC__
+    FLAGS += -D__HIP_PLATFORM_AMD__
     LIBS += -L$(ROCM_DIR)/lib -lrocsolver -lrocblas -lamdhip64
 
     # ROCm 4.0 has errors in its headers that produce excessive warnings.
@@ -1354,6 +1354,9 @@ echo:
 	@echo "---------- C++ compiler"
 	@echo "CXX           = $(CXX)"
 	@echo "CXXFLAGS      = $(CXXFLAGS)"
+	@echo "CXXFLAGS_clean= $(CXXFLAGS_clean)"
+	@echo "CPPFLAGS      = $(CPPFLAGS)"
+	@echo "CPPFLAGS_clean= $(CPPFLAGS_clean)"
 	@echo
 	@echo "---------- CUDA options"
 	@echo "cuda          = '$(cuda)'"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -128,9 +128,14 @@ ifneq ($(cuda),1)
 endif
 
 omptarget = 0
-ifneq ($(filter auto onemkl, $(gpu_backend)),)
-    # enable the omptarget offload kernels in SLATE
-    omptarget = 1
+ifneq ($(cuda),1)
+ifneq ($(hip),1)
+    ifeq (${gpu_backend},onemkl)
+        # enable the omptarget offload kernels in SLATE
+        $(info Note: enabling onemkl)
+        omptarget = 1
+    endif
+endif
 endif
 
 # Default LD=ld won't work; use CXX. Can override in make.inc or environment.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1351,6 +1351,11 @@ echo:
 	@echo "hip_hdr       = ${hip_hdr}"
 	@echo "md5_files     = $(md5_files)"
 	@echo
+	@echo "---------- oneMKL options"
+	@echo "omptarget     = '${omptarget}'"
+	@echo "omptarget_src = ${omptarget_src}"
+	@echo "omptarget_hdr = ${omptarget_hdr}"
+	@echo
 	@echo "---------- Fortran compiler"
 	@echo "FC            = $(FC)"
 	@echo "FCFLAGS       = $(FCFLAGS)"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -169,7 +169,7 @@ SLATE specific options include:
 With Makefile, options are specified as environment variables or on the
 command line using `option=value` syntax, such as:
 
-    python configure.py blas=mkl
+    python3 configure.py blas=mkl
 
 With CMake, options are specified on the command line using
 `-Doption=value` syntax (not as environment variables), such as:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,8 +99,8 @@ for its options, which include:
     blas_threaded
         Whether to search for multi-threaded or sequential BLAS.
         Currently applies to Intel MKL and IBM ESSL. One of:
-        1               multi-threaded BLAS
-        0               sequential BLAS (default in SLATE)
+        1 (yes)         multi-threaded BLAS
+        0 (no)          sequential BLAS (default in SLATE)
 
     blas_fortran
         Fortran interface to use. Currently applies only to Intel MKL.
@@ -127,6 +127,15 @@ for its options, which include:
         cuda            build with CUDA support
         hip             build with HIP/ROCm support
         none            do not build with GPU backend
+
+    gpu_aware_mpi
+        Whether MPI can transfer directly from GPU memory. Often this has
+        additional runtime requirements, such as
+        using `jsrun --smpiargs="-gpu"` on Summit,
+        or setting `export MPICH_GPU_SUPPORT_ENABLED=1` on Frontier;
+        see your platform's documentation.
+        1 (yes)         enable transfers from GPU memory
+        0 (no)          transfer only from CPU memory (default)
 
     color
         Whether to use ANSI colors in output. One of:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -305,9 +305,6 @@ installed versions, it will use those instead of compiling new versions.
 Besides the Environment variables and Options listed above, additional
 options include:
 
-    use_cuda [deprecated; use gpu_backend]
-    use_hip  [deprecated; use gpu_backend]
-
     CMAKE_CUDA_ARCHITECTURES
         CUDA architectures, as semi-colon delimited list of 2-digit numbers.
         Each number can take optional `-real` or `-virtual` suffix.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,11 +39,11 @@ set(
     ex05_blas.cc
     ex06_linear_system_lu.cc
     ex07_linear_system_cholesky.cc
-    ex08_linear_system_indefinite.cc
+    # ex08_linear_system_indefinite.cc      # failing
     ex09_least_squares.cc
     ex10_svd.cc
-    ex11_hermitian_eig.cc
-    ex12_generalized_hermitian_eig.cc
+    # ex11_hermitian_eig.cc                 # failing
+    # ex12_generalized_hermitian_eig.cc     # failing
     ex13_non_uniform_block_size.cc
 )
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,99 +1,25 @@
-# Assumes BLAS++ and LAPACK++ are installed in SLATE directory.
-# Otherwise would need to add
-#   -I${blaspp_dir}/include -I${lapackpp_dir}/include to CXXFLAGS,
-#   -L${blaspp_dir}/lib -L${lapackpp_dir}/lib and corresponding rpaths to LDFLAGS.
-#
-# Assumes everything built as shared libraries, so transitive dependencies
-# are handled implicitly. That is, linking with -lslate implicitly links with
-# -lblaspp -llapackpp -lopenblas.
-# Substitute your choice of BLAS/LAPACK library for -lopenblas.
+# Queries pkg-config for all libraries to link with.
+# User should not generally need to put anything in make.inc.
+# LIBS can be used if something like -lgfortran is missing.
 
 -include make.inc
 
-slate_dir      ?= ../install
-
-# CXXFLAGS add /opt/slate/include to include path.
-# LDFLAGS  add /opt/slate/lib     to lib path.
-# Using -rpath avoids need to add ${slate_dir}/lib to $LD_LIBRARY_PATH.
-CXX      = mpicxx
-CXXFLAGS = -fopenmp -Wall -std=c++17 -MMD -I${slate_dir}/include
-LDFLAGS  = -fopenmp -L${slate_dir}/lib -Wl,-rpath,${slate_dir}/lib
-LIBS     = -llapackpp -lblaspp
-
-# auto-detect OS
-# $OSTYPE may not be exported from the shell, so echo it
-ostype := $(shell echo $${OSTYPE})
-ifneq ($(findstring darwin, $(ostype)),)
-    # MacOS is darwin
-    macos = 1
-    LDD = otool -L
-else
-    LDD = ldd
+pkg_exists := ${shell pkg-config --exists slate; echo $$?}
+ifneq (${pkg_exists},0)
+    ${error pkg-config could not find slate. Install SLATE, then add /prefix/lib/pkgconfig with your prefix to $$PKG_CONFIG_PATH.}
 endif
 
-#-------------------------------------------------------------------------------
-# BLAS and LAPACK
-
-ifeq ($(blas),mkl)
-    # MKL on MacOS doesn't include ScaLAPACK; use default.
-    # For others, link with appropriate version of ScaLAPACK and BLACS.
-    ifneq ($(macos),1)
-        ifeq ($(mkl_blacs),openmpi)
-            ifeq ($(blas_int),int64)
-                scalapack_libs ?= -lmkl_scalapack_ilp64 -lmkl_blacs_openmpi_ilp64
-            else
-                scalapack_libs ?= -lmkl_scalapack_lp64 -lmkl_blacs_openmpi_lp64
-            endif
-        else
-            ifeq ($(blas_int),int64)
-                scalapack_libs ?= -lmkl_scalapack_ilp64 -lmkl_blacs_intelmpi_ilp64
-            else
-                scalapack_libs ?= -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64
-            endif
-        endif
-    endif
-else ifeq ($(blas),essl)
-    # IBM ESSL
-    # todo threaded, int64
-    # hmm... likely LAPACK won't be int64 even if ESSL is.
-    LIBS += -lessl -llapack
-else ifeq ($(blas),openblas)
-    # OpenBLAS
-    LIBS += -lopenblas
-else ifeq ($(blas),libsci)
-    # Cray LibSci
-    # no LIBS to add
-    scalapack_libs ?=
-else
-    $(error ERROR: unknown `blas=$(blas)`. Set blas to one of mkl, essl, openblas, libsci.)
-endif
-
-#-------------------------------------------------------------------------------
-# Check if SLATE was compiled with cublas. If so, explicitly link cublas
-# since it is called in the SLATE headers.
-# todo: is this still needed?
-
-grep_cuda := ${shell ${LDD} ${slate_dir}/lib/libslate.so | grep cublas}
-ifeq (${grep_cuda},)
-    ${info SLATE was compiled without CUDA}
-    ${info}
-else
-    cuda_nvcc := ${shell which nvcc}
-    CUDA_ROOT ?= $(cuda_nvcc:/bin/nvcc=)
-    ${info SLATE with CUDA ${CUDA_ROOT}}
-    ifeq (${cuda_nvcc},)
-        ${error SLATE was compiled with CUDA, but cannot find nvcc.}
-    endif
-
-    CXXFLAGS += -I${CUDA_ROOT}/include
-    LDFLAGS  += -L${CUDA_ROOT}/lib -Wl,-rpath,${CUDA_ROOT}/lib
-    LIBS     += -lcusolver -lcublas -lcudart
-endif
+CXX            = ${shell pkg-config --variable=CXX       slate}
+CXXFLAGS      += ${shell pkg-config --cflags             slate}
+LDFLAGS       += ${shell pkg-config --libs-only-L        slate}
+LDFLAGS       += ${shell pkg-config --libs-only-other    slate}
+slate_libs     = ${shell pkg-config --libs-only-l        slate}
+scalapack_libs = ${shell pkg-config --variable=scalapack slate}
 
 #-------------------------------------------------------------------------------
 # ScaLAPACK examples
 # Link with -lslate_scalapack_api -lscalapack.
-# Implicitly links with -lslate -lblaspp -llapackpp -lopenblas.
+# Implicitly links with -lslate -lblaspp -llapackpp and your BLAS library.
 
 scalapack_src = ${wildcard *scalapack*.cc}
 scalapack_exe = ${basename ${scalapack_src}}
@@ -104,36 +30,25 @@ scalapack: ${scalapack_exe}
 
 ${scalapack_exe}: %: %.o
 	${CXX} -o $@ $^ \
-		${LDFLAGS} \
-		-lslate_scalapack_api ${LIBS} \
-		${scalapack_libs}
-
-run_scalapack:
-	${MAKE} -j1 run_scalapack_serial
-
-run_scalapack_serial: ${scalapack_txt}
+		${LDFLAGS} -lslate_scalapack_api ${scalapack_libs} ${LIBS}
 
 #-------------------------------------------------------------------------------
 # SLATE examples
-# Link with -lslate.
-# Implicitly links with -lblaspp -llapackpp -lopenblas.
+# Link with -lslate -llapackpp -lblaspp.
+# Implicitly links with your BLAS library.
 
 slate_src = ${filter-out ${scalapack_src}, ${wildcard *.cc}}
 slate_exe = ${basename ${slate_src}}
-slate_txt = ${addsuffix .txt, ${slate_exe}}
 exe += ${slate_exe}
 
 slate: ${slate_exe}
 
 ${slate_exe}: %: %.o
 	${CXX} -o $@ $^ \
-		${LDFLAGS} \
-		-lslate ${LIBS}
+		${LDFLAGS} ${slate_libs} ${LIBS}
 
-run:
-	${MAKE} -j1 run_serial
-
-run_serial: ${slate_txt}
+check: ${exe}
+	./run_tests.py
 
 #-------------------------------------------------------------------------------
 # Generic rules.
@@ -153,40 +68,24 @@ clean_exe:
 	-rm -f ${exe}
 
 distclean: clean
-	-rm -f ${slate_txt} ${scalapack_txt}
 
 -include *.d
-
-#-------------------------------------------------------------------------------
-# Run examples.
-# Ignore errors. pipe to sort also has the side-effect of ignoring errors.
-%.txt: %
-	-mpirun -np 4 ./$< | sort -s -k 2n > $@
 
 #-------------------------------------------------------------------------------
 # Debugging
 
 echo:
-	@echo "CXX       = ${CXX}"
-	@echo "CXXFLAGS  = ${CXXFLAGS}"
-	@echo "LDFLAGS   = ${LDFLAGS}"
-	@echo "LIBS      = ${LIBS}"
-	@echo "LDD       = ${LDD}"
-	@echo
-	@echo "macos     = ${macos}"
-	@echo "grep_cuda = ${grep_cuda}"
-	@echo "cuda_nvcc = ${cuda_nvcc}"
-	@echo "CUDA_ROOT = ${CUDA_ROOT}"
-	@echo
-	@echo "slate_dir      = ${slate_dir}"
+	@echo "CXX            = ${CXX}"
+	@echo "CXXFLAGS       = ${CXXFLAGS}"
+	@echo "LDFLAGS        = ${LDFLAGS}"
+	@echo "LIBS           = ${LIBS}"
+	@echo "slate_libs     = ${slate_libs}"
 	@echo "scalapack_libs = ${scalapack_libs}"
 	@echo
 	@echo "slate_src      = ${slate_src}"
 	@echo "slate_exe      = ${slate_exe}"
-	@echo "slate_exe      = ${slate_exe}"
 	@echo
 	@echo "scalapack_src  = ${scalapack_src}"
-	@echo "scalapack_exe  = ${scalapack_exe}"
 	@echo "scalapack_exe  = ${scalapack_exe}"
 	@echo
 	@echo "exe            = ${exe}"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,20 +17,21 @@ slate_libs     = ${shell pkg-config --libs-only-l        slate}
 scalapack_libs = ${shell pkg-config --variable=scalapack slate}
 
 #-------------------------------------------------------------------------------
-# ScaLAPACK examples
-# Link with -lslate_scalapack_api -lscalapack.
-# Implicitly links with -lslate -lblaspp -llapackpp and your BLAS library.
+# SLATE's ScaLAPACK API example
+# Link with -lslate_scalapack_api -lscalapack -lslate -lblaspp -llapackpp.
+# If RUNPATH was set on libslate_scalapack_api.so when it was installed,
+# here we could implicitly link with -lslate -lblaspp -llapackpp.
+# Implicitly links with your BLAS library.
 
 scalapack_src = ${wildcard *scalapack*.cc}
 scalapack_exe = ${basename ${scalapack_src}}
-scalapack_txt = ${addsuffix .txt, ${scalapack_exe}}
 exe += ${scalapack_exe}
 
 scalapack: ${scalapack_exe}
 
 ${scalapack_exe}: %: %.o
 	${CXX} -o $@ $^ \
-		${LDFLAGS} -lslate_scalapack_api ${scalapack_libs} ${LIBS}
+		${LDFLAGS} -lslate_scalapack_api ${slate_libs} ${scalapack_libs} ${LIBS}
 
 #-------------------------------------------------------------------------------
 # SLATE examples
@@ -62,10 +63,10 @@ all: ${exe}
 	${CXX} ${CXXFLAGS} -c -o $@ $<
 
 clean:
-	-rm -f ${exe} *.o *.d
+	${RM} ${exe} *.o *.d
 
 clean_exe:
-	-rm -f ${exe}
+	${RM} ${exe}
 
 distclean: clean
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ These are designed as minimal, standalone examples to demonstrate
 how to include, call, and link with SLATE.
 
 These examples are used in the
-[SLATE tutorial presentation](https://bitbucket.org/icl/slate/downloads/slate-tutorial.pdf)
+[SLATE tutorial presentation](https://bitbucket.org/icl/slate/downloads/2023-02-ecp-slate-tutorial.pdf)
 
 These examples are also referenced in the
 [SLATE Users' Guide]((https://www.icl.utk.edu/publications/swan-010)
@@ -14,54 +14,34 @@ For compiling, there are two options:
 
 ## Option 1: Makefile
 
-Build & install SLATE (see slate/INSTALL.md):
+Build & install SLATE (see slate/INSTALL.md).
+This installs it into a sub-directory of the SLATE source.
 
     slate>  make
-    slate>  make install prefix=${cwd}/install
+    slate>  make install prefix=install
+    slate>  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:`pwd`/install
 
 Build examples:
 
     slate>  cd examples
     slate/examples>  make
-    slate/examples>  make run
-    slate/examples>  make run_scalapack
+    slate/examples>  make check
 
 Installation puts the SLATE, BLAS++, and LAPACK++ headers all in the
 same include directory, and libraries all in the same lib directory,
-which simplifies compiling the examples. The above installs it in a
-subdirectory of the slate source.
+which simplifies compiling the examples. The Makefile queries pkg-config
+for all settings.
 
-If needed, in the examples directory you can create a `make.inc` file
-that sets `slate_dir` to where SLATE was installed; it is set to
-`../install` by default to match the directions above. The scalapack
-example also needs `scalapack_libs` set to your system's ScaLAPACK
-libraries. For instance:
-
-    # make.inc file
-    slate_dir = /path/to/slate
-    scalapack_libs = -L/path/to/scalapack -lscalapack -lgfortran
-
-With Intel MKL, `scalapack_libs` should be some variant of this:
-
-    scalapack_libs = -L${MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64
-
-depending on your MPI library (Intel MPI or Open MPI). Normally use the
-`lp64` variants, unless `blas_int = int64` when SLATE was compiled, then
-use the `ilp64` variants.
-
-The examples Makefile detects whether SLATE was compiled with CUDA or
-not, and links with CUDA if needed.
-
-You may need to change the CXX compiler in the Makefile. It is set to `mpicxx`.
+todo: update the C and Fortran API examples.
 
 Examples of SLATE's C and Fortran APIs are in the c_api and fortran
-directories. They use the same `make.inc` file and can be compiled
-similarly.
+directories.
 
 
 ## Option 2: CMake
 
-Build & install SLATE (see slate/INSTALL.md):
+Build & install SLATE (see slate/INSTALL.md).
+This installs it into a sub-directory of the SLATE source.
 
     slate>  mkdir build && cd build
     slate/build>  cmake -DCMAKE_INSTALL_PREFIX=../install ..
@@ -72,15 +52,15 @@ Build examples:
 
     slate/build>  cd ../examples
     slate/examples>  mkdir build && cd build
-    slate/examples/build>  cmake -DCMAKE_PREFIX_PATH=${cwd}/../../install ..
+    slate/examples/build>  cmake -DCMAKE_PREFIX_PATH=`pwd`/../../install ..
     slate/examples/build>  make
     slate/examples/build>  make test
 
 CTest output is in `Testing/Temporary/LastTest.log`.
 
 CMake needs to find the SLATE, BLAS++, and LAPACK++ installations by
-setting the `CMAKE_PREFIX_PATH` to the absolute path to install
-directory. The above installs it in a subdirectory of the slate source.
+setting the `CMAKE_PREFIX_PATH` to the absolute path to the install
+directory.
 
 todo: The scalapack example is not yet done in CMake.
 

--- a/examples/ex01_matrix.cc
+++ b/examples/ex01_matrix.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
@@ -13,9 +15,9 @@ void test_matrix()
 {
     print_func( mpi_rank );
 
-    int64_t m=2000, n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<scalar_type> A( m, n, nb, p, q, MPI_COMM_WORLD );
+    int64_t m=2000, n=1000, nb=256;
+
+    slate::Matrix<scalar_type> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     for (int64_t j = 0; j < A.nt(); ++j) {
         for (int64_t i = 0; i < A.mt(); ++i) {
@@ -31,26 +33,23 @@ void test_matrix()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    printf( "argc %d\n", argc );
-    for (int i = 0; i < argc; ++i) {
-        printf( "argv: '%s'\n", argv[i] );
-    }
-    printf( "\n" );
-
     int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -60,6 +59,8 @@ int main( int argc, char** argv )
     test_matrix< std::complex<float> >();
     test_matrix< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex02_conversion.cc
+++ b/examples/ex02_conversion.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
@@ -13,10 +15,10 @@ void test_conversion()
 {
     print_func( mpi_rank );
 
-    int64_t m=2000, n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nb=256;
+
     slate::Matrix<scalar_type>
-        A( m, n, nb, p, q, MPI_COMM_WORLD );
+        A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
 
     // triangular and symmetric matrices must be square -- take square slice.
     auto A_square = A.slice( 0, n-1, 0, n-1 );
@@ -41,15 +43,18 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -59,6 +64,8 @@ int main( int argc, char** argv )
     test_conversion< std::complex<float> >();
     test_conversion< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex03_submatrix.cc
+++ b/examples/ex03_submatrix.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 // -----------------------------------------------------------------------------
 template <typename scalar_type>
@@ -15,10 +17,10 @@ void test_submatrix()
 
     print_func( mpi_rank );
 
-    int64_t m=2000, n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nb=256;
+
     slate::Matrix<scalar_type>
-        A( m, n, nb, p, q, MPI_COMM_WORLD );
+        A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     printf( "rank %d: A mt=%lld, nt=%lld, m=%lld, n=%lld\n",
             mpi_rank, llong(A.mt()), llong(A.nt()), llong(A.m()), llong(A.n()) );
 
@@ -68,21 +70,26 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
 
     test_submatrix< float >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex05_blas.cc
+++ b/examples/ex05_blas.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
@@ -14,11 +16,11 @@ void test_gemm()
     print_func( mpi_rank );
 
     double alpha = 2.0, beta = 1.0;
-    int64_t m=2000, n=1000, k=500, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<double> A( m, k, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B( k, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> C( m, n, nb, p, q, MPI_COMM_WORLD );
+    int64_t m=2000, n=1000, k=500, nb=256;
+
+    slate::Matrix<double> A( m, k, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B( k, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> C( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     C.insertLocalTiles();
@@ -46,12 +48,12 @@ void test_gemm_transpose()
     print_func( mpi_rank );
 
     double alpha = 2.0, beta = 1.0;
-    int64_t m=2000, n=1000, k=500, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, k=500, nb=256;
+
     // Dimensions of X, Y, Z are backwards from A, B, C in test_gemm().
-    slate::Matrix<double> X( k, m, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> Y( n, k, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> Z( m, n, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<double> X( k, m, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> Y( n, k, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> Z( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     X.insertLocalTiles();
     Y.insertLocalTiles();
     Z.insertLocalTiles();
@@ -79,14 +81,14 @@ void test_symm()
     print_func( mpi_rank );
 
     double alpha = 2.0, beta = 1.0;
-    int64_t m=2000, n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nb=256;
+
     slate::SymmetricMatrix<double>
-        A( slate::Uplo::Lower, m, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B1( m, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B2( n, m, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> C1( m, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> C2( n, m, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, m, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B1( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B2( n, m, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> C1( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> C2( n, m, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B1.insertLocalTiles();
     B2.insertLocalTiles();
@@ -118,12 +120,12 @@ void test_syrk_syr2k()
     print_func( mpi_rank );
 
     double alpha = 2.0, beta = 1.0;
-    int64_t n=1000, k=500, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<double> A( n, k, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B( n, k, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, k=500, nb=256;
+
+    slate::Matrix<double> A( n, k, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B( n, k, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::SymmetricMatrix<double>
-        C( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
+        C( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     C.insertLocalTiles();
@@ -149,12 +151,13 @@ void test_trmm_trsm()
     print_func( mpi_rank );
 
     double alpha = 2.0;
-    int64_t m=2000, n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nb=256;
+
     slate::TriangularMatrix<double>
-        A( slate::Uplo::Lower, slate::Diag::NonUnit, m, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B1( m, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B2( n, m, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, slate::Diag::NonUnit, m, nb,
+           grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B1( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B2( n, m, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B1.insertLocalTiles();
     B2.insertLocalTiles();
@@ -193,15 +196,18 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -231,6 +237,8 @@ int main( int argc, char** argv )
     test_trmm_trsm< std::complex<float> >();
     test_trmm_trsm< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex06_linear_system_lu.cc
+++ b/examples/ex06_linear_system_lu.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
@@ -13,10 +15,10 @@ void test_lu()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<scalar_type> A( n, n,    nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, nrhs=100, nb=256;
+
+    slate::Matrix<scalar_type> A( n, n,    nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     random_matrix( A );
@@ -36,11 +38,11 @@ void test_lu_mixed()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<scalar_type> A( n, n,    nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> X( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, nrhs=100, nb=256;
+
+    slate::Matrix<scalar_type> A( n, n,    nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> X( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     X.insertLocalTiles();
@@ -66,10 +68,10 @@ void test_lu_factor()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<scalar_type> A( n, n,    nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, nrhs=100, nb=256;
+
+    slate::Matrix<scalar_type> A( n, n,    nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     random_matrix( A );
@@ -91,9 +93,9 @@ void test_lu_inverse()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::Matrix<scalar_type> A( n, n, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, nb=256;
+
+    slate::Matrix<scalar_type> A( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     random_matrix( A );
     slate::Pivots pivots;
@@ -115,15 +117,18 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -146,6 +151,8 @@ int main( int argc, char** argv )
     test_lu_inverse< std::complex<float> >();
     test_lu_inverse< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex07_linear_system_cholesky.cc
+++ b/examples/ex07_linear_system_cholesky.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
@@ -13,11 +15,11 @@ void test_cholesky()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t n=1000, nrhs=100, nb=256;
+
     slate::HermitianMatrix<scalar_type>
-        A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     random_matrix_diag_dominant( A );
@@ -34,12 +36,12 @@ void test_cholesky_mixed()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t n=1000, nrhs=100, nb=256;
+
     slate::HermitianMatrix<scalar_type>
-        A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> X( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> X( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     X.insertLocalTiles();
@@ -63,11 +65,11 @@ void test_cholesky_factor()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t n=1000, nrhs=100, nb=256;
+
     slate::HermitianMatrix<scalar_type>
-        A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     random_matrix_diag_dominant( A );
@@ -88,10 +90,10 @@ void test_cholesky_inverse()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nb=256, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t n=1000, nb=256;
+
     slate::HermitianMatrix<scalar_type>
-        A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     random_matrix_diag_dominant( A );
 
@@ -112,15 +114,18 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -143,6 +148,8 @@ int main( int argc, char** argv )
     test_cholesky_inverse< std::complex<float> >();
     test_cholesky_inverse< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex08_linear_system_indefinite.cc
+++ b/examples/ex08_linear_system_indefinite.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 // TODO: failing
@@ -13,11 +15,11 @@ void test_hesv()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t n=1000, nrhs=100, nb=100;
+
     slate::HermitianMatrix<double>
-        A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     random_matrix( A );
     random_matrix( B );
@@ -28,8 +30,8 @@ void test_hesv()
     // traditional API
     // workspaces
     // todo: drop H (internal workspace)
-    slate::Matrix<double>     H( n, n, nb, p, q, MPI_COMM_WORLD );
-    slate::BandMatrix<double> T( n, n, nb, nb, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<double>     H( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::BandMatrix<double> T( n, n, nb, nb, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::Pivots pivots, pivots2;
 
     slate::hesv( A, pivots, T, pivots2, H, B );
@@ -41,19 +43,19 @@ void test_hetrf()
 {
     print_func( mpi_rank );
 
-    int64_t n=1000, nrhs=100, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t n=1000, nrhs=100, nb=100;
+
     slate::HermitianMatrix<double>
-        A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<double> B( n, nrhs, nb, p, q, MPI_COMM_WORLD );
+        A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<double> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     random_matrix( A );
     random_matrix( B );
 
     // workspaces
     // todo: drop H (internal workspace)
-    slate::Matrix<double>     H( n, n, nb, p, q, MPI_COMM_WORLD );
-    slate::BandMatrix<double> T( n, n, nb, nb, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<double>     H( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::BandMatrix<double> T( n, n, nb, nb, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::Pivots pivots, pivots2;
 
     // simplified API
@@ -73,15 +75,18 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -89,6 +94,8 @@ int main( int argc, char** argv )
     test_hesv();
     test_hetrf();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex09_least_squares.cc
+++ b/examples/ex09_least_squares.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
@@ -14,23 +16,22 @@ void test_gels_overdetermined()
     print_func( mpi_rank );
 
     // TODO: failing if m, n not divisible by nb?
-    int64_t m=2000, n=1000, nrhs=100, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nrhs=100, nb=100;
+
     int64_t max_mn = std::max( m, n );
-    slate::Matrix<scalar_type> A( m, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> BX( max_mn, nrhs, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> BX( max_mn, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     BX.insertLocalTiles();
     auto B = BX;  // == BX.slice( 0, m-1, 0, nrhs-1 );
     auto X = BX.slice( 0, n-1, 0, nrhs-1 );
     random_matrix( A );
     random_matrix( B );
-    slate::TriangularFactors<scalar_type> T;
 
     // solve AX = B, solution in X
     slate::least_squares_solve( A, BX );  // simplified API
 
-    slate::gels( A, BX );              // traditional API
+    slate::gels( A, BX );                 // traditional API
 }
 
 //------------------------------------------------------------------------------
@@ -40,24 +41,23 @@ void test_gels_underdetermined()
     print_func( mpi_rank );
 
     // TODO: failing if not divisible by nb?
-    int64_t m=2000, n=1000, nrhs=100, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nrhs=100, nb=100;
+
     int64_t max_mn = std::max( m, n );
-    slate::Matrix<scalar_type> A( m, n, nb, p, q, MPI_COMM_WORLD );
-    slate::Matrix<scalar_type> BX( max_mn, nrhs, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> BX( max_mn, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     BX.insertLocalTiles();
     auto B = BX.slice( 0, n-1, 0, nrhs-1 );
     auto X = BX;  // == BX.slice( 0, m-1, 0, nrhs-1 );
     random_matrix( A );
     random_matrix( B );
-    slate::TriangularFactors<scalar_type> T;
 
     // solve A^H X = B, solution in X
-    auto AH = conj_transpose(A);
+    auto AH = conj_transpose( A );
     slate::least_squares_solve( AH, BX );  // simplified API
 
-    slate::gels( AH, BX );              // traditional API
+    slate::gels( AH, BX );                 // traditional API
 }
 
 //------------------------------------------------------------------------------
@@ -68,15 +68,18 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -91,6 +94,8 @@ int main( int argc, char** argv )
     test_gels_underdetermined< std::complex<float> >();
     test_gels_underdetermined< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex10_svd.cc
+++ b/examples/ex10_svd.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename T>
@@ -16,10 +18,10 @@ void test_svd()
     print_func( mpi_rank );
 
     // TODO: failing if m, n not divisible by nb?
-    int64_t m=2000, n=1000, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
+    int64_t m=2000, n=1000, nb=100;
+
     int64_t min_mn = std::min( m, n );
-    slate::Matrix<T> A( m, n, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<T> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     random_matrix( A );
     std::vector<real_t> Sigma( min_mn );
@@ -34,8 +36,8 @@ void test_svd()
     // TODO: singular vectors
     // U is m x min_mn (reduced SVD) or m x m (full SVD)
     // V is min_mn x n (reduced SVD) or n x n (full SVD)
-    // slate::Matrix<T>  U( m, min_mn, nb, p, q, MPI_COMM_WORLD );
-    // slate::Matrix<T> VH( min_mn, n, nb, p, q, MPI_COMM_WORLD );
+    // slate::Matrix<T>  U( m, min_mn, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    // slate::Matrix<T> VH( min_mn, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     // U.insertLocalTiles();
     // VT.insertLocalTiles();
     // slate::svd( A, U, Sigma, VH );  // both U and V^H
@@ -51,21 +53,26 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    grid_size( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
 
     test_svd<double>();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex11_hermitian_eig.cc
+++ b/examples/ex11_hermitian_eig.cc
@@ -6,6 +6,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename T>
@@ -16,9 +18,9 @@ void test_hermitian_eig()
     print_func( mpi_rank );
 
     // TODO: failing if n not divisible by nb?
-    int64_t n=1000, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::HermitianMatrix<T> A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, nb=100;
+
+    slate::HermitianMatrix<T> A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     std::vector<real_t> Lambda( n );
 
@@ -35,7 +37,7 @@ void test_hermitian_eig()
 
     //--------------------
     // Eigenvectors
-    slate::Matrix<T> Z( n, n, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<T> Z( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     Z.insertLocalTiles();
 
     random_matrix( A );
@@ -53,15 +55,19 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    // Hermitian eig requires square MPI grid.
+    grid_size_square( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -71,6 +77,8 @@ int main( int argc, char** argv )
     test_hermitian_eig< std::complex<float> >();
     test_hermitian_eig< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/ex12_generalized_hermitian_eig.cc
+++ b/examples/ex12_generalized_hermitian_eig.cc
@@ -10,6 +10,8 @@
 
 int mpi_size = 0;
 int mpi_rank = 0;
+int grid_p = 0;
+int grid_q = 0;
 
 //------------------------------------------------------------------------------
 template <typename T>
@@ -20,10 +22,10 @@ void test_hermitian_eig()
     print_func( mpi_rank );
 
     // TODO: failing if n not divisible by nb?
-    int64_t n=1000, nb=100, p=2, q=2;
-    assert( mpi_size == p*q );
-    slate::HermitianMatrix<T> A( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
-    slate::HermitianMatrix<T> B( slate::Uplo::Lower, n, nb, p, q, MPI_COMM_WORLD );
+    int64_t n=1000, nb=100;
+
+    slate::HermitianMatrix<T> A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::HermitianMatrix<T> B( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     std::vector<real_t> Lambda( n );
@@ -54,7 +56,7 @@ void test_hermitian_eig()
 
     //--------------------
     // Eigenvectors
-    slate::Matrix<T> Z( n, n, nb, p, q, MPI_COMM_WORLD );
+    slate::Matrix<T> Z( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     Z.insertLocalTiles();
 
     random_matrix( A );
@@ -74,15 +76,19 @@ int main( int argc, char** argv )
     assert( err == 0 );
     assert( provided == MPI_THREAD_MULTIPLE );
 
-    err = MPI_Comm_size( MPI_COMM_WORLD, &mpi_size );
-    assert( err == 0 );
-    if (mpi_size != 4) {
-        printf( "Usage: mpirun -np 4 %s  # 4 ranks hard coded\n", argv[0] );
-        return -1;
-    }
+    slate_mpi_call(
+        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    err = MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank );
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+    // Determine p-by-q grid for this MPI size.
+    // Hermitian eig requires square MPI grid.
+    grid_size_square( mpi_size, &grid_p, &grid_q );
+    if (mpi_rank == 0) {
+        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                mpi_size, grid_p, grid_q );
+    }
 
     // so random_matrix is different on different ranks.
     srand( 100 * mpi_rank );
@@ -92,6 +98,8 @@ int main( int argc, char** argv )
     test_hermitian_eig< std::complex<float> >();
     test_hermitian_eig< std::complex<double> >();
 
-    err = MPI_Finalize();
-    assert( err == 0 );
+    slate_mpi_call(
+        MPI_Finalize() );
+
+    return 0;
 }

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import io
+import time
+
+timer = time.time()
+
+# ------------------------------------------------------------------------------
+# command line arguments
+parser = argparse.ArgumentParser()
+
+parser.add_argument( '--run', action='store', default='mpirun -np',
+                     help='command to run multiple tasks (i.e., processes, MPI ranks)' )
+
+parser.add_argument( '--np', action='store', default='4',
+                     help='number of MPI processes; default=%(default)s' )
+
+parser.add_argument( 'tests', nargs=argparse.REMAINDER )
+
+opts = parser.parse_args()
+
+#-------------------------------------------------------------------------------
+def run_test( cmd ):
+    print( '-' * 80 )
+    print( ' '.join( cmd ) )
+    p = subprocess.Popen( cmd, stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT )
+    p_out = io.TextIOWrapper( p.stdout, encoding='utf-8' )
+
+    # Read unbuffered ("for line in p.stdout" will buffer).
+    output = ''
+    for line in iter(p_out.readline, ''):
+        print( line, end='' )
+        output += line
+    err = p.wait()
+
+    if (err != 0):
+        print( 'FAILED, exit code', err )
+    else:
+        print( 'passed' )
+
+    print( output )
+    return err
+# end
+
+#-------------------------------------------------------------------------------
+tests = [
+    './ex01_matrix',
+    './ex02_conversion',
+    './ex03_submatrix',
+    './ex04_norm',
+    './ex05_blas',
+    './ex06_linear_system_lu',
+    './ex07_linear_system_cholesky',
+    #'./ex08_linear_system_indefinite',       # failing
+    './ex09_least_squares',
+    './ex10_svd',
+    #'./ex11_hermitian_eig',                  # failing
+    #'./ex12_generalized_hermitian_eig',      # failing
+    './ex13_non_uniform_block_size',
+    './ex14_scalapack_gemm',
+]
+
+if (opts.tests):
+    tests = opts.tests
+
+#-------------------------------------------------------------------------------
+runner = opts.run.split() + [ opts.np ]
+print( 'runner', runner )
+
+failed_tests = []
+
+for test in tests:
+    cmd = runner + test.split()
+    err = run_test( cmd )
+    if (err):
+        failed_tests.append( test )
+# end
+
+timer = time.time() - timer
+mins  = timer // 60
+secs  = timer %  60
+print( 'Elapsed %02d:%02d' % (mins, secs) )
+
+# print summary of failures
+nfailed = len( failed_tests )
+if (nfailed > 0):
+    print( str(nfailed) + ' routines FAILED:',
+               ', '.join( failed_tests ) )
+else:
+    print( 'All routines passed' )
+
+exit( nfailed )

--- a/examples/util.hh
+++ b/examples/util.hh
@@ -2,7 +2,9 @@
 #define UTIL_H
 
 #include <blas.hh>
+
 #include <stdio.h>
+#include <math.h>
 
 //------------------------------------------------------------------------------
 void print_func_( int rank, const char* func )
@@ -132,6 +134,32 @@ void print_matrix( const char* label, int m, int n, scalar_type* A, int lda )
         printf( "\n" );
     }
     printf( "];\n" );
+}
+
+//------------------------------------------------------------------------------
+/// Determine a square or short-wide p-by-q grid that is as square as
+/// possible to fit the MPI size. Worst case is p=1, q=mpi_size.
+///
+void grid_size( int mpi_size, int* p_out, int* q_out )
+{
+    int p, q;
+    for (p = int( sqrt( mpi_size ) ); p > 0; --p) {
+        q = int( mpi_size / p );
+        if (p*q == mpi_size)
+            break;
+    }
+    assert( p*q == mpi_size );
+    *p_out = p;
+    *q_out = q;
+}
+
+//------------------------------------------------------------------------------
+/// Determine a square p-by-p grid to fit the MPI size.
+///
+void grid_size_square( int mpi_size, int* p_out, int* q_out )
+{
+    *p_out = int( sqrt( mpi_size ) );
+    *q_out = *p_out;
 }
 
 //------------------------------------------------------------------------------

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2899,7 +2899,7 @@ void BaseMatrix<scalar_t>::tileGet(std::set<ij_tuple>& tile_set, int device,
                                   ? in_layoutConvert
                                   : LayoutConvert::None;
 
-    for (auto iter = tile_set.begin(); iter != tile_set.end(); iter++) {
+    for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
         int64_t i = std::get<0>(*iter);
         int64_t j = std::get<1>(*iter);
         {
@@ -2972,7 +2972,7 @@ void BaseMatrix<scalar_t>::tileGetForReading(std::set<ij_tuple>& tile_set,
 
         // find number of already existing tiles on the device
         int64_t existing_tiles = 0;
-        for (auto iter = tile_set.begin(); iter != tile_set.end(); iter++) {
+        for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
             int64_t i = std::get<0>(*iter);
             int64_t j = std::get<1>(*iter);
             existing_tiles += tileExists(i, j, device);
@@ -3075,7 +3075,7 @@ void BaseMatrix<scalar_t>::tileGetForWriting(std::set<ij_tuple>& tile_set,
 
         // find number of aready existing tiles on the device
         int64_t existing_tiles = 0;
-        for (auto iter = tile_set.begin(); iter != tile_set.end(); iter++) {
+        for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
             int64_t i = std::get<0>(*iter);
             int64_t j = std::get<1>(*iter);
             existing_tiles += tileExists(i, j, device);
@@ -3146,7 +3146,7 @@ void BaseMatrix<scalar_t>::tileGetAndHold(std::set<ij_tuple>& tile_set, int devi
 
         // find number of aready existing tiles on the device
         int64_t existing_tiles = 0;
-        for (auto iter = tile_set.begin(); iter != tile_set.end(); iter++) {
+        for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
             int64_t i = std::get<0>(*iter);
             int64_t j = std::get<1>(*iter);
             existing_tiles += tileExists(i, j, device);
@@ -3733,7 +3733,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
 
                 for (auto iter  = bucket->second.second.begin();
                           iter != bucket->second.second.end();
-                          iter++) {
+                          ++iter) {
                     storage_->releaseWorkspaceBuffer(*iter, device);
                 }
             }
@@ -3742,7 +3742,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
         queue->sync();
 
         if (reset) {
-            for (auto iter = tile_set.begin(); iter != tile_set.end(); iter++) {
+            for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
                 // #pragma omp task default(none)
                 {
                     int64_t i = std::get<0>(*iter);

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2376,11 +2376,12 @@ void BaseMatrix<scalar_t>::tileIbcastToSet(
                                recv_from, send_to);
 
     int device = HostNum;
-    #if defined(SLATE_WITH_GPU_AWARE_MPI)
-    if (target == Target::Devices) {
-        device = tileDevice(i, j);
-    }
+    #if defined( SLATE_HAVE_GPU_AWARE_MPI )
+        if (target == Target::Devices) {
+            device = tileDevice( i, j );
+        }
     #endif
+
     // Receive.
     if (! recv_from.empty()) {
         // read tile

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2384,7 +2384,7 @@ void BaseMatrix<scalar_t>::tileIbcastToSet(
 
         at(i, j, device).recv(new_vec[recv_from.front()], mpi_comm_, layout, tag);
         tileLayout(i, j, device, layout);
-        tileModified(i, j, device);
+        tileModified(i, j, device, true);
     }
 
     if (! send_to.empty()) {

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -134,14 +134,18 @@ private:
 
 public:
     /// Returns shallow copy of op(A) that is transposed.
-    /// @see conjTranspose
+    /// @see conj_transpose
     template<typename MatrixType>
     friend MatrixType transpose(MatrixType& A);
 
     /// Returns shallow copy of op(A) that is conjugate-transpose.
     /// @see transpose
     template<typename MatrixType>
-    friend MatrixType conjTranspose(MatrixType& A);
+    friend MatrixType conj_transpose( MatrixType& A );
+
+    /// @deprecated
+    template<typename MatrixType>
+    friend MatrixType conjTranspose( MatrixType& A );
 
     template <typename T>
     friend void swap(BaseMatrix<T>& A, BaseMatrix<T>& B);
@@ -1181,7 +1185,7 @@ BaseMatrix<out_scalar_t> BaseMatrix<scalar_t>::baseEmptyLike(
         std::swap(mt, nt);
     }
     else if (this->op() == Op::ConjTrans) {
-        B = conjTranspose( B );
+        B = conj_transpose( B );
         std::swap(ioffset, joffset);
         std::swap(mt, nt);
     }

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -68,7 +68,7 @@ MatrixType transpose(MatrixType&& A)
 /// @ingroup util
 ///
 template<typename MatrixType>
-MatrixType conjTranspose(MatrixType& A)
+MatrixType conj_transpose( MatrixType& A )
 {
     MatrixType AT = A;
     if (AT.op_ == Op::NoTrans)
@@ -84,9 +84,9 @@ MatrixType conjTranspose(MatrixType& A)
 //--------------------------------------
 /// Converts rvalue refs to lvalue refs.
 template<typename MatrixType>
-MatrixType conjTranspose(MatrixType&& A)
+MatrixType conj_transpose( MatrixType&& A )
 {
-    return conjTranspose(A);
+    return conj_transpose( A );
 }
 
 //------------------------------------------------------------------------------
@@ -98,16 +98,18 @@ MatrixType conjTranspose(MatrixType&& A)
 /// @ingroup util
 ///
 template<typename MatrixType>
-MatrixType conj_transpose(MatrixType& A)
+[[deprecated( "Use conj_transpose instead. Remove 2024-02." )]]
+MatrixType conjTranspose( MatrixType& A )
 {
-    return conjTranspose(A);
+    return conj_transpose( A );
 }
 
 //--------------------------------------
 template<typename MatrixType>
-MatrixType conj_transpose(MatrixType&& A)
+[[deprecated( "Use conj_transpose instead. Remove 2024-02." )]]
+MatrixType conjTranspose( MatrixType&& A )
 {
-    return conjTranspose(A);
+    return conj_transpose( A );
 }
 
 //------------------------------------------------------------------------------
@@ -158,11 +160,11 @@ public:
 
     /// Returns shallow copy of tile that is conjugate-transposed.
     template <typename TileType>
-    friend TileType conjTranspose(TileType& A);
+    friend TileType conj_transpose( TileType& A );
 
     /// @deprecated
     template <typename TileType>
-    friend TileType conj_transpose(TileType& A);
+    friend TileType conjTranspose( TileType& A );
 
     /// Returns number of rows of op(A), where A is this tile
     int64_t mb() const { return (op_ == Op::NoTrans ? mb_ : nb_); }

--- a/include/slate/Tile_blas.hh
+++ b/include/slate/Tile_blas.hh
@@ -20,10 +20,10 @@ namespace tile {
 
 //------------------------------------------------------------------------------
 /// General matrix multiply: $op(C) = \alpha op(A) op(B) + \beta C$.
-/// Use transpose() or conjTranspose() to set $op(A)$, $op(B)$, and $op(C)$.
+/// Use transpose() or conj_transpose() to set $op(A)$, $op(B)$, and $op(C)$.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 /// @ingroup gemm_tile
 ///
 template <typename scalar_t>
@@ -264,7 +264,7 @@ void hemm(
 
 //------------------------------------------------------------------------------
 /// Hermitian rank-k update: $C = \alpha op(A) op(A)^H + \beta C$.
-/// Use conjTranspose to set $op(A)$.
+/// Use conj_transpose to set $op(A)$.
 /// In the complex case, C cannot be transpose.
 /// @ingroup herk_tile
 ///
@@ -304,7 +304,7 @@ void herk(
 //------------------------------------------------------------------------------
 /// Hermitian rank-2k update:
 ///     $C = \alpha op(A) op(B)^T + \alpha op(B) op(A)^T + \beta C$.
-/// Use transpose or conjTranspose to set $op(A)$ and $op(B)$.
+/// Use transpose or conj_transpose to set $op(A)$ and $op(B)$.
 /// In the complex case, C cannot be transpose.
 /// @ingroup her2k_tile
 ///
@@ -514,8 +514,8 @@ void hemv(scalar_t alpha, Tile<scalar_t> const&& A,
 
 //------------------------------------------------------------------------------
 /// Symmetric rank-k update: $C = \alpha op(A) op(A)^T + \beta C$.
-/// Use transpose or conjTranspose to set $op(A)$.
-/// In the complex case, C cannot be conjTranspose.
+/// Use transpose or conj_transpose to set $op(A)$.
+/// In the complex case, C cannot be conj_transpose.
 /// @ingroup syrk_tile
 ///
 // Allowing C^H would require two conjugations: conj( conj(C) + A*A^T ).
@@ -556,8 +556,8 @@ void syrk(
 //------------------------------------------------------------------------------
 /// Symmetric rank-2k update:
 ///     $C = \alpha op(A) op(B)^T + \alpha op(B) op(A)^T + \beta C$.
-/// Use transpose or conjTranspose to set $op(A)$ and $op(B)$.
-/// In the complex case, C cannot be conjTranspose.
+/// Use transpose or conj_transpose to set $op(A)$ and $op(B)$.
+/// In the complex case, C cannot be conj_transpose.
 /// @ingroup syr2k_tile
 ///
 // Allowing C^H would require two conjugations: conj( conj(C) + A*A^T ).
@@ -672,10 +672,10 @@ void trmm(
 
 //------------------------------------------------------------------------------
 /// Triangular solve: $B = \alpha op(A)^{-1} B$ or $B = \alpha B op(A)^{-1}$.
-/// Use transpose/conjTranspose to set op(A). uplo is set in the tile.
+/// Use transpose/conj_transpose to set op(A). uplo is set in the tile.
 /// In the complex case,
-/// if $op(B)$ is transpose, then $op(A)$ cannot be conjTranspose;
-/// if $op(B)$ is conjTranspose, then $op(A)$ cannot be transpose.
+/// if $op(B)$ is transpose, then $op(A)$ cannot be conj_transpose;
+/// if $op(B)$ is conj_transpose, then $op(A)$ cannot be transpose.
 /// @ingroup trsm_tile
 ///
 template <typename scalar_t>

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -744,7 +744,7 @@ void MatrixStorage<scalar_t>::allocateBatchArrays(
                 blas::Queue* queue = comm_queues_[device];
 
                 // Free host arrays.
-                blas::device_free_pinned(array_host_[i][device], *queue);
+                blas::host_free_pinned(array_host_[i][device], *queue);
 
                 // Free device arrays.
                 blas::device_free(array_dev_[i][device], *queue);
@@ -757,7 +757,7 @@ void MatrixStorage<scalar_t>::allocateBatchArrays(
 
                 // Allocate host arrays;
                 array_host_[i][device]
-                    = blas::device_malloc_pinned<scalar_t*>(batch_size*3, *queue);
+                    = blas::host_malloc_pinned<scalar_t*>(batch_size*3, *queue);
 
                 // Allocate device arrays.
                 array_dev_[i][device]
@@ -788,7 +788,7 @@ void MatrixStorage<scalar_t>::clearBatchArrays()
 
             // Free host arrays.
             if (array_host_[i][device] != nullptr) {
-                blas::device_free_pinned(array_host_[i][device], *queue);
+                blas::host_free_pinned(array_host_[i][device], *queue);
                 array_host_[i][device] = nullptr;
             }
 

--- a/include/slate/internal/device.hh
+++ b/include/slate/internal/device.hh
@@ -53,8 +53,15 @@ namespace slate {
 /// GPU device implementations of kernels.
 namespace device {
 
-// Simplify checking for GPU device support (CUDA or ROCm).
-#if defined( BLAS_HAVE_CUBLAS ) || defined( BLAS_HAVE_ROCBLAS )
+// For the present, use omptarget-kernels when OneMKL is used
+#if defined( BLAS_HAVE_ONEMKL )
+    #define SLATE_HAVE_OMPTARGET
+#endif
+
+// Simplify checking for GPU device support (CUDA / ROCm / OneMKL).
+#if defined( BLAS_HAVE_CUBLAS ) \
+    || defined( BLAS_HAVE_ROCBLAS ) \
+    || defined( SLATE_HAVE_OMPTARGET )
     #define SLATE_HAVE_DEVICE
 #endif
 

--- a/include/slate/internal/device.hh
+++ b/include/slate/internal/device.hh
@@ -30,7 +30,20 @@
     } // namespace blas
 
 #elif defined( BLAS_HAVE_ROCBLAS )
+    // Default to AMD platform on ROCm.
+    #if ! defined(__HIP_PLATFORM_NVIDIA__) && ! defined(__HIP_PLATFORM_NVCC__) \
+        && ! defined(__HIP_PLATFORM_AMD__) && ! defined(__HIP_PLATFORM_HCC__)
+        #define __HIP_PLATFORM_AMD__
+        #define SLATE_HIP_PLATFORM_AMD
+    #endif
+
     #include <hip/hip_complex.h>
+
+    // If we defined __HIP_PLATFORM_AMD__, undef it.
+    #ifdef SLATE_HIP_PLATFORM_AMD
+        #undef __HIP_PLATFORM_AMD__
+        #undef SLATE_HIP_PLATFORM_AMD
+    #endif
 
     namespace blas {
 

--- a/include/slate/internal/util.hh
+++ b/include/slate/internal/util.hh
@@ -132,9 +132,9 @@ public:
 
         __sync_fetch_and_add(&count_, 1);
         if (__sync_bool_compare_and_swap(&count_, size, 0))
-            passed_++;
+            ++passed_;
         else
-            while (passed_ == passed_old);
+            while (passed_ == passed_old) {}
     }
 
 private:

--- a/lapack_api/lapack_gels.cc
+++ b/lapack_api/lapack_gels.cc
@@ -96,7 +96,7 @@ void slate_pgels(const char* transstr, int m, int n, int nrhs, scalar_t* a, int 
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     slate::gels(opA, B, {
         {slate::Option::Lookahead, lookahead},

--- a/lapack_api/lapack_gemm.cc
+++ b/lapack_api/lapack_gemm.cc
@@ -83,12 +83,12 @@ void slate_gemm(const char* transastr, const char* transbstr, int m, int n, int 
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     if (transB == blas::Op::Trans)
         B = transpose(B);
     else if (transB == blas::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     slate::gemm(alpha, A, B, beta, C, {
         {slate::Option::Lookahead, lookahead},

--- a/lapack_api/lapack_gesv.cc
+++ b/lapack_api/lapack_gesv.cc
@@ -93,7 +93,7 @@ void slate_gesv(const int n, const int nrhs, scalar_t* a, const int lda, int* ip
         for (auto t_iter = pivots.begin(); t_iter != pivots.end(); ++t_iter) {
             for (auto p_iter = t_iter->begin(); p_iter != t_iter->end(); ++p_iter) {
                 ipiv[p_count] = p_iter->tileIndex() * nb + p_iter->elementOffset() + 1 + t_iter_add;
-                p_count++;
+                ++p_count;
             }
             t_iter_add += nb;
         }

--- a/lapack_api/lapack_gesvMixed.cc
+++ b/lapack_api/lapack_gesvMixed.cc
@@ -79,7 +79,7 @@ void slate_gesv(const int n, const int nrhs, scalar_t* a, const int lda, int* ip
         for (auto t_iter = pivots.begin(); t_iter != pivots.end(); ++t_iter) {
             for (auto p_iter = t_iter->begin(); p_iter != t_iter->end(); ++p_iter) {
                 ipiv[p_count] = p_iter->tileIndex() * nb + p_iter->elementOffset() + 1 + t_iter_add;
-                p_count++;
+                ++p_count;
             }
             t_iter_add += nb;
         }

--- a/lapack_api/lapack_getrf.cc
+++ b/lapack_api/lapack_getrf.cc
@@ -103,7 +103,7 @@ void slate_getrf(const int m, const int n, scalar_t* a, const int lda, int* ipiv
         for (auto t_iter = pivots.begin(); t_iter != pivots.end(); ++t_iter) {
             for (auto p_iter = t_iter->begin(); p_iter != t_iter->end(); ++p_iter) {
                 ipiv[p_count] = p_iter->tileIndex() * nb + p_iter->elementOffset() + 1 + t_iter_add;
-                p_count++;
+                ++p_count;
             }
             t_iter_add += nb;
         }

--- a/lapack_api/lapack_getri.cc
+++ b/lapack_api/lapack_getri.cc
@@ -131,7 +131,7 @@ void slate_getri(const int n, scalar_t* a, const int lda, int* ipiv, scalar_t* w
                 int64_t tileIndex = (ipiv[p_count] - 1 - t_iter_add) / nb;
                 int64_t elementOffset = (ipiv[p_count] - 1 - t_iter_add) % nb;
                 *p_iter = Pivot(tileIndex, elementOffset);
-                p_count++;
+                ++p_count;
             }
             t_iter_add += nb;
         }

--- a/lapack_api/lapack_getrs.cc
+++ b/lapack_api/lapack_getrs.cc
@@ -102,7 +102,7 @@ void slate_getrs(const char* transstr, const int n, const int nrhs, scalar_t* a,
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     // solve
     slate::getrs(opA, pivots, B, {

--- a/lapack_api/lapack_getrs.cc
+++ b/lapack_api/lapack_getrs.cc
@@ -91,7 +91,7 @@ void slate_getrs(const char* transstr, const int n, const int nrhs, scalar_t* a,
                 int64_t tileIndex = (ipiv[p_count] - 1 - t_iter_add) / nb;
                 int64_t elementOffset = (ipiv[p_count] - 1 - t_iter_add) % nb;
                 *p_iter = Pivot(tileIndex, elementOffset);
-                p_count++;
+                ++p_count;
             }
             t_iter_add += nb;
         }

--- a/lapack_api/lapack_her2k.cc
+++ b/lapack_api/lapack_her2k.cc
@@ -72,8 +72,8 @@ void slate_her2k(const char* uplostr, const char* transastr, const int n, const 
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == C.mt());
     assert(B.mt() == C.mt());

--- a/lapack_api/lapack_herk.cc
+++ b/lapack_api/lapack_herk.cc
@@ -67,7 +67,7 @@ void slate_herk(const char* uplostr, const char* transastr, const int n, const i
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     slate::herk(alpha, A, beta, C, {

--- a/lapack_api/lapack_syr2k.cc
+++ b/lapack_api/lapack_syr2k.cc
@@ -84,8 +84,8 @@ void slate_syr2k(const char* uplostr, const char* transastr, const int n, const 
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == C.mt());
     assert(B.mt() == C.mt());

--- a/lapack_api/lapack_syrk.cc
+++ b/lapack_api/lapack_syrk.cc
@@ -79,7 +79,7 @@ void slate_syrk(const char* uplostr, const char* transastr, const int n, const i
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     slate::syrk(alpha, A, beta, C, {

--- a/lapack_api/lapack_trmm.cc
+++ b/lapack_api/lapack_trmm.cc
@@ -81,7 +81,7 @@ void slate_trmm(const char* sidestr, const char* uplostr, const char* transastr,
     if (transA == Op::Trans)
         A = transpose(A);
     else if (transA == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     slate::trmm(side, alpha, A, B, {
         {slate::Option::Lookahead, lookahead},

--- a/lapack_api/lapack_trsm.cc
+++ b/lapack_api/lapack_trsm.cc
@@ -81,7 +81,7 @@ void slate_trsm(const char* sidestr, const char* uplostr, const char* transastr,
     if (transA == Op::Trans)
         A = transpose(A);
     else if (transA == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     slate::trsm(side, alpha, A, B, {
         {slate::Option::Lookahead, lookahead},

--- a/lib/pkgconfig/slate.pc.in
+++ b/lib/pkgconfig/slate.pc.in
@@ -1,0 +1,16 @@
+prefix=#PREFIX
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+CXX=#CXX
+scalapack=#SCALAPACK
+
+Name: SLATE
+Description: Distributed, GPU-accelerated dense linear algebra library.
+Version: #VERSION
+Cflags: #CXXFLAGS -I${includedir}
+# Some platforms require CUDA LIBS to be public.
+Libs: -L${libdir} -Wl,-rpath,${libdir} -lslate #LDFLAGS #LIBS
+Libs.private:
+Requires:
+Requires.private:

--- a/old/src/gemm.cc
+++ b/old/src/gemm.cc
@@ -370,7 +370,7 @@ void gemm(scalar_t alpha, Matrix<scalar_t>& A,
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemm( alpha, AT, BT, beta, C );
 ///
 //------------------------------------------------------------------------------

--- a/old/src/internal/internal_gemm_split.cc
+++ b/old/src/internal/internal_gemm_split.cc
@@ -169,7 +169,7 @@ void gemmPrep(internal::TargetType<Target::Devices>,
                     a_array_host[index] = A(i, 0, device).data();
                     b_array_host[index] = B(0, j, device).data();
                     c_array_host[index] = C(i, j, device).data();
-                    index++;
+                    ++index;
                 }
             }
             slate_assert(index == batch_count);

--- a/old/src/internal/internal_gemm_split.cc
+++ b/old/src/internal/internal_gemm_split.cc
@@ -17,8 +17,8 @@ namespace internal {
 /// where A is a single block column and B is a single block row.
 /// Dispatches to target implementations.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 ///
 /// @param[inout] batchArrays
 ///     holds the pointer arrays to be prepared for later execution

--- a/scalapack_api/example_pdgetrf.c
+++ b/scalapack_api/example_pdgetrf.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
     // seed random generator (do not use 1 => reset)
     int srand_seed = mpi_rank*13+17;
     srand(srand_seed);
-    for (int j=0; j<localma*localna; j++)
+    for (int j = 0; j < localma*localna; ++j)
         A[j] = 1+ 0.5 - (double)rand() / RAND_MAX;
 
     // Allocate space for pivots
@@ -91,19 +91,19 @@ int main(int argc, char* argv[])
     int localnb = numroc_(&nrhs, &nb, &mypcol, &izero, &npcol);
     double* B = (double*)malloc(localmb * localnb * sizeof(double));
     descinit_(descB, &n, &nrhs, &nb, &nb, &izero, &izero, &ictxt, &localmb, &info);
-    for (int j=0; j<localmb*localnb; j++)
+    for (int j = 0; j < localmb*localnb; ++j)
         B[j] = 0.5 - (double)rand() / RAND_MAX;
 
     // Save B for checking
     int descB_sav[9];
     double* B_sav = (double*)malloc(localmb * localnb * sizeof(double));
     descinit_(descB_sav, &n, &nrhs, &nb, &nb, &izero, &izero, &ictxt, &localmb, &info);
-    for (int j=0; j<localmb*localnb; j++)
+    for (int j = 0; j < localmb*localnb; ++j)
         B_sav[j] = B[j];
 
     // Use this to print a matrix if desired
-    // for (int i=0; i<localmb; i++)
-    //     for (int j=0; j<localnb; j++)
+    // for (int i=0; i<localmb; ++i)
+    //     for (int j = 0; j < localnb; ++j)
     //         printf("B[%d,%d][%d,%d] = %f\n", myprow, mypcol, i, j, B[j*localmb+i]); fflush(0);
 
     // Solve for x, Ax=B, storing x in B
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
 
     // Reset the contants of matrix A
     srand(srand_seed);
-    for (int j=0; j<localma*localna; j++)
+    for (int j = 0; j < localma*localna; ++j)
         A[j] = 1+ 0.5 - (double)rand() / RAND_MAX;
 
     // Get norm of original A
@@ -146,8 +146,8 @@ int main(int argc, char* argv[])
 
     // Check if B_sav - Ax is (near)zero
     if (mypnum == 0) printf("Printing if any A_orig * x - B_orig > 1e-9 ...\n");
-    for (int i=0; i<localmb; i++) {
-        for (int j=0; j<localnb; j++) {
+    for (int i=0; i<localmb; ++i) {
+        for (int j = 0; j < localnb; ++j) {
             if (B_sav[j*localmb+i] > 1e-9) {
                 printf("problem at B[%d,%d][%d,%d] = %g > 1e-9\n", myprow, mypcol, i, j, B_sav[j*localmb+i]); fflush(0);
             }

--- a/scalapack_api/example_pdsgesv.c
+++ b/scalapack_api/example_pdsgesv.c
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
     // seed random generator (do not use 1 => reset)
     int srand_seed = mpi_rank*13+17;
     srand(srand_seed);
-    for (int j=0; j<localma*localna; j++)
+    for (int j = 0; j < localma*localna; ++j)
         A[j] = 0.5 - (double)rand() / RAND_MAX;
 
     // Get norm of original A
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
     // printf("Anorm = %f\n", Anorm); fflush(0);
 
     // Use this to print a matrix if desired
-    // for (int i=0; i<localma; i++)
-    //     for (int j=0; j<localna; j++)
+    // for (int i = 0; i < localma; ++i)
+    //     for (int j = 0; j < localna; ++j)
     //         printf("A[%d,%d][%d,%d] = %f\n", myprow, mypcol, i, j, A[j*localma+i]); fflush(0);
 
     // Allocate space for pivots
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
     int localnb = numroc_(&nrhs, &nb, &mypcol, &izero, &npcol);
     double* B = (double*)malloc(localmb * localnb * sizeof(double));
     descinit_(descB, &n, &nrhs, &nb, &nb, &izero, &izero, &ictxt, &localmb, &info);
-    for (int j=0; j<localmb*localnb; j++)
+    for (int j = 0; j < localmb*localnb; ++j)
         B[j] = 0.5 - (double)rand() / RAND_MAX;
 
     // Allocate X (same as B)
@@ -106,19 +106,19 @@ int main(int argc, char* argv[])
     int descX[9];
     double* X = (double*)malloc(localmb * localnb * sizeof(double));
     descinit_(descX, &n, &nrhs, &nb, &nb, &izero, &izero, &ictxt, &localmb, &info);
-    for (int j=0; j<localmb*localnb; j++)
+    for (int j = 0; j < localmb*localnb; ++j)
         X[j] = 0;
 
     // Save B for checking
     int descBref[9];
     double* Bref = (double*)malloc(localmb * localnb * sizeof(double));
     descinit_(descBref, &n, &nrhs, &nb, &nb, &izero, &izero, &ictxt, &localmb, &info);
-    for (int j=0; j<localmb*localnb; j++)
+    for (int j = 0; j < localmb*localnb; ++j)
         Bref[j] = B[j];
 
     // Use this to print a matrix if desired
-    // for (int i=0; i<localmb; i++)
-    //     for (int j=0; j<localnb; j++)
+    // for (int i = 0; i < localmb; ++i)
+    //     for (int j = 0; j < localnb; ++j)
     //         printf("B[%d,%d][%d,%d] = %f\n", myprow, mypcol, i, j, B[j*localmb+i]); fflush(0);
 
     int iters = 0;
@@ -131,8 +131,8 @@ int main(int argc, char* argv[])
     if (mypnum == 0) { printf("pdsgesv_ completed in %d iterations\n", iters); fflush(0); }
 
     // Use this to print a matrix if desired
-    // for (int i=0; i<localmb; i++)
-    //     for (int j=0; j<localnb; j++)
+    // for (int i = 0; i < localmb; ++i)
+    //     for (int j = 0; j < localnb; ++j)
     //         printf("X[%d,%d][%d,%d] = %f\n", myprow, mypcol, i, j, X[j*localmb+i]); fflush(0);
 
     // Get norm of the solution stored in X
@@ -141,7 +141,7 @@ int main(int argc, char* argv[])
 
     // Reset the contants of matrix A
     srand(srand_seed);
-    for (int j=0; j<localma*localna; j++)
+    for (int j = 0; j < localma*localna; ++j)
         A[j] = 0.5 - (double)rand() / RAND_MAX;
 
     if (mypnum == 0) { printf("Calling pdgemm_ for B_orig - A_orig * X to check results\n"); fflush(0); }
@@ -165,8 +165,8 @@ int main(int argc, char* argv[])
 
     // Check if Bref - Ax is (near)zero
     // if (mypnum == 0) printf("Printing if any A_orig * x - B_orig > 1e-9 ...\n");
-    // for (int i=0; i<localmb; i++)
-    //     for (int j=0; j<localnb; j++)
+    // for (int i = 0; i < localmb; ++i)
+    //     for (int j = 0; j < localnb; ++j)
     //         if (Bref[j*localmb+i] > 1e-9)
     //             printf("problem at B[%d,%d][%d,%d] = %g > 1e-9\n", myprow, mypcol, i, j, Bref[j*localmb+i]); fflush(0);
 

--- a/scalapack_api/scalapack_gels.cc
+++ b/scalapack_api/scalapack_gels.cc
@@ -132,7 +132,7 @@ void slate_pgels(const char* transstr, int m, int n, int nrhs, scalar_t* a, int 
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "gels");

--- a/scalapack_api/scalapack_gemm.cc
+++ b/scalapack_api/scalapack_gemm.cc
@@ -148,12 +148,12 @@ void slate_pgemm(const char* transastr, const char* transbstr, int m, int n, int
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     if (transB == blas::Op::Trans)
         B = transpose(B);
     else if (transB == blas::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "gemm");

--- a/scalapack_api/scalapack_getrs.cc
+++ b/scalapack_api/scalapack_getrs.cc
@@ -178,7 +178,7 @@ void slate_pgetrs(const char* transstr, int n, int nrhs, scalar_t* a, int ia, in
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     // call the SLATE getrs routine
     slate::getrs(opA, pivots, B, opts);

--- a/scalapack_api/scalapack_her2k.cc
+++ b/scalapack_api/scalapack_her2k.cc
@@ -92,8 +92,8 @@ void slate_pher2k(const char* uplostr, const char* transstr, int n, int k, scala
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == CH.mt());
     assert(B.mt() == CH.mt());

--- a/scalapack_api/scalapack_herk.cc
+++ b/scalapack_api/scalapack_herk.cc
@@ -88,7 +88,7 @@ void slate_pherk(const char* uplostr, const char* transstr, int n, int k, blas::
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     slate::herk(alpha, A, beta, C, {

--- a/scalapack_api/scalapack_syr2k.cc
+++ b/scalapack_api/scalapack_syr2k.cc
@@ -129,8 +129,8 @@ void slate_psyr2k(const char* uplostr, const char* transstr, int n, int k, scala
         B = transpose(B);
     }
     else if (trans == blas::Op::ConjTrans) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
     assert(A.mt() == CS.mt());
     assert(B.mt() == CS.mt());

--- a/scalapack_api/scalapack_syrk.cc
+++ b/scalapack_api/scalapack_syrk.cc
@@ -122,7 +122,7 @@ void slate_psyrk(const char* uplostr, const char* transstr, int n, int k, scalar
     if (transA == blas::Op::Trans)
         A = transpose(A);
     else if (transA == blas::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     assert(A.mt() == C.mt());
 
     if (verbose && myprow == 0 && mypcol == 0)

--- a/scalapack_api/scalapack_trmm.cc
+++ b/scalapack_api/scalapack_trmm.cc
@@ -124,7 +124,7 @@ void slate_ptrmm(const char* sidestr, const char* uplostr, const char* transastr
     if (transA == Op::Trans)
         AT = transpose(AT);
     else if (transA == Op::ConjTrans)
-        AT = conjTranspose(AT);
+        AT = conj_transpose( AT );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "trmm");

--- a/scalapack_api/scalapack_trsm.cc
+++ b/scalapack_api/scalapack_trsm.cc
@@ -124,7 +124,7 @@ void slate_ptrsm(const char* sidestr, const char* uplostr, const char* transastr
     if (transA == Op::Trans)
         AT = transpose(AT);
     else if (transA == Op::ConjTrans)
-        AT = conjTranspose(AT);
+        AT = conj_transpose( AT );
 
     if (verbose && myprow == 0 && mypcol == 0)
         logprintf("%s\n", "trsm");

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -108,7 +108,7 @@ bool Debug::checkTilesLayout(BaseMatrix<scalar_t> const& A)
         auto tile_end = A.storage_->tiles_.end();
 
         for (int64_t i = 0; i < A.mt(); ++i) {
-            for (int64_t j = 0; j < A.nt(); j++) {
+            for (int64_t j = 0; j < A.nt(); ++j) {
                 index = A.globalIndex(i, j);
                 tmp_tile = A.storage_->tiles_.find(index);
                 if (tmp_tile != tile_end
@@ -149,7 +149,7 @@ void Debug::printTilesLives(BaseMatrix<scalar_t> const& A)
     for (int64_t i = 0; i < A.mt(); ++i) {
         snprintf( buf, len, "%02d [%4lld]: ", A.mpiRank(), llong( i ) );
         msg += buf;
-        for (int64_t j = 0; j < A.nt(); j++) {
+        for (int64_t j = 0; j < A.nt(); ++j) {
             index = A.globalIndex(i, j);
             tmp_tile = A.storage_->find(index);
             if (tmp_tile == tile_end)

--- a/src/auxiliary/Trace.cc
+++ b/src/auxiliary/Trace.cc
@@ -164,9 +164,6 @@ enum class Color {
 
 //------------------------------------------------------------------------------
 const int max_nest          = 4;
-const int font_size         = 18;
-const int max_rank_chars    = 6;
-const int ylabel_width      = font_size * max_rank_chars;
 
 // Used by Block. If this is a static member of Block, some compilers
 // have a link error.

--- a/src/cholqr.cc
+++ b/src/cholqr.cc
@@ -26,8 +26,10 @@ void cholqr(
     Matrix<scalar_t>& R,
     Options const& opts )
 {
+    // Constants
     const scalar_t one  = 1.0;
     const scalar_t zero = 0.0;
+
     auto AH = conjTranspose( A );
     HermitianMatrix<scalar_t> R_hermitian( Uplo::Upper, R );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R_hermitian );
@@ -74,20 +76,22 @@ void cholqr(
 {
     slate_assert( R.uplo() == Uplo::Upper );
 
-    scalar_t s_one = 1.0;
-    blas::real_type<scalar_t> one  = 1.0;
-    blas::real_type<scalar_t> zero = 0.0;
+    // Constants
+    scalar_t one = 1.0;
+    blas::real_type<scalar_t> r_one  = 1.0;
+    blas::real_type<scalar_t> r_zero = 0.0;
+
     auto AH = conjTranspose( A );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R );
 
     // Compute R = AH * A.
-    herk( one, AH, zero, R, opts );
+    herk( r_one, AH, r_zero, R, opts );
 
     // Compute Ut * U = chol(R).
     potrf( R, opts );
 
     // Compute Q = A * U^{-1}.
-    trsm( Side::Right, s_one, U, A, opts );
+    trsm( Side::Right, one, U, A, opts );
 }
 
 } // namespace impl

--- a/src/cholqr.cc
+++ b/src/cholqr.cc
@@ -30,7 +30,7 @@ void cholqr(
     const scalar_t one  = 1.0;
     const scalar_t zero = 0.0;
 
-    auto AH = conjTranspose( A );
+    auto AH = conj_transpose( A );
     HermitianMatrix<scalar_t> R_hermitian( Uplo::Upper, R );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R_hermitian );
 
@@ -81,7 +81,7 @@ void cholqr(
     blas::real_type<scalar_t> r_one  = 1.0;
     blas::real_type<scalar_t> r_zero = 0.0;
 
-    auto AH = conjTranspose( A );
+    auto AH = conj_transpose( A );
     auto U = TriangularMatrix<scalar_t>( Diag::NonUnit, R );
 
     // Compute R = AH * A.

--- a/src/colNorms.cc
+++ b/src/colNorms.cc
@@ -41,7 +41,7 @@ void colNorms(
         //     in_norm = Norm::One;
     }
     if (A.op() == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     else if (A.op() == Op::Trans)
         A = transpose(A);
 

--- a/src/device/dev_gescale_row_col.cc
+++ b/src/device/dev_gescale_row_col.cc
@@ -44,6 +44,9 @@ void gescale_row_col_batch(
 #elif defined( BLAS_HAVE_ROCBLAS )
     typedef hipFloatComplex devFloatComplex;
     typedef hipDoubleComplex devDoubleComplex;
+#else // no std::complex mapping
+    typedef std::complex<float> devFloatComplex;
+    typedef std::complex<double> devDoubleComplex;
 #endif
 
 //----------------------------------------

--- a/src/gbmm.cc
+++ b/src/gbmm.cc
@@ -211,7 +211,7 @@ void gbmm(
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gbmm( alpha, AT, BT, beta, C );
 ///
 //------------------------------------------------------------------------------

--- a/src/gecondest.cc
+++ b/src/gecondest.cc
@@ -141,11 +141,11 @@ void gecondest(
         }
         else {
             // Multiply by inv(U^H).
-            auto UH = conjTranspose( U );
+            auto UH = conj_transpose( U );
             slate::trsmB(Side::Left, alpha, UH, X, opts);
 
             // Multiply by inv(L^H).
-            auto LH = conjTranspose( L );
+            auto LH = conj_transpose( L );
             slate::trsmB(Side::Left, alpha, LH, X, opts);
         }
 

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -31,10 +31,10 @@ void gelqf(
     using lapack::device_info_int;
     using blas::real;
 
+    // Constants
+    const int priority_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
-
-    const int priority_one = 1;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
@@ -170,7 +170,7 @@ void gelqf(
             }
 
             // panel, high priority
-            #pragma omp task depend(inout:block[k]) priority(priority_one)
+            #pragma omp task depend(inout:block[k]) priority(1)
             {
                 //--------------------
                 // Instead of doing LQ of panel, we do QR of transpose( panel ),
@@ -188,7 +188,7 @@ void gelqf(
                 internal::geqrf<target>(
                     std::move(AT_panel), std::move(TlT_panel),
                     dwork_array, work_size, ib,
-                    max_panel_threads, priority_one);
+                    max_panel_threads, priority_1 );
 
                 // Find first local tile, which is triangular factor (T in I - VTV^H),
                 // and copy it to Tlocal.
@@ -265,7 +265,7 @@ void gelqf(
 
                 #pragma omp task depend(in:block[k]) \
                                  depend(inout:block[i]) \
-                                 priority(priority_one)
+                                 priority(1)
                 {
                     // Apply local reflectors
                     internal::unmlq<Target::HostTask>(

--- a/src/gemm.cc
+++ b/src/gemm.cc
@@ -18,7 +18,7 @@ namespace slate {
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemm( alpha, AT, BT, beta, C );
 ///
 /// Complexity (in real): $2 m n k$ flops.

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -195,7 +195,7 @@ void gemmA(
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemm( alpha, AT, BT, beta, C );
 ///
 /// This algorithmic variant manages computation to be local to the

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -83,7 +83,8 @@ void gemmA(
                 for (int64_t i = 0; i < B.mt(); ++i)
                     bcast_list_B.push_back(
                         {i, k, {A.sub( 0, A.mt()-1, i, i )}} );
-                B.template listBcast<target>( bcast_list_B, layout, k );
+                int tag_k = k;
+                B.template listBcast<target>( bcast_list_B, layout, tag_k );
             }
         }
 
@@ -134,8 +135,9 @@ void gemmA(
                     for (int64_t i = 0; i < B.mt(); ++i)
                         bcast_list_B.push_back(
                             {i, k+lookahead, {A.sub( 0, A.mt()-1, i, i )}} );
+                    int tag_kl = k+lookahead;
                     B.template listBcast<target>(
-                        bcast_list_B, layout, k+lookahead );
+                        bcast_list_B, layout, tag_kl );
                 }
             }
 

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -57,7 +57,7 @@ void gemmC(
     uint8_t* gemm  =  gemm_vector.data();
     uint8_t* c     =     c_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -123,7 +123,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  std::move(C),
-                    layout, default_priority, default_queue, opts2);
+                    layout, default_priority, queue_0, opts2);
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
@@ -172,7 +172,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, k, k),
                            B.sub(k, k, 0, B.nt()-1),
                     one,   std::move( C ),
-                    layout, default_priority, default_queue, opts2);
+                    layout, default_priority, queue_0, opts2);
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
                 auto B_rowblock = B.sub(k, k, 0, B.nt()-1);

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -205,7 +205,7 @@ void gemmC(
 /// The matrices can be transposed or conjugate-transposed beforehand, e.g.,
 ///
 ///     auto AT = slate::transpose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::gemmC( alpha, AT, BT, beta, C );
 ///
 //------------------------------------------------------------------------------

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -38,6 +38,8 @@ void gemmC(
 
     // Constants
     const scalar_t one = 1.0;
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     const Layout layout = Layout::ColMajor;
 
     // Options
@@ -56,8 +58,6 @@ void gemmC(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     uint8_t* c     =     c_vector.data();
-    const int default_priority = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -123,7 +123,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  std::move(C),
-                    layout, default_priority, queue_0, opts2);
+                    layout, priority_0, queue_0, opts2 );
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
@@ -172,7 +172,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, k, k),
                            B.sub(k, k, 0, B.nt()-1),
                     one,   std::move( C ),
-                    layout, default_priority, queue_0, opts2);
+                    layout, priority_0, queue_0, opts2 );
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
                 auto B_rowblock = B.sub(k, k, 0, B.nt()-1);

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -219,9 +219,9 @@ void geqrf(
                             else
                                 bcast_list_V.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}});
                         }
-                        int tag_0  = 0;
-                        int life_3 = 3;
-                        int life_2 = 2;
+                        const int tag_0  = 0;
+                        const int life_3 = 3;
+                        const int life_2 = 2;
                         A.template listBcast<target>(
                             bcast_list_V_first, layout, tag_0, life_3, set_hold );
                         A.template listBcast<target>(

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -107,11 +107,11 @@ void geqrf(
     std::vector< scalar_t* > dwork_array( num_devices, nullptr );
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0; // use default batch size
-        const int64_t num_queues = 3 + lookahead;
-        A.allocateBatchArrays(batch_size_zero, num_queues);
+        const int64_t batch_size_default = 0; // use default batch size
+        int num_queues = 3 + lookahead;
+        A.allocateBatchArrays( batch_size_default, num_queues );
         A.reserveDeviceWorkspace();
-        W.allocateBatchArrays(batch_size_zero, num_queues);
+        W.allocateBatchArrays( batch_size_default, num_queues );
         // todo: this is demanding too much device workspace memory
         // only one tile-row of matrix W per MPI process is going to be used,
         // but W with size of whole A is being allocated

--- a/src/gesvMixed.cc
+++ b/src/gesvMixed.cc
@@ -20,7 +20,7 @@ bool iterRefConverged(std::vector<scalar_t>& colnorms_R,
     bool value = true;
     int64_t size = colnorms_X.size();
 
-    for (int64_t i = 0; i < size; i++) {
+    for (int64_t i = 0; i < size; ++i) {
         if (colnorms_R[i] > colnorms_X[i] * cte) {
             value = false;
             break;
@@ -211,7 +211,7 @@ void gesvMixed( Matrix<scalar_hi>& A, Pivots& pivots,
     }
 
     // iterative refinement
-    for (int iiter = 0; iiter < itermax && ! converged; iiter++) {
+    for (int iiter = 0; iiter < itermax && ! converged; ++iiter) {
         // Convert R from high to low precision, store result in X_lo.
         copy( R, X_lo, opts );
 

--- a/src/gesvd.cc
+++ b/src/gesvd.cc
@@ -39,7 +39,7 @@ void gesvd(
     if (flip) {
         slate_not_implemented("m < n not yet supported");
         swap(m, n);
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
 
     // Scale matrix to allowable range, if necessary.

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -28,7 +28,13 @@ void getrf(
     using real_t = blas::real_type<scalar_t>;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
+    const int life_1 = 1;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
 
     // Options
     real_t pivot_threshold
@@ -56,11 +62,6 @@ void getrf(
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
     pivots.resize(min_mt_nt);
 
-    const int priority_one = 1;
-    const int priority_zero = 0;
-    int life_factor_one = 1;
-    const int queue_0 = 0;
-    const int queue_1 = 1;
     const int64_t batch_size_zero = 0;
     const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
@@ -89,12 +90,12 @@ void getrf(
             pivots.at(k).resize(diag_len);
 
             // panel, high priority
-            #pragma omp task depend(inout:column[k]) priority(priority_one)
+            #pragma omp task depend(inout:column[k]) priority(1)
             {
                 // factor A(k:mt-1, k)
                 internal::getrf_panel<Target::HostTask>(
                     A.sub(k, A_mt-1, k, k), diag_len, ib, pivots.at(k),
-                    pivot_threshold, max_panel_threads, priority_one, k);
+                    pivot_threshold, max_panel_threads, priority_1, k );
 
                 BcastList bcast_list_A;
                 int tag_k = k;
@@ -103,7 +104,7 @@ void getrf(
                     bcast_list_A.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}});
                 }
                 A.template listBcast<target>(
-                    bcast_list_A, Layout::ColMajor, tag_k, life_factor_one, is_shared);
+                    bcast_list_A, Layout::ColMajor, tag_k, life_1, is_shared );
 
                 // Root broadcasts the pivot to all ranks.
                 // todo: Panel ranks send the pivots to the right.
@@ -118,14 +119,14 @@ void getrf(
             // update lookahead column(s), high priority
             for (int64_t j = k+1; j < k+1+lookahead && j < A_nt; ++j) {
                 #pragma omp task depend(in:column[k]) \
-                                 depend(inout:column[j]) priority(priority_one)
+                                 depend(inout:column[j]) priority(1)
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
                     int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, queue_jk1 );
+                        target_layout, priority_1, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -135,7 +136,7 @@ void getrf(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_one, Layout::ColMajor, queue_jk1 );
+                        priority_1, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -146,7 +147,7 @@ void getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        target_layout, priority_one, queue_jk1 );
+                        target_layout, priority_1, queue_jk1 );
                 }
             }
             // pivot to the left
@@ -159,7 +160,7 @@ void getrf(
                     int tag_0 = 0;
                     internal::permuteRows<Target::HostTask>(
                         Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
-                        host_layout, priority_zero, tag_0, queue_0);
+                        host_layout, priority_0, tag_0, queue_0 );
                 }
             }
             // update trailing submatrix, normal priority
@@ -173,7 +174,7 @@ void getrf(
                     // todo: target
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, k+1+lookahead, A_nt-1),
-                        pivots.at(k), target_layout, priority_zero, tag_kl1, queue_1);
+                        pivots.at(k), target_layout, priority_0, tag_kl1, queue_1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -185,7 +186,7 @@ void getrf(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, A_nt-1),
-                        priority_zero, Layout::ColMajor, queue_1);
+                        priority_0, Layout::ColMajor, queue_1 );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastList bcast_list_A;
@@ -202,7 +203,7 @@ void getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, k+1+lookahead, A_nt-1),
                         one,  A.sub(k+1, A_mt-1, k+1+lookahead, A_nt-1),
-                        target_layout, priority_zero, queue_1);
+                        target_layout, priority_0, queue_1 );
                 }
             }
             if (is_shared) {

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -122,9 +122,10 @@ void getrf(
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
+                    int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, j-k+1);
+                        target_layout, priority_one, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -134,7 +135,7 @@ void getrf(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_one, Layout::ColMajor, j-k+1);
+                        priority_one, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -145,7 +146,7 @@ void getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        target_layout, priority_one, j-k+1);
+                        target_layout, priority_one, queue_jk1 );
                 }
             }
             // pivot to the left

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -157,7 +157,7 @@ void getrf(
                                  depend(inout:column[k-1])
                 {
                     // swap rows in A(k:mt-1, 0:k-1)
-                    int tag_0 = 0;
+                    const int tag_0 = 0;
                     internal::permuteRows<Target::HostTask>(
                         Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
                         host_layout, priority_0, tag_0, queue_0 );

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -62,8 +62,6 @@ void getrf(
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
     pivots.resize(min_mt_nt);
 
-    const int64_t batch_size_zero = 0;
-    const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
 
     // OpenMP needs pointer types, but vectors are exception safe
@@ -74,7 +72,9 @@ void getrf(
     // So, the data dependencies protect the corresponding MPI tags
 
     if (target == Target::Devices) {
-        A.allocateBatchArrays(batch_size_zero, num_queues);
+        const int64_t batch_size_default = 0;
+        int num_queues = 2 + lookahead;
+        A.allocateBatchArrays( batch_size_default, num_queues );
         A.reserveDeviceWorkspace();
     }
 

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -30,8 +30,13 @@ void getrf_tntpiv(
     using lapack::device_info_int;
     using lapack::device_pivot_int;
 
-
+    // Constants
     const scalar_t one = 1.0;
+    const int life_1 = 1;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
@@ -52,14 +57,9 @@ void getrf_tntpiv(
     if (target == Target::Devices)
         target_layout = Layout::RowMajor;
 
-    const int priority_one = 1;
-    const int priority_zero = 0;
     int64_t A_nt = A.nt();
     int64_t A_mt = A.mt();
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
-    int life_factor_one = 1;
-    const int queue_0 = 0;
-    const int queue_1 = 1;
     const int64_t batch_size_zero = 0;
     const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
@@ -148,7 +148,7 @@ void getrf_tntpiv(
 
             // panel, high priority
             #pragma omp task depend(inout:column[k]) \
-                             priority(priority_one)
+                             priority(1)
             {
                 auto Apanel = Awork.sub( k, A_mt-1, k, k );
                 Apanel.insertLocalTiles();
@@ -158,7 +158,7 @@ void getrf_tntpiv(
                 internal::getrf_tntpiv_panel<target>(
                     A.sub(k, A_mt-1, k, k), std::move(Apanel),
                     dwork_array, work_size, diag_len, ib,
-                    pivots.at(k), max_panel_threads, priority_one);
+                    pivots.at(k), max_panel_threads, priority_1 );
 
                 // Root broadcasts the pivot to all ranks.
                 // todo: Panel ranks send the pivots to the right.
@@ -174,7 +174,7 @@ void getrf_tntpiv(
                 int tag_k = k;
                 internal::permuteRows<target>(
                     Direction::Forward, A.sub(k, A_mt-1, k, k),
-                    pivots.at(k), target_layout, priority_one, tag_k, queue_0);
+                    pivots.at(k), target_layout, priority_1, tag_k, queue_0 );
 
                 // Copy factored diagonal tile into place.
                 internal::copy<Target::HostTask>(
@@ -187,7 +187,7 @@ void getrf_tntpiv(
                                                A.sub(k, k, k+1, A_nt-1)}});
 
                 A.template listBcast<target>(
-                    bcast_list_A, host_layout, tag_k, life_factor_one, is_shared);
+                    bcast_list_A, host_layout, tag_k, life_1, is_shared );
 
                 Apanel.clear();
             }
@@ -196,7 +196,7 @@ void getrf_tntpiv(
             // A_k+1:mt,k = A_k+1:mt,k * Tkk^{-1}
             #pragma omp task depend(inout:column[k]) \
                              depend(inout:listBcastMT_token) \
-                             priority(priority_one)
+                             priority(1)
             {
                 auto Akk = A.sub(k, k, k, k);
                 auto Tkk = TriangularMatrix<scalar_t>(
@@ -206,7 +206,7 @@ void getrf_tntpiv(
                     Side::Right,
                     one, std::move(Tkk),
                          A.sub( k+1, A_mt-1, k, k ),
-                    priority_one, Layout::ColMajor, queue_0);
+                    priority_1, Layout::ColMajor, queue_0 );
 
                 BcastListTag bcast_list;
                 // bcast the tiles of the panel to the right hand side
@@ -216,21 +216,21 @@ void getrf_tntpiv(
                     bcast_list.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}, tag});
                 }
                 A.template listBcastMT<target>(
-                    bcast_list, Layout::ColMajor, life_factor_one, is_shared);
+                    bcast_list, Layout::ColMajor, life_1, is_shared );
             }
 
             // update lookahead column(s), high priority
             for (int64_t j = k+1; j < k+1+lookahead && j < A_nt; ++j) {
                 #pragma omp task depend(in:column[k]) \
                                  depend(inout:column[j]) \
-                                 priority(priority_one)
+                                 priority(1)
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
                     int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, queue_jk1 );
+                        target_layout, priority_1, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk = TriangularMatrix<scalar_t>(
@@ -240,7 +240,7 @@ void getrf_tntpiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub( k, k, j, j ),
-                        priority_one, Layout::ColMajor, queue_jk1 );
+                        priority_1, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -253,7 +253,7 @@ void getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, j, j ),
                         one,  A.sub( k+1, A_mt-1, j, j ),
-                        host_layout, priority_one, queue_jk1 );
+                        host_layout, priority_1, queue_jk1 );
                 }
             }
 
@@ -267,7 +267,7 @@ void getrf_tntpiv(
                     int tag = 1 + k + A_mt * 2;
                     internal::permuteRows<Target::HostTask>(
                         Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
-                        host_layout, priority_zero, tag, queue_0);
+                        host_layout, priority_0, tag, queue_0 );
                 }
             }
 
@@ -282,7 +282,7 @@ void getrf_tntpiv(
                     int tag_kl1 = k+1+lookahead;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, k+1+lookahead, A_nt-1),
-                        pivots.at(k), target_layout, priority_zero, tag_kl1, queue_1);
+                        pivots.at(k), target_layout, priority_0, tag_kl1, queue_1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk =
@@ -293,7 +293,7 @@ void getrf_tntpiv(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub( k, k, k+1+lookahead, A_nt-1 ),
-                        priority_zero, Layout::ColMajor, queue_1);
+                        priority_0, Layout::ColMajor, queue_1 );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastListTag bcast_list;
@@ -311,7 +311,7 @@ void getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, k+1+lookahead, A_nt-1 ),
                         one,  A.sub( k+1, A_mt-1, k+1+lookahead, A_nt-1 ),
-                        host_layout, priority_zero, queue_1);
+                        host_layout, priority_0, queue_1 );
                 }
             }
             if (is_shared) {

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -60,8 +60,6 @@ void getrf_tntpiv(
     int64_t A_nt = A.nt();
     int64_t A_mt = A.mt();
     int64_t min_mt_nt = std::min(A.mt(), A.nt());
-    const int64_t batch_size_zero = 0;
-    const int num_queues = 2 + lookahead;
     bool is_shared = target == Target::Devices && lookahead > 0;
     pivots.resize(min_mt_nt);
 
@@ -73,7 +71,9 @@ void getrf_tntpiv(
     std::vector< scalar_t* > dwork_array( num_devices, nullptr );
 
     if (target == Target::Devices) {
-        A.allocateBatchArrays(batch_size_zero, num_queues);
+        const int64_t batch_size_default = 0;
+        int num_queues = 2 + lookahead;
+        A.allocateBatchArrays( batch_size_default, num_queues );
         A.reserveDeviceWorkspace();
 
         int64_t mlocal = 0;

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -227,9 +227,10 @@ void getrf_tntpiv(
                 {
                     // swap rows in A(k:mt-1, j)
                     int tag_j = j;
+                    int queue_jk1 = j-k+1;
                     internal::permuteRows<target>(
                         Direction::Forward, A.sub(k, A_mt-1, j, j), pivots.at(k),
-                        target_layout, priority_one, tag_j, j-k+1);
+                        target_layout, priority_one, tag_j, queue_jk1 );
 
                     auto Akk = A.sub(k, k, k, k);
                     auto Tkk = TriangularMatrix<scalar_t>(
@@ -239,7 +240,7 @@ void getrf_tntpiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub( k, k, j, j ),
-                        priority_one, Layout::ColMajor, j-k+1);
+                        priority_one, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -252,7 +253,7 @@ void getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, j, j ),
                         one,  A.sub( k+1, A_mt-1, j, j ),
-                        host_layout, priority_one, j-k+1);
+                        host_layout, priority_one, queue_jk1 );
                 }
             }
 

--- a/src/hbmm.cc
+++ b/src/hbmm.cc
@@ -55,9 +55,9 @@ void hbmm(
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
-        C = conjTranspose(C);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
+        C = conj_transpose( C );
         alpha = conj(alpha);
         beta  = conj(beta);
     }
@@ -320,7 +320,7 @@ void hbmm(
                 if (i_end-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, i_end-1);
                     internal::gemm<target>(
-                        alpha, conjTranspose(Arow_k),
+                        alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, i_end-1, 0, C.nt()-1),
                         layout);

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -202,8 +202,8 @@ void he2hb(
                                           A.sub( i+1, nt-1, i, i ) }, i } );
                         }
                     }
-                    int life_5 = 5;
-                    int life_6 = 6;
+                    const int life_5 = 5;
+                    const int life_6 = 6;
                     A.template listBcastMT<target>(
                         bcast_list_V_first, layout, life_5, set_hold );
                     A.template listBcastMT<target>(
@@ -247,7 +247,7 @@ void he2hb(
                                 { i0, k, { Tlocal.sub( i, i, k+1, i ),
                                            Tlocal.sub( i+1, nt-1, i, i ) }, i } );
                         }
-                        int life_1 = 1;
+                        const int life_1 = 1;
                         Tlocal.template listBcastMT<target>(
                             bcast_list_T, layout, life_1, set_hold );
                     }

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -36,15 +36,14 @@ void he2hb(
     assert( A.uplo() == Uplo::Lower );  // for now
 
     // Constants
-    // Assumes column major
-    const Layout layout = Layout::ColMajor;
-    const LayoutConvert layout_conv = LayoutConvert( layout );
-
-    const int priority_one = 1;
     const scalar_t zero = 0.0;
     const scalar_t one  = 1.0;
     const scalar_t half = 0.5;
     const real_t r_one  = 1.0;
+    const int priority_1 = 1;
+    // Assumes column major
+    const Layout layout = Layout::ColMajor;
+    const LayoutConvert layout_conv = LayoutConvert( layout );
 
     // Options
     int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
@@ -168,7 +167,7 @@ void he2hb(
                 internal::geqrf<Target::HostTask>(
                     std::move( A_panel ),
                     std::move( Tlocal_panel ),
-                    ib, max_panel_threads, priority_one);
+                    ib, max_panel_threads, priority_1 );
 
                 // triangle-triangle reductions
                 // ttqrt handles tile transfers internally

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -41,6 +41,8 @@ void he2hb(
     const scalar_t half = 0.5;
     const real_t r_one  = 1.0;
     const int priority_1 = 1;
+    const int batch_size_default = 0;
+    const int num_queues = 10;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layout_conv = LayoutConvert( layout );
@@ -105,7 +107,6 @@ void he2hb(
     // Since W( 0, 0 ) is otherwise unused, store TVAVT there.
     W.tileInsert( 0, 0 );
     auto TVAVT = W.sub( 0, 0, 0, 0 );
-    int num_queues = 10;
 
     int my_rank = A.mpiRank();
 
@@ -153,7 +154,7 @@ void he2hb(
                     if (target == Target::Devices) {
                         A.allocateBatchArrays();
                         A.reserveDeviceWorkspace();
-                        W.allocateBatchArrays( 0, num_queues );
+                        W.allocateBatchArrays( batch_size_default, num_queues );
                         W.reserveDeviceWorkspace();
                     }
                 }

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -202,8 +202,12 @@ void he2hb(
                                           A.sub( i+1, nt-1, i, i ) }, i } );
                         }
                     }
-                    A.template listBcastMT<target>( bcast_list_V_first, layout, 5, set_hold );
-                    A.template listBcastMT<target>( bcast_list_V, layout, 6, set_hold );
+                    int life_5 = 5;
+                    int life_6 = 6;
+                    A.template listBcastMT<target>(
+                        bcast_list_V_first, layout, life_5, set_hold );
+                    A.template listBcastMT<target>(
+                        bcast_list_V, layout, life_6, set_hold );
 
                     if (first_indices.size() > 1) {
                         //BcastList bcast_list_T;
@@ -243,7 +247,9 @@ void he2hb(
                                 { i0, k, { Tlocal.sub( i, i, k+1, i ),
                                            Tlocal.sub( i+1, nt-1, i, i ) }, i } );
                         }
-                        Tlocal.template listBcastMT<target>( bcast_list_T, layout, 1, set_hold );
+                        int life_1 = 1;
+                        Tlocal.template listBcastMT<target>(
+                            bcast_list_T, layout, life_1, set_hold );
                     }
                 } // task
 

--- a/src/heev.cc
+++ b/src/heev.cc
@@ -76,6 +76,8 @@ void heev(
     const real_t sqrt_sml = sqrt( sml_num );
     const real_t sqrt_big = sqrt( big_num );
 
+    Target target = get_option( opts, Option::Target, Target::HostTask );
+
     // Scale matrix to allowable range, if necessary.
     real_t Anorm = norm( Norm::Max, A );
     real_t alpha = 1.0;
@@ -111,14 +113,14 @@ void heev(
     Lambda.resize(n);
     std::vector<real_t> E(n - 1);
     Matrix<scalar_t> V;
+    // Matrix to store Householder vectors.
+    // Could pack into a lower triangular matrix, but we store each
+    // parallelogram in a 2nb-by-nb tile, with nt(nt + 1)/2 tiles.
+    int64_t vm = 2*nb;
+    int64_t nt = A.nt();
+    int64_t vn = nt*(nt + 1)/2*nb;
+    V = Matrix<scalar_t>(vm, vn, vm, nb, 1, 1, A.mpiComm());
     if (A.mpiRank() == 0) {
-        // Matrix to store Householder vectors.
-        // Could pack into a lower triangular matrix, but we store each
-        // parallelogram in a 2nb-by-nb tile, with nt(nt + 1)/2 tiles.
-        int64_t vm = 2*nb;
-        int64_t nt = A.nt();
-        int64_t vn = nt*(nt + 1)/2*nb;
-        V = Matrix<scalar_t>(vm, vn, vm, nb, 1, 1, A.mpiComm());
         V.insertLocalTiles();
 
         // 2. Reduce band to real symmetric tri-diagonal.
@@ -135,9 +137,20 @@ void heev(
         MPI_Bcast( &E[0],      n-1, mpi_real_type, 0, A.mpiComm() );
         // QR iteration to get eigenvalues and eigenvectors of tridiagonal.
         steqr2( Job::Vec, Lambda, E, Z );
+
+        int mpi_size;
+        // Find the total number of processors.
+        slate_mpi_call(
+            MPI_Comm_size(A.mpiComm(), &mpi_size));
+
+        Matrix<scalar_t> Z1d(Z.m(), Z.n(), Z.tileNb(0), 1, mpi_size, Z.mpiComm());
+        Z1d.insertLocalTiles(target);
+        Z1d.redistribute(Z);
         // Back-transform: Z = Q1 * Q2 * Z.
-        unmtr_hb2st( Side::Left, Op::NoTrans, V, Z );
-        unmtr_he2hb( Side::Left, Op::NoTrans, A, T, Z );
+        unmtr_hb2st( Side::Left, Op::NoTrans, V, Z1d, opts );
+
+        Z.redistribute(Z1d);
+        unmtr_he2hb( Side::Left, Op::NoTrans, A, T, Z, opts );
     }
     else {
         if (A.mpiRank() == 0) {

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -44,8 +44,8 @@ void hegst(
     slate_assert(A.nt() == B.nt());
 
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
     }
 
     int64_t nt = A.nt();
@@ -91,7 +91,7 @@ void hegst(
                         B.template tileBcast<target>(k, k, Asub, layout);
 
                         internal::trsm<target>(
-                            Side::Right,  one,  conjTranspose(TBkk),
+                            Side::Right,  one,  conj_transpose( TBkk ),
                                                 std::move(Asub));
                     }
 
@@ -197,7 +197,7 @@ void hegst(
                                         one,  std::move(Asub));
 
                         internal::trmm<Target::HostTask>(
-                            Side::Left, one,  conjTranspose(TBkk),
+                            Side::Left, one,  conj_transpose( TBkk ),
                                               std::move(Asub));
                     }
                 }

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -26,6 +26,14 @@ void hegst(
     using BcastList = typename Matrix<scalar_t>::BcastList;
     using real_t = blas::real_type<scalar_t>;
 
+    // Constants
+    const scalar_t half = 0.5;
+    const scalar_t one  = 1.0;
+    const real_t r_one  = 1.0;
+    const int tag_0  = 0;
+    const int life_2 = 2;
+    const Layout layout = Layout::ColMajor;
+
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
@@ -41,15 +49,6 @@ void hegst(
     }
 
     int64_t nt = A.nt();
-
-    const scalar_t half = 0.5;
-    const scalar_t one  = 1.0;
-    const real_t r_one  = 1.0;
-
-    const int tag_zero        = 0;
-    const int life_factor_two = 2;
-
-    const Layout layout = Layout::ColMajor;
 
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> column_vector(nt);
@@ -99,7 +98,7 @@ void hegst(
                     #pragma omp task depend(inout:column[k])
                     {
                         A.tileBcast(
-                            k, k, Asub, layout, tag_zero, life_factor_two);
+                            k, k, Asub, layout, tag_0, life_2 );
 
                         BcastList bcast_list;
                         for (int64_t i = k+1; i < nt; ++i) {
@@ -107,7 +106,7 @@ void hegst(
                                                          A.sub(i, nt-1, i, i)}});
                         }
                         B.template listBcast<target>(
-                            bcast_list, layout, tag_zero, life_factor_two);
+                            bcast_list, layout, tag_0, life_2 );
                     }
 
                     #pragma omp task depend(in:column[k]) \
@@ -154,7 +153,7 @@ void hegst(
                     #pragma omp task depend(inout:column[0])
                     {
                         A.tileBcast(
-                            k, k, Asub, layout, tag_zero, life_factor_two);
+                            k, k, Asub, layout, tag_0, life_2 );
 
                         BcastList bcast_list;
                         for (int64_t i = 0; i < k; ++i) {
@@ -162,7 +161,7 @@ void hegst(
                                                          A.sub(i, i,   0, i)}});
                         }
                         B.template listBcast<target>(
-                            bcast_list, layout, tag_zero, life_factor_two);
+                            bcast_list, layout, tag_0, life_2 );
 
                         B.template tileBcast<target>(k, k, Asub, layout);
                     }

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -47,9 +47,9 @@ void hemmA(
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
-        A = conjTranspose(A);
-        B = conjTranspose(B);
-        C = conjTranspose(C);
+        A = conj_transpose( A );
+        B = conj_transpose( B );
+        C = conj_transpose( C );
         alpha = conj(alpha);
         beta  = conj(beta);
     }
@@ -424,7 +424,7 @@ void hemmA(
                 if (A.mt()-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, A.nt()-1);
                     internal::gemmA<target>(
-                        alpha, conjTranspose(Arow_k),
+                        alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, C.mt()-1, 0, C.nt()-1),
                         layout);

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -48,7 +48,8 @@ void hemmC(
 
     // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -81,8 +82,6 @@ void hemmC(
     std::vector<uint8_t>  gemm_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -157,7 +156,7 @@ void hemmC(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local );
+                    priority_0, opts_local );
 
                 // Erase remote tile on all devices including host
                 A.eraseRemoteWorkspaceTile( 0, 0 );
@@ -170,7 +169,7 @@ void hemmC(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -240,7 +239,7 @@ void hemmC(
                         alpha,  conjTranspose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -250,7 +249,7 @@ void hemmC(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -261,7 +260,7 @@ void hemmC(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -345,7 +344,7 @@ void hemmC(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local);
+                    priority_0, opts_local );
 
                 A.eraseRemoteWorkspaceTile( 0, 0 );
                 A.eraseLocalWorkspaceTile( 0, 0 );
@@ -356,7 +355,7 @@ void hemmC(
                         alpha, conjTranspose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -424,7 +423,7 @@ void hemmC(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -434,7 +433,7 @@ void hemmC(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -445,7 +444,7 @@ void hemmC(
                             alpha,  conjTranspose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -82,7 +82,7 @@ void hemmC(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -170,7 +170,7 @@ void hemmC(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -240,7 +240,7 @@ void hemmC(
                         alpha,  conjTranspose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -261,7 +261,7 @@ void hemmC(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -356,7 +356,7 @@ void hemmC(
                         alpha, conjTranspose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -424,7 +424,7 @@ void hemmC(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -445,7 +445,7 @@ void hemmC(
                             alpha,  conjTranspose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -56,9 +56,9 @@ void hemmC(
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
-        A = conjTranspose( A );
-        B = conjTranspose( B );
-        C = conjTranspose( C );
+        A = conj_transpose( A );
+        B = conj_transpose( B );
+        C = conj_transpose( C );
         alpha = conj( alpha );
         beta  = conj( beta );
     }
@@ -236,7 +236,7 @@ void hemmC(
                     auto Arow_k = A.sub(k, k, 0, k-1);
                     auto Brow_k = B.sub( k, k, 0, B.nt()-1 );
                     internal::gemm<target>(
-                        alpha,  conjTranspose( Arow_k ),
+                        alpha,  conj_transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
@@ -352,7 +352,7 @@ void hemmC(
                 if (A.mt()-1 > 0) {
                     auto Arow_0 = A.sub( 0, 0, 1, A.mt()-1 );
                     internal::gemm<target>(
-                        alpha, conjTranspose( Arow_0 ),
+                        alpha, conj_transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
@@ -441,7 +441,7 @@ void hemmC(
                     if (A.mt()-1 > k) {
                         auto Arow_k = A.sub( k, k, k+1, A.mt()-1 );
                         internal::gemm<target>(
-                            alpha,  conjTranspose( Arow_k ),
+                            alpha,  conj_transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
                             layout, priority_0, queue_0, opts_local );

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -59,7 +59,7 @@ void her2k(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -122,7 +122,7 @@ void her2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, default_queue, layout, opts_local );
+                default_priority, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -169,7 +169,7 @@ void her2k(
                     alpha,         std::move( A_colk ),
                                    std::move( B_colk ),
                     real_t( 1.0 ), std::move( C ),
-                    default_priority, default_queue, layout, opts_local );
+                    default_priority, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -58,7 +58,7 @@ void her2k(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -122,7 +122,7 @@ void her2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -169,7 +169,7 @@ void her2k(
                     alpha,         std::move( A_colk ),
                                    std::move( B_colk ),
                     real_t( 1.0 ), std::move( C ),
-                    default_priority, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -40,7 +40,7 @@ void her2k(
 
     // if upper, change to lower
     if (C.uplo() == Uplo::Upper)
-        C = conjTranspose(C);
+        C = conj_transpose( C );
 
     // A is mt-by-nt, C is mt-by-mt
     assert(A.mt() == C.mt());
@@ -200,8 +200,8 @@ void her2k(
 /// matrix, and A and B are an n-by-k matrices.
 /// The matrices can be conjugate-transposed beforehand, e.g.,
 ///
-///     auto AT = slate::conjTranspose( A );
-///     auto BT = slate::conjTranspose( B );
+///     auto AT = slate::conj_transpose( A );
+///     auto BT = slate::conj_transpose( B );
 ///     slate::her2k( alpha, AT, BT, beta, C );
 ///
 /// Complexity (in real): $\approx 2 k n^{2}$ flops.

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -55,7 +55,7 @@ void herk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -106,7 +106,7 @@ void herk(
             internal::herk<target>(
                 alpha, A.sub(0, A.mt()-1, 0, 0),
                 beta,  std::move(C),
-                default_priority, queue_0, layout, opts2);
+                priority_0, queue_0, layout, opts2);
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
@@ -145,7 +145,7 @@ void herk(
                 internal::herk<target>(
                     alpha,       A.sub(0, A.mt()-1, k, k),
                     real_t(1.0), std::move(C),
-                    default_priority, queue_0, layout, opts2);
+                    priority_0, queue_0, layout, opts2);
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -56,7 +56,7 @@ void herk(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -106,7 +106,7 @@ void herk(
             internal::herk<target>(
                 alpha, A.sub(0, A.mt()-1, 0, 0),
                 beta,  std::move(C),
-                default_priority, default_queue, layout, opts2);
+                default_priority, queue_0, layout, opts2);
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
@@ -145,7 +145,7 @@ void herk(
                 internal::herk<target>(
                     alpha,       A.sub(0, A.mt()-1, k, k),
                     real_t(1.0), std::move(C),
-                    default_priority, default_queue, layout, opts2);
+                    default_priority, queue_0, layout, opts2);
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -45,7 +45,7 @@ void herk(
 
     // if upper, change to lower
     if (C.uplo() == Uplo::Upper)
-        C = conjTranspose(C);
+        C = conj_transpose( C );
 
     // A is mt-by-nt, C is mt-by-mt
     assert(A.mt() == C.mt());
@@ -176,7 +176,7 @@ void herk(
 /// matrix, and A is an n-by-k matrix.
 /// The matrices can be conjugate-transposed beforehand, e.g.,
 ///
-///     auto AT = slate::conjTranspose( A );
+///     auto AT = slate::conj_transpose( A );
 ///     slate::herk( alpha, AT, beta, C );
 ///
 /// Complexity (in real): $\approx k n^{2}$ flops.

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -106,7 +106,7 @@ void hesv(HermitianMatrix<scalar_t>& A, Pivots& pivots,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     // factorization
     hetrf(A_, pivots, T, pivots2, H, opts);

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -155,7 +155,7 @@ void hetrf(
             {
                 //printf( " >> update T(%ld, %ld) on rank-%d <<\n", k, k, rank); fflush(stdout);
                 auto Hj = H.sub(k, k, 0, k-2);
-                Hj = conjTranspose(Hj);
+                Hj = conj_transpose( Hj );
 
                 #if 0
                 slate::internal::gemm_W<Target::HostTask>(
@@ -186,7 +186,7 @@ void hetrf(
                 if (T.tileIsLocal(k, k)) {
                     H.tileInsert(k, k);
                     auto Lkj = A.sub(k, k, k-2, k-2);
-                    Lkj = conjTranspose(Lkj);
+                    Lkj = conj_transpose( Lkj );
                     tile::gemm<scalar_t>(
                         one,  T(k,   k-1),
                               Lkj(0, 0),
@@ -292,7 +292,7 @@ void hetrf(
                                 H.tileBcast(k, j, A.sub(k+1, A_mt-1, j, j), layout, tag1);
                             }
                             auto Hj = H.sub(k, k, 0, k-2);
-                            Hj = conjTranspose(Hj);
+                            Hj = conj_transpose( Hj );
 
                             #if 1
                                 slate::internal::gemmA<Target::HostTask>(
@@ -333,7 +333,7 @@ void hetrf(
                             }
                             for (int64_t j = 0; j < k-1; ++j) {
                                 auto Hj = H.sub(k, k, j, j);
-                                Hj = conjTranspose(Hj);
+                                Hj = conj_transpose( Hj );
                                 slate::internal::gemm<target>(
                                     -one, A.sub(k+1, A_mt-1, j, j),
                                           Hj.sub(0, 0, 0, 0),
@@ -355,7 +355,7 @@ void hetrf(
                     H.tileBcast(k, k-1, A.sub(k+1, A_mt-1, k, k), layout, tag1);
 
                     auto Hj = H.sub(k, k, k-1, k-1);
-                    Hj = conjTranspose(Hj);
+                    Hj = conj_transpose( Hj );
                     slate::internal::gemm<target>(
                         -one, A.sub(k+1, A_mt-1, k-1, k-1),
                               Hj.sub(0,   0,     0, 0),
@@ -412,7 +412,7 @@ void hetrf(
                         auto Akk = A.sub(k, k, k-1, k-1);
                         auto Lkk = TriangularMatrix< scalar_t >(Uplo::Lower, Diag::NonUnit, Akk);
 
-                        Lkk = conjTranspose(Lkk);
+                        Lkk = conj_transpose( Lkk );
                         tile::trsm(
                             Side::Right, Diag::Unit,
                             one, Lkk(0, 0), T(k+1, k) );

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -34,6 +34,12 @@ void hetrf(
     using BcastList  = typename Matrix<scalar_t>::BcastList;
     using ReduceList = typename Matrix<scalar_t>::ReduceList;
 
+    // Constants
+    const scalar_t zero = 0.0;
+    const scalar_t one  = 1.0;
+    const int64_t ione  = 1;
+    const int64_t izero = 0;
+    const int priority_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -61,11 +67,6 @@ void hetrf(
     //uint8_t* ind1 = Ind1.data();
     //uint8_t* ind2 = Ind2.data();
 
-    const scalar_t zero = 0.0;
-    const scalar_t one  = 1.0;
-    int64_t ione  = 1;
-    int64_t izero = 0;
-    int priority_one = 1;
     assert(A.uplo() == Uplo::Lower); // upper not implemented, yet
 
     pivots.resize(A_mt);
@@ -337,7 +338,7 @@ void hetrf(
                                     -one, A.sub(k+1, A_mt-1, j, j),
                                           Hj.sub(0, 0, 0, 0),
                                     one,  A.sub(k+1, A_mt-1, k, k),
-                                    layout, priority_one);
+                                    layout, priority_1 );
                             }
                         }
                     }
@@ -359,7 +360,7 @@ void hetrf(
                         -one, A.sub(k+1, A_mt-1, k-1, k-1),
                               Hj.sub(0,   0,     0, 0),
                         one,  A.sub(k+1, A_mt-1, k, k),
-                        layout, priority_one);
+                        layout, priority_1 );
                 }
             }
 
@@ -370,7 +371,7 @@ void hetrf(
                 //printf( " >> LU panel(%ld:%ld,%ld) diag_len=%ld on rank-%d <<\n", k+1, A_mt-1, k, diag_len, rank); fflush(stdout);
                 internal::getrf_panel<Target::HostTask>(
                     A.sub(k+1, A_mt-1, k, k), diag_len, ib,
-                    pivots.at(k+1), max_panel_threads, priority_one);
+                    pivots.at(k+1), max_panel_threads, priority_1 );
 
                 // copy U(k, k) into T(k+1, k)
                 //printf( " >> compute T(%ld,%ld) on rank-%d <<\n", k+1, k, rank); fflush(stdout);

--- a/src/hetrs.cc
+++ b/src/hetrs.cc
@@ -73,7 +73,7 @@ void hetrs(HermitianMatrix<scalar_t>& A, Pivots& pivots,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     int64_t A_nt = A_.nt();
     int64_t A_mt = A_.mt();
@@ -102,7 +102,7 @@ void hetrs(HermitianMatrix<scalar_t>& A, Pivots& pivots,
         // backward substitution with L^T from Aasen's
         auto Lkk = TriangularMatrix<scalar_t>( Diag::NonUnit, A_, 1, A_mt-1, 0, A_nt-2 );
         auto Bkk = B.sub(1, B_mt-1, 0, B_nt-1);
-        Lkk = conjTranspose(Lkk);
+        Lkk = conj_transpose( Lkk );
         trsm(Side::Left, one, Lkk, Bkk, opts);
 
         // pivot right-hand-sides

--- a/src/internal/internal_copyhb2st.cc
+++ b/src/internal/internal_copyhb2st.cc
@@ -45,7 +45,7 @@ void copyhb2st(internal::TargetType<Target::HostTask>,
 
     // If lower, change to upper.
     if (A.uplo() == Uplo::Lower) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
 
     // Make sure it is a tri-diagonal matrix.

--- a/src/internal/internal_copytb2bd.cc
+++ b/src/internal/internal_copytb2bd.cc
@@ -43,7 +43,7 @@ void copytb2bd(internal::TargetType<Target::HostTask>,
 
     // If lower, change to upper.
     if (A.uplo() == Uplo::Lower) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
 
     // Make sure it is a bi-diagonal matrix.

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -15,6 +15,9 @@ namespace slate {
 
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET)
+
 template <>
 void geadd(
     int64_t m, int64_t n,
@@ -65,6 +68,8 @@ void geadd(
 #endif
 }
 
+#endif // ! defined( SLATE_HAVE_OMPTARGET)
+
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.
 template <>
@@ -88,6 +93,9 @@ void geadd(
 
 //==============================================================================
 namespace batch {
+
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
 
 template <>
 void geadd(
@@ -138,6 +146,8 @@ void geadd(
           batch_count, queue);
 #endif
 }
+
+#endif // if ! defined( SLATE_HAVE_OMPTARGET)
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_gebr.cc
+++ b/src/internal/internal_gebr.cc
@@ -90,7 +90,7 @@ void gerf(int64_t n, scalar_t* v, Matrix<scalar_t>& A)
     v[0] = one;
 
     // w = A^H v
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     std::vector<scalar_t> w(AH.m());
 
     scalar_t* wi = w.data();
@@ -164,7 +164,7 @@ void gebr1(internal::TargetType<Target::HostTask>,
 
     // Zero A[0, 1:n-1].
     // Apply A Q^H => becomes Q A^H.
-    auto A1 = conjTranspose(A);
+    auto A1 = conj_transpose( A );
     gerfg(A1, n1, v1);
     gerf(n1, v1, A1);
 
@@ -220,7 +220,7 @@ void gebr2(internal::TargetType<Target::HostTask>,
 
     // Zero A[0, 1:n-1].
     // Apply A Q^H => becomes Q A^H.
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     gerfg(AH, n2, v2);
     gerf(n2, v2, AH);
 }
@@ -266,7 +266,7 @@ void gebr3(internal::TargetType<Target::HostTask>,
     trace::Block trace_block("internal::gebr3");
 
     // Apply the reflector from task 2: Q A.
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     gerf(n1, v1, AH);
 
     // Zero A[1:m-1, 0].

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -15,6 +15,9 @@
 namespace slate {
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void gecopy(
     int64_t m, int64_t n,
@@ -98,6 +101,8 @@ void gecopy(
            batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 //---------------------------------------------------
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -141,6 +141,10 @@ void gemm(internal::TargetType<Target::HostNest>,
           Layout layout, int priority, int64_t queue_index,
           Options const& opts )
 {
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // check dimensions
     assert(A.nt() == 1);
     assert(B.mt() == 1);
@@ -178,6 +182,7 @@ void gemm(internal::TargetType<Target::HostNest>,
 
     if (err)
         slate_error(err_msg+", line "+std::to_string(err));
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -17,8 +17,8 @@ namespace internal {
 /// where A is a single block column and B is a single block row.
 /// Dispatches to target implementations.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 ///
 /// @param[in] layout
 ///     Indicates the Layout (ColMajor/RowMajor) to operate with.

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -20,8 +20,8 @@ namespace internal {
 /// for all i = 0 : A.mt, j = 0 : A.nt, k=.
 /// Dispatches to target implementations.
 /// In the complex case,
-/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conjTranspose;
-/// if $op(C)$ is conjTranspose, then $op(A)$ and $op(B)$ cannot be transpose.
+/// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
+/// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 /// @ingroup gemm_internal
 ///
 template <Target target, typename scalar_t>

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -211,7 +211,7 @@ void gemmA(internal::TargetType<Target::Devices>,
             int cpt = 0;
             for (int64_t j = 0; j < A.nt(); ++j) {
                 if (A.tileIsLocal( i, j )) {
-                    cpt++;
+                    ++cpt;
                 }
             }
             if (cpt == 0 && C.tileIsLocal( i, 0 )) {

--- a/src/internal/internal_genorm.cc
+++ b/src/internal/internal_genorm.cc
@@ -21,6 +21,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void genorm(
     Norm in_norm, NormScope scope,
@@ -58,6 +61,8 @@ void genorm(
            values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_gescale.cc
+++ b/src/internal/internal_gescale.cc
@@ -16,6 +16,9 @@ namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device single tile routine
 template <>
 void gescale(
@@ -104,6 +107,8 @@ void gescale(
             queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_geset.cc
+++ b/src/internal/internal_geset.cc
@@ -19,6 +19,9 @@ namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device single tile routine
 template <>
 void geset(
@@ -67,6 +70,8 @@ void geset(
 #endif
 }
 
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
+
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.
 template <>
@@ -92,6 +97,9 @@ void geset(
 namespace batch {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device::batch routine
 template <>
 void geset(
@@ -139,6 +147,8 @@ void geset(
           batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -269,7 +269,7 @@ void he2hb_hemm(
             //queue->sync(); // sync all the queues/streams
 
             // sync all the queues (in case of queue per iteration i)
-            for (int64_t i = 0; i < num_queues; i++) {
+            for (int64_t i = 0; i < num_queues; ++i) {
                 blas::Queue* queue = C.compute_queue( device, i );
                 queue->sync();
             }

--- a/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
+++ b/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
@@ -78,7 +78,7 @@ void he2hb_her2k_offdiag_ranks(
                     A.tileGetForReading( i, 0, layout_conv );
                     C.tileGetForWriting( j, i, layout_conv );
                     // Aji -= Wjk Vik^H
-                    tile::gemm( alpha, B( j, 0 ), conjTranspose( A( i, 0 ) ),
+                    tile::gemm( alpha, B( j, 0 ), conj_transpose( A( i, 0 ) ),
                                 beta, C( j, i ) );
                     B.tileTick( j, 0 );
                     A.tileTick( i, 0 );

--- a/src/internal/internal_hebr.cc
+++ b/src/internal/internal_hebr.cc
@@ -65,7 +65,7 @@ void herf(int64_t n, scalar_t* v, HermitianMatrix<scalar_t>& A)
             else {
                 auto Aij = i > j
                          ? A(i, j)
-                         : conjTranspose(A(j, i));
+                         : conj_transpose( A( j, i ) );
                 tile::gemv( one, Aij, vj, beta, wi );
             }
             beta = one;
@@ -206,7 +206,7 @@ void hebr2(internal::TargetType<Target::HostTask>,
     trace::Block trace_block("internal::hebr2");
 
     // Apply the reflector from task type 1 or 2.
-    auto AH = conjTranspose(A);
+    auto AH = conj_transpose( A );
     gerf(n1, v1, AH);
 
     // Zero A[1:n-1, 0].

--- a/src/internal/internal_henorm.cc
+++ b/src/internal/internal_henorm.cc
@@ -23,6 +23,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void henorm(
     Norm in_norm, Uplo uplo,
@@ -60,6 +63,8 @@ void henorm(
            values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA.

--- a/src/internal/internal_her2k.cc
+++ b/src/internal/internal_her2k.cc
@@ -159,6 +159,10 @@ void her2k(internal::TargetType<Target::HostNest>,
 {
     using blas::conj;
 
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::her2k()
     //       to take layout param
@@ -233,6 +237,7 @@ void her2k(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_herk.cc
+++ b/src/internal/internal_herk.cc
@@ -140,6 +140,10 @@ void herk(internal::TargetType<Target::HostNest>,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>& C,
           int priority, int queue_index, Layout layout, Options const& opts)
 {
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     scalar_t alpha_ = scalar_t(alpha);
     scalar_t beta_  = scalar_t(beta);
 
@@ -208,6 +212,7 @@ void herk(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_swap.cc
+++ b/src/internal/internal_swap.cc
@@ -597,12 +597,12 @@ void permuteRows(
                             remote_count[r] = remote_index[r] - remote_offsets[r];
                         }
 
-                        #if defined(SLATE_WITH_GPU_AWARE_MPI)
-                        scalar_t* remote_rows = remote_rows_dev;
+                        #if defined( SLATE_HAVE_GPU_AWARE_MPI )
+                            scalar_t* remote_rows = remote_rows_dev;
                         #else
-                        int64_t remote_rows_size = remote_offsets[comm_size]*nb;
-                        std::vector<scalar_t> remote_rows_vect (remote_rows_size);
-                        scalar_t* remote_rows = remote_rows_vect.data();
+                            int64_t remote_rows_size = remote_offsets[comm_size]*nb;
+                            std::vector<scalar_t> remote_rows_vect( remote_rows_size );
+                            scalar_t* remote_rows = remote_rows_vect.data();
                         #endif
 
                         // Gather remote rows to root.
@@ -619,9 +619,10 @@ void permuteRows(
                         }
                         MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
 
-                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
-                        blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
-                                                      remote_rows_size, *compute_queue);
+                        #if ! defined( SLATE_HAVE_GPU_AWARE_MPI )
+                            blas::device_memcpy<scalar_t>(
+                                remote_rows_dev, remote_rows,
+                                remote_rows_size, *compute_queue );
                         #endif
 
                         // Swap rows locally.
@@ -656,9 +657,10 @@ void permuteRows(
                         }
                         compute_queue->sync();
 
-                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
-                        blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
-                                                      remote_rows_size, *compute_queue);
+                        #if ! defined( SLATE_HAVE_GPU_AWARE_MPI )
+                            blas::device_memcpy<scalar_t>(
+                                remote_rows, remote_rows_dev,
+                                remote_rows_size, *compute_queue );
                         #endif
 
                         // Scatter remote rows.
@@ -714,14 +716,15 @@ void permuteRows(
                             compute_queue->sync();
 
                             // Send rows, then recv updated rows.
-                            #if defined(SLATE_WITH_GPU_AWARE_MPI)
-                            scalar_t* remote_rows = remote_rows_dev;
+                            #if defined( SLATE_HAVE_GPU_AWARE_MPI )
+                                scalar_t* remote_rows = remote_rows_dev;
                             #else
-                            int64_t remote_rows_size = remote_length*nb;
-                            std::vector<scalar_t> remote_rows_vect (remote_rows_size);
-                            scalar_t* remote_rows = remote_rows_vect.data();
-                            blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
-                                                          remote_rows_size, *compute_queue);
+                                int64_t remote_rows_size = remote_length*nb;
+                                std::vector<scalar_t> remote_rows_vect( remote_rows_size );
+                                scalar_t* remote_rows = remote_rows_vect.data();
+                                blas::device_memcpy<scalar_t>(
+                                    remote_rows, remote_rows_dev,
+                                    remote_rows_size, *compute_queue );
                             #endif
 
                             MPI_Send(remote_rows, remote_length, row_type,
@@ -729,9 +732,10 @@ void permuteRows(
                             MPI_Recv(remote_rows, remote_length, row_type,
                                      root_rank, tag, comm, MPI_STATUS_IGNORE);
 
-                            #if !defined(SLATE_WITH_GPU_AWARE_MPI)
-                            blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
-                                                          remote_rows_size, *compute_queue);
+                            #if ! defined( SLATE_HAVE_GPU_AWARE_MPI )
+                                blas::device_memcpy<scalar_t>(
+                                    remote_rows_dev, remote_rows,
+                                    remote_rows_size, *compute_queue );
                             #endif
 
                             // Unpack pivot rows from workspace.

--- a/src/internal/internal_swap.cc
+++ b/src/internal/internal_swap.cc
@@ -296,7 +296,7 @@ void permuteRows(
                         scalar_t* rows_r = remote_rows + nb*remote_offsets[r];
                         MPI_Irecv(rows_r, remote_count[r], row_type,
                                   r, tag, comm, &requests[request_count]);
-                        request_count++;
+                        ++request_count;
                     }
                 }
                 MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
@@ -343,7 +343,7 @@ void permuteRows(
                         scalar_t* rows_r = remote_rows + nb*remote_offsets[r];
                         MPI_Isend(rows_r, remote_count[r], row_type,
                                   r, tag, comm, &requests[request_count]);
-                        request_count++;
+                        ++request_count;
                     }
                 }
                 MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
@@ -614,7 +614,7 @@ void permuteRows(
                                 scalar_t* rows_r = remote_rows + nb*remote_offsets[r];
                                 MPI_Irecv(rows_r, remote_count[r], row_type,
                                           r, tag, comm, &requests[request_count]);
-                                request_count++;
+                                ++request_count;
                             }
                         }
                         MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
@@ -670,7 +670,7 @@ void permuteRows(
                                 scalar_t* rows_r = remote_rows + nb*remote_offsets[r];
                                 MPI_Isend(rows_r, remote_count[r], row_type,
                                           r, tag, comm, &requests[request_count]);
-                                request_count++;
+                                ++request_count;
                             }
                         }
                         MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);

--- a/src/internal/internal_swap.cc
+++ b/src/internal/internal_swap.cc
@@ -597,9 +597,13 @@ void permuteRows(
                             remote_count[r] = remote_index[r] - remote_offsets[r];
                         }
 
+                        #if defined(SLATE_WITH_GPU_AWARE_MPI)
+                        scalar_t* remote_rows = remote_rows_dev;
+                        #else
                         int64_t remote_rows_size = remote_offsets[comm_size]*nb;
                         std::vector<scalar_t> remote_rows_vect (remote_rows_size);
                         scalar_t* remote_rows = remote_rows_vect.data();
+                        #endif
 
                         // Gather remote rows to root.
                         std::vector<MPI_Request> requests (comm_size);
@@ -615,8 +619,10 @@ void permuteRows(
                         }
                         MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
 
+                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
                         blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
                                                       remote_rows_size, *compute_queue);
+                        #endif
 
                         // Swap rows locally.
                         for (int64_t i = begin; i != end; i += inc) {
@@ -650,8 +656,10 @@ void permuteRows(
                         }
                         compute_queue->sync();
 
+                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
                         blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
                                                       remote_rows_size, *compute_queue);
+                        #endif
 
                         // Scatter remote rows.
                         // reuse requests array from before
@@ -683,7 +691,6 @@ void permuteRows(
                         }
 
                         if (remote_length > 0) {
-                            int64_t remote_rows_size = remote_length*nb;
 
                             // Pack pivot rows into workspace.
                             int64_t count = 0;
@@ -707,19 +714,25 @@ void permuteRows(
                             compute_queue->sync();
 
                             // Send rows, then recv updated rows.
-                            // todo: MPI GPU direct.
+                            #if defined(SLATE_WITH_GPU_AWARE_MPI)
+                            scalar_t* remote_rows = remote_rows_dev;
+                            #else
+                            int64_t remote_rows_size = remote_length*nb;
                             std::vector<scalar_t> remote_rows_vect (remote_rows_size);
                             scalar_t* remote_rows = remote_rows_vect.data();
                             blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
                                                           remote_rows_size, *compute_queue);
+                            #endif
 
                             MPI_Send(remote_rows, remote_length, row_type,
                                      root_rank, tag, comm);
                             MPI_Recv(remote_rows, remote_length, row_type,
                                      root_rank, tag, comm, MPI_STATUS_IGNORE);
 
+                            #if !defined(SLATE_WITH_GPU_AWARE_MPI)
                             blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
                                                           remote_rows_size, *compute_queue);
+                            #endif
 
                             // Unpack pivot rows from workspace.
                             count = 0;

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -22,6 +22,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void synorm(
     Norm in_norm, Uplo uplo,
@@ -97,6 +100,8 @@ void synormOffdiag(
                   values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_syr2k.cc
+++ b/src/internal/internal_syr2k.cc
@@ -153,6 +153,10 @@ void syr2k(internal::TargetType<Target::HostNest>,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
            int priority, int queue_index, Layout layout, Options const& opts)
 {
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::syr2k()
     //       to take layout param
@@ -226,6 +230,7 @@ void syr2k(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_syrk.cc
+++ b/src/internal/internal_syrk.cc
@@ -139,6 +139,10 @@ void syrk(internal::TargetType<Target::HostNest>,
           int priority, int queue_index, Layout layout,
           Options const& opts)
 {
+#if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
+    // SYCL/OMP-target-offload can't process this section
+    slate_not_implemented("Target::HostNest isn't supported in this configuration.");
+#else
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::syrk()
     //       to take layout param
@@ -204,6 +208,7 @@ void syrk(internal::TargetType<Target::HostNest>,
 
     if (err)
         throw std::exception();
+#endif // omit if SLATE_HAVE_OMPTARGET
 }
 
 //------------------------------------------------------------------------------

--- a/src/internal/internal_transpose.cc
+++ b/src/internal/internal_transpose.cc
@@ -20,6 +20,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET)
+
 template <>
 void transpose(
     int64_t n,
@@ -159,6 +162,7 @@ void transpose_batch(
 #endif
 }
 
+#endif // ! defined( SLATE_HAVE_OMPTARGET)
 
 //------------------------------------------------------------------------------
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_trnorm.cc
+++ b/src/internal/internal_trnorm.cc
@@ -21,6 +21,9 @@ namespace slate {
 // cu*Complex in .cu files, and cast from std::complex here.
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void trnorm(
     Norm in_norm, Uplo uplo, Diag diag,
@@ -58,6 +61,8 @@ void trnorm(
            values, ldv, batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_tzadd.cc
+++ b/src/internal/internal_tzadd.cc
@@ -15,6 +15,9 @@ namespace slate {
 
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void tzadd(
     Uplo uplo,
@@ -66,6 +69,8 @@ void tzadd(
           batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -15,6 +15,9 @@
 namespace slate {
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void tzcopy(
     Uplo uplo,
@@ -106,6 +109,8 @@ void tzcopy(
            batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 //---------------------------------------------------
 #if ! defined( SLATE_HAVE_DEVICE )

--- a/src/internal/internal_tzscale.cc
+++ b/src/internal/internal_tzscale.cc
@@ -14,6 +14,9 @@
 namespace slate {
 namespace device {
 
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 template <>
 void tzscale(
     Uplo uplo,
@@ -57,6 +60,8 @@ void tzscale(
             batch_count, queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 // Specializations to allow compilation without CUDA or HIP.

--- a/src/internal/internal_tzset.cc
+++ b/src/internal/internal_tzset.cc
@@ -19,6 +19,9 @@ namespace slate {
 namespace device {
 
 //------------------------------------------------------------------------------
+// CUBLAS/ROCBLAS need complex translation, others do not
+#if ! defined( SLATE_HAVE_OMPTARGET )
+
 // device single tile routine
 template <>
 void tzset(
@@ -72,6 +75,8 @@ void tzset(
         queue);
 #endif
 }
+
+#endif // ! defined( SLATE_HAVE_OMPTARGET )
 
 #if ! defined( SLATE_HAVE_DEVICE )
 //----------------------------------------

--- a/src/internal/internal_unmlq.cc
+++ b/src/internal/internal_unmlq.cc
@@ -152,7 +152,7 @@ void unmlq(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op == Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -202,7 +202,7 @@ void unmlq(internal::TargetType<target>,
         if (row_indices.size() > 1) {
             // C1 <- C1 - V1^H W
             internal::gemm<target>(
-                    -one, conjTranspose(V.sub(0, 0, row_indices[1], mt-1)),
+                    -one, conj_transpose( V.sub( 0, 0, row_indices[1], mt-1 ) ),
                           std::move(Wr),
                     one,  C.sub(row_indices[1], mt-1, 0, nt-1),
                     layout);
@@ -211,7 +211,7 @@ void unmlq(internal::TargetType<target>,
         if (trapezoid) {
             // C0b <- C0b - V0b^H W
             internal::gemm<Target::HostTask>(
-                    -one, conjTranspose(std::move(V0b)),
+                    -one, conj_transpose( std::move( V0b ) ),
                           std::move(Wr),
                     one,  std::move(C0b),
                     layout);
@@ -220,7 +220,7 @@ void unmlq(internal::TargetType<target>,
         // W <- V0^H W
         internal::trmm<Target::HostTask>(
                 Side::Left,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wr));
 
         // C0 <- C0 - W
@@ -328,7 +328,7 @@ void unmlq(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op == Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -339,14 +339,14 @@ void unmlq(internal::TargetType<target>,
         internal::copy(std::move(C0), std::move(Wc));
         internal::trmm<Target::HostTask>(
                 Side::Right,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wc));
 
         if (trapezoid) {
             // W <- C0b V0b^H + W
             internal::gemm<Target::HostTask>(
                     one, std::move(C0b),
-                         conjTranspose(V0b),
+                         conj_transpose( V0b ),
                     one, std::move(Wc),
                     layout);
         }
@@ -361,7 +361,7 @@ void unmlq(internal::TargetType<target>,
             }
             internal::gemm<target>(
                     one, std::move(Ci),
-                         conjTranspose(V.sub(0, 0, col, col)),
+                         conj_transpose( V.sub( 0, 0, col, col ) ),
                     one, std::move(Wc),
                     layout);
         }

--- a/src/internal/internal_unmqr.cc
+++ b/src/internal/internal_unmqr.cc
@@ -150,7 +150,7 @@ void unmqr(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Lower, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op != Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -163,14 +163,14 @@ void unmqr(internal::TargetType<target>,
                 priority, queue_index);
         internal::trmm<target>(
                 Side::Left,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wr),
                 priority, queue_index);
 
         if (trapezoid) {
             // W <- V0b^H C0b + W
             internal::gemm<target>(
-                    one, conjTranspose(V0b),
+                    one, conj_transpose( V0b ),
                          std::move(C0b),
                     one, std::move(Wr),
                     layout,
@@ -186,7 +186,7 @@ void unmqr(internal::TargetType<target>,
                 Ci.tileGetAndHoldAllOnDevices(LayoutConvert(layout));
             }
             internal::gemm<target>(
-                    one, conjTranspose(V.sub(row, row, 0, 0)),
+                    one, conj_transpose( V.sub( row, row, 0, 0 ) ),
                          std::move(Ci),
                     one, std::move(Wr),
                     layout,
@@ -331,7 +331,7 @@ void unmqr(internal::TargetType<target>,
         auto V0tr = TriangularMatrix<scalar_t>(Uplo::Lower, Diag::Unit, V0);
         auto T0tr = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, T0);
         if (op != Op::NoTrans) {
-            T0tr = conjTranspose(T0tr);
+            T0tr = conj_transpose( T0tr );
         }
 
         // --------------------
@@ -388,7 +388,7 @@ void unmqr(internal::TargetType<target>,
             // C1 <- C1 - W V1^H
             internal::gemm<target>(
                     -one, std::move(Wc),
-                          conjTranspose(V.sub(col_indices[1], nt-1, 0, 0)),
+                          conj_transpose( V.sub( col_indices[1], nt-1, 0, 0 ) ),
                     one,  C.sub(0, mt-1, col_indices[1], nt-1),
                     layout,
                     priority, queue_index);
@@ -398,7 +398,7 @@ void unmqr(internal::TargetType<target>,
             // C0b <- C0b - W V0b^H
             internal::gemm<target>(
                     -one, std::move(Wc),
-                          conjTranspose(V0b),
+                          conj_transpose( V0b ),
                     one,  std::move(C0b),
                     layout,
                     priority, queue_index);
@@ -407,7 +407,7 @@ void unmqr(internal::TargetType<target>,
         // W <- W V0^H
         internal::trmm<target>(
                 Side::Right,
-                one, conjTranspose(V0tr),
+                one, conj_transpose( V0tr ),
                      std::move(Wc),
                 priority, queue_index);
 

--- a/src/norm.cc
+++ b/src/norm.cc
@@ -39,7 +39,7 @@ norm(
             in_norm = Norm::One;
     }
     if (A.op() == Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     else if (A.op() == Op::Trans)
         A = transpose(A);
 

--- a/src/omptarget/device_geadd.cc
+++ b/src/omptarget/device_geadd.cc
@@ -1,0 +1,209 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Routine for element-wise tile addition.
+/// Sets
+/// \[
+///     B = \alpha A + \beta B.
+/// \]
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] alpha
+///     The scalar alpha.
+///
+/// @param[in] A
+///     is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] beta
+///     The scalar beta.
+///
+/// @param[in,out] B
+///     is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void geadd(
+    int64_t m, int64_t n,
+    scalar_t const& alpha, scalar_t* A, int64_t lda,
+    scalar_t const& beta, scalar_t* B, int64_t ldb,
+    blas::Queue &queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(A, B) device(queue.device())
+    #pragma omp teams distribute parallel for schedule(static, 1)
+    for (int64_t i = 0; i < m; ++i) {
+        scalar_t* rowA = &A[i];
+        scalar_t* rowB = &B[i];
+        for (int64_t j = 0; j < n; ++j) {
+            rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geadd(
+    int64_t m, int64_t n,
+    float const& alpha, float* Aarray, int64_t lda,
+    float const& beta, float* Barray, int64_t ldb,
+    blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    double const& alpha, double* Aarray, int64_t lda,
+    double const& beta, double* Barray, int64_t ldb,
+    blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    std::complex<float> const& alpha, std::complex<float>* Aarray, int64_t lda,
+    std::complex<float> const& beta, std::complex<float>* Barray, int64_t ldb,
+    blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    std::complex<double> const& alpha, std::complex<double>* Aarray, int64_t lda,
+    std::complex<double> const& beta, std::complex<double>* Barray, int64_t ldb,
+    blas::Queue &queue);
+
+//==============================================================================
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise tile addition.
+/// Sets
+/// \[
+///     Barray[k] = \alpha Aarray[k] + \beta Barray[k].
+/// \]
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] alpha
+///     The scalar alpha.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] beta
+///     The scalar beta.
+///
+/// @param[in,out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void geadd(
+    int64_t m, int64_t n,
+    scalar_t const& alpha, scalar_t** Aarray, int64_t lda,
+    scalar_t const& beta, scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* tileA = Aarray[k];
+        scalar_t* tileB = Barray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[i];
+            scalar_t* rowB = &tileB[i];
+            for (int64_t j = 0; j < n; ++j) {
+                rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geadd(
+    int64_t m, int64_t n,
+    float const& alpha, float** Aarray, int64_t lda,
+    float const& beta, float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    double const& alpha, double** Aarray, int64_t lda,
+    double const& beta, double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    std::complex<float> const& alpha, std::complex<float>** Aarray, int64_t lda,
+    std::complex<float> const& beta, std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geadd(
+    int64_t m, int64_t n,
+    std::complex<double> const& alpha, std::complex<double>** Aarray, int64_t lda,
+    std::complex<double> const& beta, std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace batch
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_gecopy.cc
+++ b/src/omptarget/device_gecopy.cc
@@ -1,0 +1,140 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <algorithm>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise copy and precision conversion,
+/// copying A to B. Sets
+/// \[
+///     Barray[k] = Aarray[k].
+/// \]
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename src_scalar_t, typename dst_scalar_t>
+void gecopy(
+    int64_t m, int64_t n,
+    src_scalar_t const* const*  Aarray, int64_t lda,
+    dst_scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        src_scalar_t const* tileA = Aarray[k];
+        dst_scalar_t* tileB = Barray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            src_scalar_t const* rowA = &tileA[i];
+            dst_scalar_t* rowB = &tileB[i];
+            for (int64_t j = 0; j < n; ++j) {
+                // todo: confirm type conversion float-complex -> double-complex
+                // todo: confirm type conversion double-complex -> float-complex
+                rowB[j*ldb] = rowA[j*lda];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void gecopy(
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_genorm.cc
+++ b/src/omptarget/device_genorm.cc
@@ -1,0 +1,281 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., m-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= m.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: ldv >= m.
+///         On exit, values[k*ldv + i] = sum_{j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= i < m.
+///
+///     - Norm::Fro: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    if (scope == NormScope::Matrix) {
+
+        //---------
+        // max norm
+        if (norm == lapack::Norm::Max) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count, queue);
+            }
+            else {
+                assert(ldv == 1);
+                blas::device_memset(values, 0, batch_count, queue);
+                queue.sync(); // sync queue before switching to openmp device execution
+                // Use omp target offload
+                // note: the max_nan_reduction preserves nans
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    const scalar_t* tileA = Aarray[k];
+                    #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                    for (int64_t i = 0; i < m; ++i) {
+                        const scalar_t* rowA = &tileA[i];
+                        real_t max = 0;
+                        for (int64_t j = 0; j < n; ++j) {
+                            max = max_nan(max, abs_val(rowA[j*lda]));
+                        }
+                        values[k] = max_nan(values[k], max);
+                    }
+                }
+            }
+        }
+        //---------
+        // one norm
+        else if (norm == lapack::Norm::One) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * n, queue);
+            }
+            else {
+                assert(ldv >= n);
+                queue.sync(); // sync queue before switching to openmp device execution
+                // use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    // distribute cols to threads (j)
+                    #pragma omp parallel for schedule(static, 1)
+                    for (int64_t j = 0; j < n; ++j) {
+                        values[k*ldv + j] = 0;
+                        for (int64_t i = 0; i < m; ++i) {
+                            values[k*ldv + j] += abs_val( Aarray[k][i + j*lda] );
+                        }
+                    }
+                }
+            }
+        }
+        //---------
+        // inf norm
+        else if (norm == lapack::Norm::Inf) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * m, queue);
+            }
+            else {
+                assert(ldv >= m);
+                queue.sync(); // sync queue before switching to openmp device execution
+                // use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    // distribute rows to threads (i)
+                    #pragma omp parallel for schedule(static, 1)
+                    for (int64_t i = 0; i < m; ++i) {
+                        values[k*ldv + i] = 0;
+                        for (int64_t j = 0; j < n; ++j) {
+                            values[k*ldv + i] += abs_val( Aarray[k][i + j*lda] );
+                        }
+                    }
+                }
+            }
+        }
+        //---------
+        // Frobenius norm
+        else if (norm == lapack::Norm::Fro) {
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * 2, queue);
+            }
+            else {
+                assert(ldv == 2);
+                queue.sync(); // sync queue before switching to openmp device execution
+                // use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    const scalar_t* tileA = Aarray[k];
+                    values[k*2 + 0] = 0; // scale_k
+                    values[k*2 + 1] = 1; // sumsq_k
+                    // distribute rows to threads (i)
+                    #pragma omp parallel for schedule(static, 1)
+                    for (int64_t i = 0; i < m; ++i) {
+                        real_t scale_ki = 0;
+                        real_t sumsq_ki = 1;
+                        for (int64_t j = 0; j < n; ++j)
+                            add_sumsq(scale_ki, sumsq_ki, abs_val( tileA[i + j*lda] ));
+                        // accumulate the scale and sumsq for each k
+                        // todo: critical section is slow, is there a better way?
+                        #pragma omp critical
+                        {
+                            real_t scale_k = values[k*2 + 0];
+                            real_t sumsq_k = values[k*2 + 1];
+                            if (scale_k > scale_ki) {
+                                sumsq_k = sumsq_k + sumsq_ki*(scale_ki / scale_k)*(scale_ki / scale_k);
+                                // scale_k stays same
+                            }
+                            else if (scale_ki != 0) {
+                                sumsq_k = sumsq_k*(scale_k / scale_ki)*(scale_k / scale_ki) + sumsq_ki;
+                                scale_k = scale_ki;
+                            }
+                            values[k*2 + 0] = scale_k;
+                            values[k*2 + 1] = sumsq_k;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    else if (scope == NormScope::Columns) {
+
+        if (norm == Norm::Max) {
+
+            if (m == 0 || n == 0) {
+                blas::device_memset(values, 0, batch_count * n, queue);
+            }
+            else {
+                // todo:  NOTE THIS NORM IS NOT CHECKED YET
+                assert(ldv >= n);
+                blas::device_memset(values, 0, batch_count * n, queue);
+                queue.sync(); // sync queue before switching to openmp device execution
+                // Use omp target offload
+                #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+                #pragma omp teams distribute
+                for (int64_t k = 0; k < batch_count; ++k) {
+                    const scalar_t* tileA = Aarray[k];
+                    // distribute cols to threads (j)
+                    #pragma omp parallel for collapse(1) schedule(static, 1)
+                    for (int64_t j = 0; j < n; ++j) {
+                        const scalar_t* colA = &tileA[j*lda];
+                        for (int64_t i = 0; i < m; ++i) {
+                            values[j*ldv] = max_nan(values[j*ldv], abs_val(colA[i]));
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            slate_not_implemented("The norm isn't yet supported");
+        }
+    }
+    else {
+        slate_not_implemented("The norm scope isn't yet supported.");
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void genorm(
+    lapack::Norm norm, NormScope scope,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_gescale.cc
+++ b/src/omptarget/device_gescale.cc
@@ -1,0 +1,225 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Kernel implementing element-wise tile scale.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] numer
+///     Scale value numerator.
+///
+/// @param[in] denom
+///     Scale value denominator.
+///
+/// @param[in,out] A
+///     An m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale(
+    int64_t m, int64_t n,
+    scalar_t2 numer, scalar_t2 denom,
+    scalar_t* A, int64_t lda,
+    blas::Queue& queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+
+    scalar_t2 mul = numer / denom;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(A) device(queue.device())
+    #pragma omp teams distribute parallel for schedule(static, 1)
+    for (int64_t i = 0; i < m; ++i) {
+        scalar_t* rowA = &A[ i ];
+        for (int64_t j = 0; j < n; ++j)
+            rowA[ j*lda ] = rowA[ j*lda ] * mul;
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    float* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer, double denom,
+    double* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<float> numer, std::complex<float> denom,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer,  double denom,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<double> numer, std::complex<double> denom,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue);
+
+
+//==============================================================================
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise tile scale. Sets
+/// \[
+///     Aarray[k] *= (numer / denom).
+/// \]
+/// This does NOT currently take extra care to avoid over/underflow.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] numer
+///     Scale value numerator.
+///
+/// @param[in] denom
+///     Scale value denominator.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale(
+    int64_t m, int64_t n,
+    scalar_t2 numer, scalar_t2 denom,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    scalar_t2 mul = numer / denom;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* A = Aarray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &A[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * mul;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer, double denom,
+    double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    float numer, float denom,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<float> numer, std::complex<float> denom,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    double numer,  double denom,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale(
+    int64_t m, int64_t n,
+    std::complex<double> numer, std::complex<double> denom,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+} // namespace batch
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_gescale_row_col.cc
+++ b/src/omptarget/device_gescale_row_col.cc
@@ -1,0 +1,285 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Kernel implementing row and column scaling.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale_row_col().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] Rarray
+///     Vector of length m containing row scaling factors.
+///
+/// @param[in] Carray
+///     Vector of length n containing column scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array of tiles of dimension gridDim.x,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_row_col_batch_kernel(
+    int64_t m, int64_t n,
+    scalar_t2 const* const* Rarray,
+    scalar_t2 const* const* Carray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    queue.sync(); // sync queue before switching to openmp device execution
+    #pragma omp target is_device_ptr(Rarray, Carray, Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t2 const* R = Rarray[ k ];
+        scalar_t2 const* C = Carray[ k ];
+        scalar_t* tileA    = Aarray[ k ];
+        #pragma omp parallel for schedule(static, 1)
+        // thread per row
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            scalar_t2 ri = R[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * (ri * C[ j ]);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Kernel implementing column scaling.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale_row_col().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] Carray
+///     Vector of length n containing column scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array of tiles of dimension gridDim.x,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_col_batch_kernel(
+    int64_t m, int64_t n,
+    scalar_t2 const* const* Carray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    queue.sync(); // sync queue before switching to openmp device execution
+    #pragma omp target is_device_ptr(Carray, Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t2 const* C = Carray[ k ];
+        scalar_t* tileA    = Aarray[ k ];
+        #pragma omp parallel for schedule(static, 1)
+        // thread per row
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * C[ j ];
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Kernel implementing row scaling.
+/// Each thread block deals with one tile.
+/// Each thread deals with one row.
+/// Launched by gescale_row_col().
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 1.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 1.
+///
+/// @param[in] Rarray
+///     Vector of length m containing row scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array of tiles of dimension gridDim.x,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_row_batch_kernel(
+    int64_t m, int64_t n,
+    scalar_t2 const* const* Rarray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    queue.sync(); // sync queue before switching to openmp device execution
+    #pragma omp target is_device_ptr(Rarray, Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t2 const* R = Rarray[ k ];
+        scalar_t* tileA    = Aarray[ k ];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            scalar_t2 ri = R[ i ];
+            for (int64_t j = 0; j < n; ++j)
+                rowA[ j*lda ] = rowA[ j*lda ] * ri;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Batched routine for row and column scaling.
+///
+/// @param[in] equed
+///     Form of scaling to do.
+///     - Equed::Row:  sets $ A = diag(R) A         $
+///     - Equed::Col:  sets $ A =         A diag(C) $
+///     - Equed::Both: sets $ A = diag(R) A diag(C) $
+///     for each R in Rarray, C in Carray, and A in Aarray.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Rarray
+///     Vector of length m containing row scaling factors.
+///
+/// @param[in] Carray
+///     Vector of length n containing column scaling factors.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, typename scalar_t2>
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    scalar_t2 const* const* Rarray,
+    scalar_t2 const* const* Carray,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    // Use omp target offload
+    if (equed == Equed::Row) {
+        gescale_row_batch_kernel(
+            m, n, Rarray, Aarray, lda, batch_count, queue );
+    }
+    else if (equed == Equed::Col) {
+        gescale_col_batch_kernel(
+            m, n, Carray, Aarray, lda, batch_count, queue );
+    }
+    else if (equed == Equed::Both) {
+        gescale_row_col_batch_kernel(
+            m, n, Rarray, Carray, Aarray, lda, batch_count, queue );
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    float const* const* Rarray,
+    float const* const* Carray,
+    float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    double const* const* Rarray,
+    double const* const* Carray,
+    double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+// real R, C
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    float const* const* Rarray,
+    float const* const* Carray,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    double const* const* Rarray,
+    double const* const* Carray,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+// complex R, C
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    std::complex<float> const* const* Rarray,
+    std::complex<float> const* const* Carray,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void gescale_row_col_batch(
+    Equed equed, int64_t m, int64_t n,
+    std::complex<double> const* const* Rarray,
+    std::complex<double> const* const* Carray,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_geset.cc
+++ b/src/omptarget/device_geset.cc
@@ -1,0 +1,186 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Element-wise m-by-n matrix A
+/// to diag_value on the diagonal and offdiag_value on the off-diagonals.
+///
+/// @param[in] m
+///     Number of rows of A. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of A. n >= 0.
+///
+/// @param[in] offdiag_value
+///     The value to set outside of the diagonal.
+///
+/// @param[in] diag_value
+///     The value to set on the diagonal.
+///
+/// @param[out] A
+///     An m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of A. lda >= m.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void geset(
+    int64_t m, int64_t n,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
+    scalar_t* A, int64_t lda,
+    blas::Queue &queue)
+{
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(A) device(queue.device())
+    #pragma omp teams distribute parallel for schedule(static, 1)
+    for (int64_t i = 0; i < m; ++i) {
+        scalar_t* rowA = &A[i];
+        for (int64_t j = 0; j < n; ++j) {
+            rowA[j*lda] = (j != i) ? offdiag_value : diag_value;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geset(
+    int64_t m, int64_t n,
+    float const& offdiag_value, float const& diag_value,
+    float* A, int64_t lda,
+    blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    double const& offdiag_value, double const& diag_value,
+    double* A, int64_t lda,
+    blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue &queue);
+
+//==============================================================================
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// Initializes a batch of m-by-n matrices Aarray[k]
+/// to diag_value on the diagonal and offdiag_value on the off-diagonals.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] offdiag_value
+///     The value to set outside of the diagonal.
+///
+/// @param[in] diag_value
+///     The value to set on the diagonal.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void geset(
+    int64_t m, int64_t n,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+    // quick return
+    if (m == 0 || n == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* tileA = Aarray[k];
+        // distribute i to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[i];
+            for (int64_t j = 0; j < n; ++j) {
+                rowA[j*lda] = (j == i ? diag_value : offdiag_value);
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void geset(
+    int64_t m, int64_t n,
+    float const& offdiag_value, float const& diag_value,
+    float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    double const& offdiag_value, double const& diag_value,
+    double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void geset(
+    int64_t m, int64_t n,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace batch
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_henorm.cc
+++ b/src/omptarget/device_henorm.cc
@@ -1,0 +1,256 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., n-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an n-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: for symmetric, same as Norm::One
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+    ////int64_t nb = 512;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    //---------
+    // max norm
+    if (norm == lapack::Norm::Max) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count, queue);
+        }
+        else {
+            assert(ldv == 1);
+            blas::device_memset(values, 0, batch_count, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
+            // Use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads
+                // note: the max_nan_reduction preserves nans
+                #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    const scalar_t* rowA = &tileA[i];
+                    real_t max = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                            max = max_nan(max, abs_val(rowA[j*lda]));
+                        int64_t j = i;
+                        max = max_nan(max, abs_val( std::real( rowA[j*lda] ))); // diag (real)
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        for (int64_t j = n-1; j > i; --j) // strictly upper
+                            max = max_nan(max, abs_val(rowA[j*lda]));
+                        int64_t j = i;
+                        max = max_nan(max, abs_val( std::real( rowA[j*lda] ))); // diag (real)
+                    }
+                    values[k] = max_nan(values[0], max);
+                }
+            }
+        }
+    }
+    //---------
+    // one norm or inf norm (same values)
+    else if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * n, queue);
+        }
+        else {
+            assert(ldv >= n);
+            queue.sync(); // sync queue before switching to openmp device execution
+            // use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows to threads (i)
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t idx = 0; idx < n; ++idx) {
+                    // get pointer to row_i and corresponding column col_i
+                    scalar_t const* row = &tileA[idx];
+                    scalar_t const* column = &tileA[lda*idx];
+                    real_t sum = 0;
+                    // accumulate down row_idx and the symmetric col_idx
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < idx; ++j) // strictly lower
+                            sum += abs_val(row[j*lda]);
+                        sum += abs_val( std::real( row[idx*lda] )); // diag (real)
+                        for (int64_t i = idx + 1; i < n; ++i) // strictly lower
+                            sum += abs_val(column[i]);
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        for (int64_t j = n-1; j > idx; --j) // strictly upper
+                            sum += abs_val(row[j*lda]);
+                        sum += abs_val( std::real( row[idx*lda] )); // diag (real)
+                        for (int64_t i = 0; i < idx && i < n; ++i) // strictly upper
+                            sum += abs_val(column[i]);
+                    }
+                    values[k*ldv + idx] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // Frobenius norm
+    else if (norm == lapack::Norm::Fro) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * 2, queue);
+        }
+        else {
+            assert(ldv == 2);
+            queue.sync(); // sync queue before switching to openmp device execution
+            // use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                values[k*2 + 0] = 0; // scale_k
+                values[k*2 + 1] = 1; // sumsq_k
+                // distribute rows to threads (i)
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    scalar_t const* rowI = &tileA[i];
+                    real_t scale_ki = 0;
+                    real_t sumsq_ki = 1;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < i; ++j)
+                            add_sumsq(scale_ki, sumsq_ki, abs_val( rowI[j*lda] ));
+                        sumsq_ki *= 2; // double sumsq for symmetric entries
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val( std::real( rowI[i*lda] )));
+                    }
+                    else {      // uplo == Upper
+                        // Loop backwards (n-1 down to i) to maintain coalesced reads.
+                        for (int64_t j = n-1; j > i; --j) // strictly upper
+                            add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[j*lda]));
+                        sumsq_ki *= 2; // double for symmetric entries
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val( std::real( rowI[i*lda] )));
+                    }
+                    // accumulate the scale and sumsq for each k
+                    #pragma omp critical
+                    {
+                        real_t scale_k = values[k*2 + 0];
+                        real_t sumsq_k = values[k*2 + 1];
+                        if (scale_k > scale_ki) {
+                            sumsq_k = sumsq_k + sumsq_ki*(scale_ki / scale_k)*(scale_ki / scale_k);
+                            // scale_k stays same
+                        }
+                        else if (scale_ki != 0) {
+                            sumsq_k = sumsq_k*(scale_k / scale_ki)*(scale_k / scale_ki) + sumsq_ki;
+                            scale_k = scale_ki;
+                        }
+                        values[k*2 + 0] = scale_k;
+                        values[k*2 + 1] = sumsq_k;
+
+                    }
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void henorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_synorm.cc
+++ b/src/omptarget/device_synorm.cc
@@ -1,0 +1,371 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., n-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an n-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: for symmetric, same as Norm::One
+///
+///     - Norm::Fro: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    //---------
+    // max norm
+    if (norm == lapack::Norm::Max) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count, queue);
+        }
+        else {
+            assert(ldv == 1);
+            blas::device_memset(values, 0, batch_count, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
+            // Use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads
+                // note: the max_nan_reduction preserves nans
+                #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    const scalar_t* row = &tileA[i];
+                    real_t max = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j <= i; ++j) // lower
+                            max = max_nan(max, abs_val(row[j*lda]));
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        for (int64_t j = n-1; j >= i; --j) // upper
+                            max = max_nan(max, abs_val(row[j*lda]));
+                    }
+                    values[k] = max_nan(values[k], max);
+                }
+            }
+        }
+    }
+    //---------
+    // one norm
+    else if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * n, queue);
+        }
+        else {
+            assert(ldv >= n);
+            queue.sync(); // sync queue before switching to openmp device execution
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            // distribute tiles to teams
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows to threads (i)
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t idx = 0; idx < n; ++idx) {
+                    // get pointer to row_i and corresponding column col_i
+                    scalar_t const* row = &tileA[idx];
+                    scalar_t const* column = &tileA[lda*idx];
+                    real_t sum = 0;
+                    // accumulate down row_i and the symmetric col_i
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j <= idx; ++j) // lower
+                            sum += abs_val(row[j*lda]);
+                        for (int64_t i = idx + 1; i < n; ++i) // strictly lower
+                            sum += abs_val(column[i]);
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i) to maintain coalesced reads.
+                        for (int64_t j = n-1; j >= idx; --j) // upper
+                            sum += abs_val(row[j*lda]);
+                        for (int64_t i = 0; i < idx && i < n; ++i) // strictly upper
+                            sum += abs_val(column[i]);
+                    }
+                    values[k*ldv + idx] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // Frobenius norm
+    else if (norm == lapack::Norm::Fro) {
+        if (n == 0) {
+            blas::device_memset(values, 0, batch_count * 2, queue);
+        }
+        else {
+            assert(ldv == 2);
+            queue.sync(); // sync queue before switching to openmp device execution
+            // use omp target offload
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                values[k*2 + 0] = 0; // scale_k
+                values[k*2 + 1] = 1; // sumsq_k
+                // distribute rows to threads (i)
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < n; ++i) {
+                    scalar_t const* rowI = &tileA[i];
+                    real_t scale_ki = 0;
+                    real_t sumsq_ki = 1;
+                    if (uplo == lapack::Uplo::Lower) {
+                        for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                            add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[j*lda]));
+                        // double sumsq for symmetric entries
+                        sumsq_ki *= 2;
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[i*lda]));
+                    }
+                    else {      // uplo == Upper
+                        // Loop backwards (n-1 down to i) to maintain coalesced reads.
+                        for (int64_t j = n-1; j > i; --j) // strictly upper
+                            add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[j*lda]));
+                        // double for symmetric entries
+                        sumsq_ki *= 2;
+                        // add diagonal (real)
+                        add_sumsq(scale_ki, sumsq_ki, abs_val(rowI[i*lda]));
+                    }
+                    // accumulate the scale and sumsq for each k
+                    // todo: try to speed this up
+                    #pragma omp critical
+                    {
+                        combine_sumsq(values[k*2+0], values[k*2+1], scale_ki, sumsq_ki);
+                    }
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., n-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an n-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: for symmetric, same as Norm::One
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     GPU device to execute in.
+///
+template <typename scalar_t>
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+    //---------
+    // one norm and inf norm
+    if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
+        assert(ldv >= n+m);
+        queue.sync(); // sync queue before switching to openmp device execution
+        // use openmp offload
+        #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+        #pragma omp teams distribute
+        for (int64_t k = 0; k < batch_count; ++k) {
+            const scalar_t* tileA = Aarray[k];
+            // distribute col to threads (j)
+            #pragma omp parallel for schedule(static, 1)
+            for (int64_t j = 0; j < n; ++j) {
+                real_t colsum = 0;
+                // accumulate down col
+                for (int64_t i = 0; i < m; ++i)
+                    colsum += abs_val(tileA[i + j*lda]);
+                values[k*ldv + j] = colsum;
+            }
+            // distribute rows to threads (i)
+            #pragma omp parallel for schedule(static, 1)
+            for (int64_t i = 0; i < m; ++i) {
+                real_t rowsum = 0;
+                for (int64_t j = 0; j < n; ++j)
+                    rowsum += abs_val(tileA[i + j*lda]);
+                values[k*ldv + i + n] = rowsum;
+            }
+        }
+    }
+    else {
+        slate_not_implemented("Only Norm::One and Norm::Inf is supported.");
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synorm(
+    lapack::Norm norm, lapack::Uplo uplo,
+    int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+//----------------------------------------
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void synormOffdiag(
+    lapack::Norm norm,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv,
+    int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_transpose.cc
+++ b/src/omptarget/device_transpose.cc
@@ -1,0 +1,585 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Device routine handles batches of square matrices.
+
+///
+/// The routine loads blocks of data into small ib x ib local storage
+/// and then writes the blocks back transposed into the correct
+/// location transposed.
+///
+template <typename scalar_t>
+void transpose_sqr_batch_func(
+    int n, scalar_t** Aarray, int64_t lda, int batch_count, blas::Queue& queue)
+{
+    static const int ib = 16;
+    queue.sync(); // sync queue before switching to openmp device execution
+    // i, j are row & column indices of top-left corner of each local block.
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    // Distribute the blocks to omp teams
+    #pragma omp teams distribute collapse(2)
+    for (int k = 0; k < batch_count; ++k) {
+        for (int i = 0; i < n; i += ib) {
+            for (int j = 0; j <= i; j += ib) {
+                scalar_t *A = Aarray[k];
+                // allocate local blocks for storage
+                // +1 to avoid memory bank conflicts.
+                scalar_t sA1[ ib ][ ib+1 ], sA2[ ib ][ ib+1 ];
+                // todo: make sA1, sA2 team-local, shared by threads (OpenMP > 5)
+                // #pragma omp private(sA1, sA2)
+                // #pragma omp allocate (sA1,sA2) allocator(omp_pteam_mem_alloc)
+                // ii, jj are row & column offsets within each block.
+                int max_ii = ( i+ib < n ? std::min(ib, n) : n-i );
+                int max_jj = ( j+ib < n ? std::min(ib, n) : n-j );
+                if (i == j) { // diagonal blocks
+                    // Load ibxib block from A(i,j) into sA1
+                    #pragma omp parallel for simd collapse(2)
+                    for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            sA1[jj][ii] = A[i+ii + (j+jj)*lda];
+                    // Save transposed block, A(i, j) = trans(sA1).
+                    #pragma omp parallel for simd collapse(2)
+                    for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            A[i+ii + (j+jj)*lda] = sA1[ii][jj];
+                }
+                else { // off-diagonal block
+                    // Load blocks A(i, j) and A(j, i) into shared memory sA1 and sA2.
+                    #pragma omp parallel for simd collapse(2)
+                    for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            sA1[ii][jj] = A[i+ii + (j+jj)*lda]; // sA1(i,j)=A(i,j)
+                    #pragma omp parallel for simd collapse(2)
+                    for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            sA2[jj][ii] = A[j+jj + (i+ii)*lda]; // sA2(j,i)=A(j,i)
+                    // Save transposed blocks, A(i, j) = trans(sA2), A(j, i) = trans(sA1).
+                    #pragma omp parallel for simd collapse(2)
+                    for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            A[i+ii + (j+jj)*lda] = sA2[jj][ii]; // A(i,j)=trans(sA2)=sA2(i,j)
+                    #pragma omp parallel for simd collapse(2)
+                    for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            A[j+jj + (i+ii)*lda] = sA1[ii][jj]; // A(j,i)=trans(sA1)=sA1(j,i)
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Device routine handles single square matrix
+
+/// The routine loads blocks of data into small ib x ib local storage
+/// and then writes the blocks back transposed into the correct
+/// location transposed.
+///
+template <typename scalar_t>
+void transpose_sqr_func(
+    int n, scalar_t* A, int64_t lda, blas::Queue& queue)
+{
+    // printf("%s:%d sqr queue.device() %d\n", __FILE__, __LINE__, queue.device());
+
+    static const int ib = 16;
+    queue.sync(); // sync queue before switching to openmp device execution
+    // i, j are row & column indices of top-left corner of each local block.
+    #pragma omp target is_device_ptr(A) device(queue.device())
+    // Distribute the blocks to omp teams
+    #pragma omp teams distribute collapse(2)
+    for (int i = 0; i < n; i += ib) {
+        for (int j = 0; j <= i; j += ib) {
+            // allocate local blocks for storage
+            // +1 to avoid memory bank conflicts.
+            scalar_t sA1[ ib ][ ib+1 ], sA2[ ib ][ ib+1 ];
+            // todo: make sA1, sA2 team-local, shared by threads (OpenMP > 5)
+            // #pragma omp private(sA1, sA2)
+            // #pragma omp allocate (sA1,sA2) allocator(omp_pteam_mem_alloc)
+            // ii, jj are row & column offsets within each block.
+            int max_ii = ( i+ib < n ? std::min(ib, n) : n-i );
+            int max_jj = ( j+ib < n ? std::min(ib, n) : n-j );
+            if (i == j) { // diagonal blocks
+                // Load ibxib block from A(i,j) into sA1
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_ii; ++ii)
+                    for (int jj = 0; jj < max_jj; ++jj)
+                        sA1[jj][ii] = A[i+ii + (j+jj)*lda];
+                // Save transposed block, A(i, j) = trans(sA1).
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_ii; ++ii)
+                        for (int jj = 0; jj < max_jj; ++jj)
+                            A[i+ii + (j+jj)*lda] = sA1[ii][jj];
+            }
+            else { // off-diagonal block
+                // Load blocks A(i, j) and A(j, i) into shared memory sA1 and sA2.
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_ii; ++ii)
+                    for (int jj = 0; jj < max_jj; ++jj)
+                        sA1[ii][jj] = A[i+ii + (j+jj)*lda]; // sA1(i,j)=A(i,j)
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_ii; ++ii)
+                    for (int jj = 0; jj < max_jj; ++jj)
+                        sA2[jj][ii] = A[j+jj + (i+ii)*lda]; // sA2(j,i)=A(j,i)
+                // Save transposed blocks, A(i, j) = trans(sA2), A(j, i) = trans(sA1).
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_ii; ++ii)
+                    for (int jj = 0; jj < max_jj; ++jj)
+                        A[i+ii + (j+jj)*lda] = sA2[jj][ii]; // A(i,j)=trans(sA2)=sA2(i,j)
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_ii; ++ii)
+                    for (int jj = 0; jj < max_jj; ++jj)
+                        A[j+jj + (i+ii)*lda] = sA1[ii][jj]; // A(j,i)=trans(sA1)=sA1(j,i)
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Device routine handles batches of rectangular matrices.
+///
+/// The routine loads blocks of data into small NX x NB local storage
+/// and then writes the blocks back transposed into the correct
+/// location transposed.
+///
+template <typename scalar_t, int NX>
+void transpose_rect_batch_func(
+    int m, int n,
+    scalar_t** dAarray, int64_t lda,
+    scalar_t** dATarray, int64_t ldat,
+    int batch_count, blas::Queue& queue)
+{
+    static const int NB = 32;
+    queue.sync(); // sync queue before switching to openmp device execution
+    // i, j are row & column indices of top-left corner of each local block.
+    #pragma omp target is_device_ptr(dAarray, dATarray) device(queue.device())
+    #pragma omp teams distribute collapse(2)
+    for (int k = 0; k < batch_count; ++k) {
+        for (int i = 0; i < m; i += NX) {
+            for (int j = 0; j < n; j += NB) {
+                scalar_t *dA = dAarray[k];
+                scalar_t *dAT = dATarray[k];
+                // todo: make sA team-local, shared by threads
+                // #pragma omp private(sA)
+                // todo: allocators supported after OpenMP 5.0
+                // #if (_OPENMP > 201810)
+                // #pragma omp allocate (sA) allocator(omp_pteam_mem_alloc)
+                // #endif
+                scalar_t sA[ NX ][ NB+1 ];
+                int max_NX = ( i+NX < m ? std::min(NX, m) : m-i );
+                int max_NB = ( j+NB < n ? std::min(NB, n) : n-j );
+                // Load NXxNB block from A(i,j) so that sA(i,j) = dA(i,j)
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_NX; ++ii)
+                    for (int jj = 0; jj < max_NB; ++jj)
+                        sA[ii][jj] = dA[i+ii + (j+jj)*lda];
+                // Save transposed block, dAT(j, i) = sA(i,j).
+                #pragma omp parallel for simd collapse(2)
+                for (int ii = 0; ii < max_NX; ++ii)
+                    for (int jj = 0; jj < max_NB; ++jj)
+                        dAT[j+jj + (i+ii)*ldat] = sA[ii][jj];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Device routine handles single rectangular matrox
+///
+/// The routine loads blocks of data into small NX x NB local storage
+/// and then writes the blocks back transposed into the correct
+/// location transposed.
+///
+template <typename scalar_t, int NX>
+void transpose_rect_func(
+    int m, int n,
+    scalar_t* dA, int64_t lda,
+    scalar_t* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    static const int NB = 32;
+    queue.sync(); // sync queue before switching to openmp device execution
+    // i, j are row & column indices of top-left corner of each local block.
+    #pragma omp target is_device_ptr(dA, dAT) device(queue.device())
+    #pragma omp teams distribute collapse(2)
+    for (int i = 0; i < m; i += NX) {
+        for (int j = 0; j < n; j += NB) {
+            // todo: make sA team-local, shared by threads
+            // #pragma omp private(sA)
+            // todo: allocators supported after OpenMP 5.0
+            // #if (_OPENMP > 201810)
+            // #pragma omp allocate (sA) allocator(omp_pteam_mem_alloc)
+            // #endif
+            scalar_t sA[ NX ][ NB+1 ];
+            int max_NX = ( i+NX < m ? std::min(NX, m) : m-i );
+            int max_NB = ( j+NB < n ? std::min(NB, n) : n-j );
+            // Load NXxNB block from A(i,j) so that sA(i,j) = dA(i,j)
+            #pragma omp parallel for simd collapse(2)
+            for (int ii = 0; ii < max_NX; ++ii)
+                for (int jj = 0; jj < max_NB; ++jj)
+                    sA[ii][jj] = dA[i+ii + (j+jj)*lda];
+            // Save transposed block, dAT(j, i) = sA(i,j).
+            #pragma omp parallel for simd collapse(2)
+            for (int ii = 0; ii < max_NX; ++ii)
+                for (int jj = 0; jj < max_NB; ++jj)
+                    dAT[j+jj + (i+ii)*ldat] = sA[ii][jj];
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a square matrix in place.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in,out] A
+///     A square n-by-n matrix stored in an lda-by-n array in GPU memory.
+///     On output, A is transposed.
+///
+/// @param[in] lda
+///     Leading dimension of A. lda >= n.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void transpose(
+    int64_t n,
+    scalar_t* A, int64_t lda,
+    blas::Queue& queue)
+{
+    if (n <= 1)
+        return;
+    assert(lda >= n);
+
+    transpose_sqr_func(n, A, lda, queue);
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a batch of square matrices in place.
+///
+/// @param[in] n
+///     Number of rows and columns of each tile. n >= 0.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to
+///     matrices, where each Aarray[k] is a square n-by-n matrix stored in an
+///     lda-by-n array in GPU memory.
+///     On output, each Aarray[k] is transposed.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= n.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void transpose_batch(
+    int64_t n,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    if (batch_count < 0 || n <= 1)
+        return;
+    assert(lda >= n);
+
+    transpose_sqr_batch_func(n, Aarray, lda, batch_count, queue);
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a rectangular matrix out-of-place.
+///
+/// @param[in] m
+///     Number of columns of tile. m >= 0.
+///
+/// @param[in] n
+///     Number of rows of tile. n >= 0.
+///
+/// @param[in] dA
+///     A rectangular m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of dA. lda >= m.
+///
+/// @param[out] dAT
+///     A rectangular m-by-n matrix stored in an ldat-by-m array in GPU memory.
+///     On output, dAT is the transpose of dA.
+///
+/// @param[in] ldat
+///     Leading dimension of dAT. ldat >= n.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, int NX>
+void transpose(
+    int64_t m, int64_t n,
+    scalar_t* dA,  int64_t lda,
+    scalar_t* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    if ((m <= 0) || (n <= 0))
+        return;
+    assert(lda >= m);
+    assert(ldat >= n);
+
+    transpose_rect_func<scalar_t, NX>( m, n, dA, lda, dAT, ldat, queue );
+}
+
+//------------------------------------------------------------------------------
+/// Physically transpose a batch of rectangular matrices out-of-place.
+///
+/// @param[in] m
+///     Number of columns of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of rows of each tile. n >= 0.
+///
+/// @param[in] dA_array
+///     Array in GPU memory of dimension batch_count, containing pointers to
+///     matrices, where each dA_array[k] is a rectangular m-by-n matrix stored in an
+///     lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each dA_array[k] tile. lda >= m.
+///
+/// @param[out] dAT_array
+///     Array in GPU memory of dimension batch_count, containing pointers to
+///     matrices, where each dAT_array[k] is a rectangular m-by-n matrix
+///     stored in an ldat-by-m array in GPU memory.
+///     On output, each dAT_array[k] is the transpose of dA_array[k].
+///
+/// @param[in] lda
+///     Leading dimension of each dAT_array[k] tile. ldat >= n.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t, int NX>
+void transpose_batch(
+    int64_t m, int64_t n,
+    scalar_t **dA_array,  int64_t lda,
+    scalar_t **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    if ((m <= 0) || (n <= 0))
+        return;
+    assert(lda >= m);
+    assert(ldat >= n);
+
+    transpose_rect_batch_func<scalar_t, NX>( m, n, dA_array, lda, dAT_array, ldat, batch_count, queue );
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+// Square matrix
+
+template
+void transpose(
+    int64_t n,
+    float* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void transpose(
+    int64_t n,
+    double* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void transpose(
+    int64_t n,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue);
+
+template
+void transpose(
+    int64_t n,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue);
+
+// ----------------------------------------
+// Explicit instantiations.
+// Batch of square matrices
+
+template
+void transpose_batch(
+    int64_t n,
+    float** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+template
+void transpose_batch(
+    int64_t n,
+    double** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+template
+void transpose_batch(
+    int64_t n,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+template
+void transpose_batch(
+    int64_t n,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count,
+    blas::Queue& queue);
+
+
+// ----------------------------------------
+// Explicit instantiations.
+// Rectangular matrix
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    float* dA,  int64_t lda,
+    float* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<float,32>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    double* dA,  int64_t lda,
+    double* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<double,32>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    std::complex<float>* dA,  int64_t lda,
+    std::complex<float>* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<std::complex<float>,32>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+template<>
+void transpose(
+    int64_t m, int64_t n,
+    std::complex<double>* dA,  int64_t lda,
+    std::complex<double>* dAT, int64_t ldat,
+    blas::Queue& queue)
+{
+    transpose<std::complex<double>,16>(
+        m, n,
+        dA,  lda,
+        dAT, ldat,
+        queue);
+}
+
+// ----------------------------------------
+// Explicit instantiations.
+// Batch of rectangular matrices
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    float **dA_array,  int64_t lda,
+    float **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<float,32>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    double **dA_array,  int64_t lda,
+    double **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<double,32>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    std::complex<float> **dA_array,  int64_t lda,
+    std::complex<float> **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<std::complex<float>,32>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+template<>
+void transpose_batch(
+    int64_t m, int64_t n,
+    std::complex<double> **dA_array,  int64_t lda,
+    std::complex<double> **dAT_array, int64_t ldat,
+    int64_t batch_count,
+    blas::Queue& queue)
+{
+    transpose_batch<std::complex<double>,16>(
+        m, n,
+        dA_array,  lda,
+        dAT_array, ldat,
+        batch_count,
+        queue);
+}
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_trnorm.cc
+++ b/src/omptarget/device_trnorm.cc
@@ -1,0 +1,335 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine that returns the largest absolute value of elements for
+/// each tile in Aarray. Sets
+///     tiles_maxima[k] = max_{i, j}( abs( A^(k)_(i, j) )),
+/// for each tile A^(k), where
+/// A^(k) = Aarray[k],
+/// k = 0, ..., blockDim.x-1,
+/// i = 0, ..., m-1,
+/// j = 0, ..., n-1.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile. lda >= m.
+///
+/// @param[out] values
+///     Array in GPU memory, dimension batch_count * ldv.
+///     - Norm::Max: ldv = 1.
+///         On exit, values[k] = max_{i, j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count.
+///
+///     - Norm::One: ldv >= n.
+///         On exit, values[k*ldv + j] = sum_{i} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= j < n.
+///
+///     - Norm::Inf: ldv >= m.
+///         On exit, values[k*ldv + i] = sum_{j} abs( A^(k)_(i, j) )
+///         for 0 <= k < batch_count, 0 <= i < m.
+///
+///     - Norm::Max: ldv = 2.
+///         On exit,
+///             values[k*2 + 0] = scale_k
+///             values[k*2 + 1] = sumsq_k
+///         where scale_k^2 sumsq_k = sum_{i,j} abs( A^(k)_(i, j) )^2
+///         for 0 <= k < batch_count.
+///
+/// @param[in] ldv
+///     Leading dimension of tiles_sums (values) array.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] stream
+///     device to execute in.
+///
+template <typename scalar_t>
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    scalar_t const* const* Aarray, int64_t lda,
+    blas::real_type<scalar_t>* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    //---------
+    // max norm
+    if (norm == lapack::Norm::Max) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count, queue);
+        }
+        else {
+            assert(ldv == 1);
+            // use omp offload
+            blas::device_memset(values, 0, batch_count, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads, each thread computes 1 column max
+                // nan-preserving max reduction operation
+                #pragma omp parallel for reduction(max_nan_reduction:values[k]) schedule(static, 1)
+                for (int64_t i = 0; i < m; ++i) {
+                    const scalar_t* row = &tileA[i];
+                    real_t max = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // unit diag
+                                max = 1;
+                            for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                        else { // non-unit
+                            for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                    }
+                    else { // Upper
+                        // Loop backwards (n-1 down to i)
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                max = 1;
+                            for (int64_t j = n-1; j > i; --j) // strictly upper
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                        else { // non-unit
+                            for (int64_t j = n-1; j >= i; --j) // upper
+                                max = max_nan(max, abs_val(row[j*lda]));
+                        }
+                    }
+                    values[k] = max_nan(values[k], max);
+                }
+            }
+        }
+    }
+    //---------
+    // one norm
+    else if (norm == lapack::Norm::One) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count * n, queue);
+        }
+        else {
+            assert(ldv >= n);
+            blas::device_memset(values, 0, batch_count * n, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute cols (j) to threads
+                // each thread computes one column sum
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t j = 0; j < n; ++j) {
+                    const scalar_t* column = &tileA[lda*j];
+                    real_t sum = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (j < m) // diag
+                                sum += 1;
+                            for (int64_t i = j+1; i < m; ++i) // strictly lower
+                                sum += abs_val(column[i]);
+                        }
+                        else { // diag == non-unit
+                            for (int64_t i = j; i < m; ++i) // lower
+                                sum += abs_val(column[i]);
+                        }
+                    }
+                    else { // uplo = upper
+                        if (diag == lapack::Diag::Unit) {
+                            if (j < m) // diag
+                                sum += 1;
+                            for (int64_t i = 0; i < j && i < m; ++i) // strictly upper
+                                sum += abs_val(column[i]);
+                        }
+                        else {
+                            for (int64_t i = 0; i <= j && i < m; ++i) // upper
+                                sum += abs_val(column[i]);
+                        }
+                    }
+                    values[k*ldv + j] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // inf norm
+    else if (norm == lapack::Norm::Inf) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count * m, queue);
+        }
+        else {
+            assert(ldv >= m);
+            queue.sync(); // sync queue before switching to openmp device execution
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute i to threads, each thread sums one row
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < m; ++i) {
+                    scalar_t const* row = &tileA[i];
+                    real_t sum = 0;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                sum += 1;
+                            for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                                sum += abs_val(row[j*lda]);
+                        }
+                        else {
+                            for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                                sum += abs_val(row[j*lda]);
+                        }
+                    }
+                    else {
+                        // Loop backwards (n-1 down to i)
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                sum += 1;
+                            for (int64_t j = n-1; j > i; --j) // strictly upper
+                                sum += abs_val(row[j*lda]);
+                        }
+                        else {
+                            for (int64_t j = n-1; j >= i; --j) // upper
+                                sum += abs_val(row[j*lda]);
+                        }
+                    }
+                    values[k*ldv + i] = sum;
+                }
+            }
+        }
+    }
+    //---------
+    // Frobenius norm
+    else if (norm == lapack::Norm::Fro) {
+        if (m == 0 || n == 0) {
+            blas::device_memset(values, 0, batch_count * 2, queue);
+        }
+        else {
+            assert(ldv == 2);
+            blas::device_memset(values, 0, batch_count * 2, queue);
+            queue.sync(); // sync queue before switching to openmp device execution
+            #pragma omp target is_device_ptr(Aarray, values) device(queue.device())
+            #pragma omp teams distribute
+            // distribute each batch array to a team
+            for (int64_t k = 0; k < batch_count; ++k) {
+                const scalar_t* tileA = Aarray[k];
+                // distribute rows (i) to threads
+                #pragma omp parallel for schedule(static, 1)
+                for (int64_t i = 0; i < m; ++i) {
+                    const scalar_t* row = &tileA[i];
+                    real_t scale = 0;
+                    real_t sumsq = 1;
+                    if (uplo == lapack::Uplo::Lower) {
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                add_sumsq(scale, sumsq, real_t(1));
+                            for (int64_t j = 0; j < i && j < n; ++j) // strictly lower
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                        else { // diag == non-unit
+                            for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                    }
+                    else { // uplo == upper
+                        // Loop backwards (n-1 down to i)
+                        if (diag == lapack::Diag::Unit) {
+                            if (i < n) // diag
+                                add_sumsq(scale, sumsq, real_t(1));
+                            for (int64_t j = n-1; j > i; --j) // strictly upper
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                        else { // diag == non-unit
+                            for (int64_t j = n-1; j >= i; --j) // upper
+                                add_sumsq(scale, sumsq, abs_val(row[j*lda]));
+                        }
+                    }
+                    // accumulate the scale and sumsq for each k
+                    // todo: this is slow; (reduction with 2 values? two-reductions?)
+                    #pragma omp critical
+                    {
+                        real_t scale_k = values[k*2 + 0];
+                        real_t sumsq_k = values[k*2 + 1];
+                        if (scale_k > scale) {
+                            sumsq_k = sumsq_k + sumsq*(scale / scale_k)*(scale / scale_k);
+                            // scale_k stays same
+                        }
+                        else if (scale != 0) {
+                            sumsq_k = sumsq_k*(scale_k / scale)*(scale_k / scale) + sumsq;
+                            scale_k = scale;
+                        }
+                        values[k*2 + 0] = scale_k;
+                        values[k*2 + 1] = sumsq_k;
+                    }
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    float* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+template
+void trnorm(
+    lapack::Norm norm, lapack::Uplo uplo, lapack::Diag diag,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    double* values, int64_t ldv, int64_t batch_count,
+    blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_tzadd.cc
+++ b/src/omptarget/device_tzadd.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <complex>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise trapezoidal tile addition.
+/// Sets upper or lower part of
+/// \[
+///     Barray[k] = \alpha Aarray[k] + \beta Barray[k].
+/// \]
+///
+/// @param[in] uplo
+///     Whether each Aarray[k] is upper or lower trapezoidal.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] alpha
+///     The scalar alpha.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] beta
+///     The scalar beta.
+///
+/// @param[in,out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void tzadd(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    scalar_t const& alpha, scalar_t** Aarray, int64_t lda,
+    scalar_t const& beta, scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* tileA = Aarray[ k ];
+        scalar_t* tileB = Barray[ k ];
+        // distribute rows (i) to thread
+        #pragma omp parallel for collapse(1) schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            scalar_t* rowB = &tileB[ i ];
+            // add lower/upper
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                    rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+                }
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) { // upper
+                    rowB[j*ldb] = alpha * rowA[j*lda] + beta * rowB[j*ldb];
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzadd(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float const& alpha, float** Aarray, int64_t lda,
+    float const& beta, float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzadd(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double const& alpha, double** Aarray, int64_t lda,
+    double const& beta, double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzadd(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> const& alpha, std::complex<float>** Aarray, int64_t lda,
+    std::complex<float> const& beta, std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzadd(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> const& alpha, std::complex<double>** Aarray, int64_t lda,
+    std::complex<double> const& beta, std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_tzcopy.cc
+++ b/src/omptarget/device_tzcopy.cc
@@ -1,0 +1,145 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise copy and precision conversion.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[out] Barray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Barray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] ldb
+///     Leading dimension of each tile in B. ldb >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray and Barray. batch_count >= 0.
+///
+/// @param[in] stream
+///     Device to execute in.
+///
+template <typename src_scalar_t, typename dst_scalar_t>
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    src_scalar_t const* const* Aarray, int64_t lda,
+    dst_scalar_t** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    #pragma omp target is_device_ptr(Aarray, Barray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        src_scalar_t const* tileA = Aarray[k];
+        dst_scalar_t* tileB = Barray[k];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            src_scalar_t const* rowA = &tileA[i];
+            dst_scalar_t* rowB = &tileB[i];
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) // lower
+                    rowB[j*ldb] = rowA[j*lda];
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) // upper
+                    rowB[j*ldb] = rowA[j*lda];
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    double** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    float** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> const* const* Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+template
+void tzcopy(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> const* const* Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_tzscale.cc
+++ b/src/omptarget/device_tzscale.cc
@@ -1,0 +1,123 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include "device_util.hh"
+
+#include <cstdio>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise trapezoidal tile scale.
+/// Sets upper or lower part of
+/// \[
+///     Aarray[k] *= (numer / denom).
+/// \]
+/// This does NOT currently take extra care to avoid over/underflow.
+///
+/// @param[in] uplo
+///     Whether each Aarray[k] is upper or lower trapezoidal.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] numer
+///     Scale value numerator.
+///
+/// @param[in] denom
+///     Scale value denominator.
+///
+/// @param[in,out] Aarray
+///     Array in GPU memory of dimension batch_count, containing pointers to tiles,
+///     where each Aarray[k] is an m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in A. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    blas::real_type<scalar_t> numer, blas::real_type<scalar_t> denom,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue)
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    blas::real_type<scalar_t> mul = numer / denom;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* tileA = Aarray[ k ];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &tileA[ i ];
+            // lower or upper
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                    rowA[j*lda] = rowA[j*lda] * mul;
+                }
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) // upper
+                    rowA[j*lda] = rowA[j*lda] * mul;
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float numer, float denom, float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double numer, double denom, double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float numer, float denom,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+template
+void tzscale(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double numer, double denom,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue);
+
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_tzset.cc
+++ b/src/omptarget/device_tzset.cc
@@ -1,0 +1,217 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/Exception.hh"
+#include "slate/internal/device.hh"
+
+#include <cstdio>
+#include <cmath>
+#include <complex>
+
+#include "device_util.hh"
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// Element-wise trapezoidal tile set.
+/// Sets upper or lower part of Aarray[k] to
+/// diag_value on the diagonal and offdiag_value on the off-diagonals.
+///
+/// @param[in] uplo
+///     Whether each Aarray[k] is upper or lower trapezoidal.
+///
+/// @param[in] m
+///     Number of rows of A. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of A. n >= 0.
+///
+/// @param[in] offdiag_value
+///     Constant to set offdiagonal entries to.
+///
+/// @param[in] diag_value
+///     Constant to set diagonal entries to.
+///
+/// @param[out] A
+///     An m-by-n matrix stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of A. lda >= m.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
+    scalar_t* A, int64_t lda,
+    blas::Queue& queue )
+{
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(A) device(queue.device())
+    // distribute rows (i) to threads
+    #pragma omp teams distribute parallel for schedule(static, 1)
+    for (int64_t i = 0; i < m; ++i) {
+        scalar_t* rowA = &A[ i ];
+        // lower or upper
+        if (uplo == lapack::Uplo::Lower) {
+            for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+            }
+        }
+        else {
+            for (int64_t j = n-1; j >= i; --j) { // upper
+                rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float const& offdiag_value, float const& diag_value,
+    float* A, int64_t lda,
+    blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double const& offdiag_value, double const& diag_value,
+    double* A, int64_t lda,
+    blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
+    std::complex<float>* A, int64_t lda,
+    blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
+    std::complex<double>* A, int64_t lda,
+    blas::Queue& queue );
+
+//==============================================================================
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// Batched routine for element-wise trapezoidal tile set.
+/// Sets upper or lower part of Aarray[k] to
+/// diag_value on the diagonal and offdiag_value on the off-diagonals.
+///
+/// @param[in] m
+///     Number of rows of each tile. m >= 0.
+///
+/// @param[in] n
+///     Number of columns of each tile. n >= 0.
+///
+/// @param[in] offdiag_value
+///     Constant to set offdiagonal entries to.
+///
+/// @param[in] diag_value
+///     Constant to set diagonal entries to.
+///
+/// @param[out] Aarray
+///     Array in GPU memory of dimension batch_count, containing
+///     pointers to tiles, where each Aarray[k] is an m-by-n matrix
+///     stored in an lda-by-n array in GPU memory.
+///
+/// @param[in] lda
+///     Leading dimension of each tile in Aarray. lda >= m.
+///
+/// @param[in] batch_count
+///     Size of Aarray. batch_count >= 0.
+///
+/// @param[in] queue
+///     BLAS++ queue to execute in.
+///
+template <typename scalar_t>
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    scalar_t const& offdiag_value, scalar_t const& diag_value,
+    scalar_t** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue )
+{
+    // quick return
+    if (batch_count == 0)
+        return;
+
+    queue.sync(); // sync queue before switching to openmp device execution
+    // Use omp target offload
+    #pragma omp target is_device_ptr(Aarray) device(queue.device())
+    #pragma omp teams distribute
+    for (int64_t k = 0; k < batch_count; ++k) {
+        scalar_t* A = Aarray[ k ];
+        // distribute rows (i) to threads
+        #pragma omp parallel for schedule(static, 1)
+        for (int64_t i = 0; i < m; ++i) {
+            scalar_t* rowA = &A[ i ];
+            // lower or upper
+            if (uplo == lapack::Uplo::Lower) {
+                for (int64_t j = 0; j <= i && j < n; ++j) { // lower
+                    rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+                }
+            }
+            else {
+                for (int64_t j = n-1; j >= i; --j) { // upper
+                    rowA[ j*lda ] = i == j ? diag_value : offdiag_value;
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    float const& offdiag_value, float const& diag_value,
+    float** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    double const& offdiag_value, double const& diag_value,
+    double** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> const& offdiag_value, std::complex<float> const& diag_value,
+    std::complex<float>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue );
+
+template
+void tzset(
+    lapack::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> const& offdiag_value, std::complex<double> const& diag_value,
+    std::complex<double>** Aarray, int64_t lda,
+    int64_t batch_count, blas::Queue& queue );
+
+} // namespace batch
+} // namespace device
+} // namespace slate

--- a/src/omptarget/device_util.hh
+++ b/src/omptarget/device_util.hh
@@ -1,0 +1,160 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#ifndef SLATE_OMPTARGET_UTIL_HH
+#define SLATE_OMPTARGET_UTIL_HH
+
+#include <math.h>
+
+namespace slate {
+namespace device {
+
+//------------------------------------------------------------------------------
+/// max that propogates nan consistently:
+///     max_nan( 1,   nan ) = nan
+///     max_nan( nan, 1   ) = nan
+#pragma omp declare target
+template <typename real_t>
+inline real_t max_nan(real_t x, real_t y)
+{
+    return (isnan(y) || (y) >= (x) ? (y) : (x));
+}
+#pragma omp end declare target
+
+// OpenMP reduction operation that allows for the nan propogation
+#pragma omp declare reduction(max_nan_reduction: float, double: omp_out = max_nan(omp_out, omp_in))
+
+//------------------------------------------------------------------------------
+/// Square of number.
+/// @return x^2
+#pragma omp declare target
+template <typename scalar_t>
+inline scalar_t sqr(scalar_t x)
+{
+    return x*x;
+}
+#pragma omp end declare target
+
+//------------------------------------------------------------------------------
+/// Adds two scaled, sum-of-squares representations.
+/// On exit, scale1 and sumsq1 are updated such that:
+///     scale1^2 sumsq1 := scale1^2 sumsq1 + scale2^2 sumsq2.
+#pragma omp declare target
+template <typename real_t>
+void combine_sumsq(
+    real_t& scale1, real_t& sumsq1,
+    real_t  scale2, real_t  sumsq2 )
+{
+    if (scale1 > scale2) {
+        sumsq1 = sumsq1 + sumsq2*sqr(scale2 / scale1);
+        // scale1 stays same
+    }
+    else if (scale2 != 0) {
+        sumsq1 = sumsq1*sqr(scale1 / scale2) + sumsq2;
+        scale1 = scale2;
+    }
+}
+#pragma omp end declare target
+
+//------------------------------------------------------------------------------
+/// Adds new value to scaled, sum-of-squares representation.
+/// On exit, scale and sumsq are updated such that:
+///     scale^2 sumsq := scale^2 sumsq + (absx)^2
+#pragma omp declare target
+template <typename real_t>
+inline void add_sumsq(
+    real_t& scale, real_t& sumsq,
+    real_t absx)
+{
+    if (scale < absx) {
+        sumsq = 1 + sumsq * sqr(scale / absx);
+        scale = absx;
+    }
+    else if (scale != 0) {
+        sumsq = sumsq + sqr(absx / scale);
+    }
+}
+#pragma omp end declare target
+
+//------------------------------------------------------------------------------
+/// Overloaded versions of absolute value on device.
+#pragma omp declare target
+inline float abs_val(float x)
+{
+    return fabsf(x);
+}
+
+inline double abs_val(double x)
+{
+    return fabs(x);
+}
+
+inline float abs_val(std::complex<float> x)
+{
+    // use our implementation that scales per LAPACK.
+    // todo try std::abs(x)
+    // todo try device specific abs eg for cuda
+    float a = std::real(x);
+    float b = std::imag(x);
+    float z, w, t;
+    if (isnan( a )) {
+        return a;
+    }
+    else if (isnan( b )) {
+        return b;
+    }
+    else {
+        a = fabsf(a);
+        b = fabsf(b);
+        w = std::max(a, b);
+        z = std::min(a, b);
+        if (z == 0) {
+            t = w;
+        }
+        else {
+            t = z/w;
+            t = 1 + t*t;
+            t = w * sqrtf(t);
+        }
+        return t;
+    }
+}
+
+inline double abs_val(std::complex<double> x)
+{
+    // use our implementation that scales per LAPACK.
+    // todo try std::abs(x)
+    // todo try device specific abs eg for cuda
+    double a = std::real(x);
+    double b = std::imag(x);
+    double z, w, t;
+    if (isnan( a )) {
+        return a;
+    }
+    else if (isnan( b )) {
+        return b;
+    }
+    else {
+        a = fabs(a);
+        b = fabs(b);
+        w = std::max(a, b);
+        z = std::min(a, b);
+        if (z == 0) {
+            t = w;
+        }
+        else {
+            t = z/w;
+            t = 1.0 + t*t;
+            t = w * sqrt(t);
+        }
+        return t;
+    }
+}
+#pragma omp end declare target
+
+} // namespace device
+} // namespace slate
+
+#endif // SLATE_OMPTARGET_UTIL_HH

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -40,7 +40,7 @@ void pbtrf(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     int64_t A_nt = A.nt();
 

--- a/src/pbtrs.cc
+++ b/src/pbtrs.cc
@@ -65,10 +65,10 @@ void pbtrs(HermitianBandMatrix<scalar_t>& A,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     auto L = TriangularBandMatrix<scalar_t>(Diag::NonUnit, A_);
-    auto LT = conjTranspose(L);
+    auto LT = conj_transpose( L );
 
     tbsm(Side::Left, one, L, B, opts);
 

--- a/src/posvMixed.cc
+++ b/src/posvMixed.cc
@@ -21,7 +21,7 @@ bool iterRefConverged(std::vector<scalar_t>& colnorms_R,
     bool value = true;
     int64_t size = colnorms_X.size();
 
-    for (int64_t i = 0; i < size; i++) {
+    for (int64_t i = 0; i < size; ++i) {
         if (colnorms_R[i] > colnorms_X[i] * cte) {
             value = false;
             break;
@@ -212,7 +212,7 @@ void posvMixed( HermitianMatrix<scalar_hi>& A,
     }
 
     // iterative refinement
-    for (int iiter = 0; iiter < itermax && ! converged; iiter++) {
+    for (int iiter = 0; iiter < itermax && ! converged; ++iiter) {
         // Convert R from high to low precision, store result in X_lo.
         copy( R, X_lo, opts );
 

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -269,10 +269,11 @@ void potrf(
                                  depend(inout:column[j])
                 {
                     // A(j, j) -= A(j, k) * A(j, k)^H
+                    int queue_jk1 = j-k+2;
                     internal::herk<Target::Devices>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
-                        priority_zero, j-k+2, layout, opts2);
+                        priority_zero, queue_jk1, layout, opts2 );
 
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
@@ -281,7 +282,7 @@ void potrf(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, priority_zero, j-k+2, opts2);
+                            layout, priority_zero, queue_jk1, opts2 );
                     }
                 }
             }

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -268,11 +268,11 @@ void potrf(
                                  depend(inout:column[j])
                 {
                     // A(j, j) -= A(j, k) * A(j, k)^H
-                    int queue_jk1 = j-k+2;
+                    int queue_jk2 = j-k+2;
                     internal::herk<Target::Devices>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
-                        priority_0, queue_jk1, layout, opts2 );
+                        priority_0, queue_jk2, layout, opts2 );
 
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
@@ -281,7 +281,7 @@ void potrf(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, priority_0, queue_jk1, opts2 );
+                            layout, priority_0, queue_jk2, opts2 );
                     }
                 }
             }

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -39,7 +39,7 @@ void potrf(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 
@@ -170,7 +170,7 @@ void potrf(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -146,7 +146,7 @@ void potrf(
     using real_t = blas::real_type<scalar_t>;
     using BcastListTag = typename Matrix<scalar_t>::BcastListTag;
 
-	// Constants
+    // Constants
     const scalar_t one = 1.0;
     const int priority_0 = 0;
     const int queue_0 = 0;
@@ -178,9 +178,6 @@ void potrf(
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
 
-    const int64_t batch_size_zero = 0;
-    const int num_queues = 3 + lookahead;  // Number of kernels with lookahead
-
     // Allocate batch arrays = number of kernels without lookahead + lookahead
     // number of kernels without lookahead = 3
     // (internal::potrf, internal::gemm, and internal::trsm)
@@ -189,7 +186,9 @@ void potrf(
     // and the batch_arrays_index starts from
     // the number of kernels without lookahead, and then incremented by 1
     // for every execution for the internal::herk
-    A.allocateBatchArrays(batch_size_zero, num_queues);
+    const int64_t batch_size_default = 0;
+    int num_queues = 3 + lookahead;  // Number of kernels with lookahead
+    A.allocateBatchArrays( batch_size_default, num_queues );
     A.reserveDeviceWorkspace();
 
     // Allocate

--- a/src/potrs.cc
+++ b/src/potrs.cc
@@ -67,10 +67,10 @@ void potrs(HermitianMatrix<scalar_t>& A,
 
     // if upper, change to lower
     if (A_.uplo() == Uplo::Upper)
-        A_ = conjTranspose(A_);
+        A_ = conj_transpose( A_ );
 
     auto L = TriangularMatrix<scalar_t>(Diag::NonUnit, A_);
-    auto LT = conjTranspose(L);
+    auto LT = conj_transpose( L );
 
     trsm(Side::Left, one, L, B, opts);
 

--- a/src/print.cc
+++ b/src/print.cc
@@ -155,7 +155,7 @@ void print(
         lda = mb;
         data_vector.resize( lda * nb );
         data = data_vector.data();
-        blas::device_getmatrix(
+        blas::device_copy_matrix(
             mb, nb,
             A.data(), A.stride(),
             data, lda, queue );

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -78,7 +78,7 @@ void symm(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -164,7 +164,7 @@ void symm(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -231,7 +231,7 @@ void symm(
                         alpha,  transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -252,7 +252,7 @@ void symm(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -342,7 +342,7 @@ void symm(
                         alpha, transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -407,7 +407,7 @@ void symm(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, default_queue, opts_local );
+                        layout, default_priority, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -428,7 +428,7 @@ void symm(
                             alpha,  transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, default_queue, opts_local );
+                            layout, default_priority, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -46,7 +46,8 @@ void symm(
 
     // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -77,8 +78,6 @@ void symm(
     std::vector<uint8_t>  gemm_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -151,7 +150,7 @@ void symm(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local );
+                    priority_0, opts_local );
 
                 // Erase remote tile on all devices including host
                 A.eraseRemoteWorkspaceTile( 0, 0 );
@@ -164,7 +163,7 @@ void symm(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_0.eraseLocalWorkspace();
 
@@ -231,7 +230,7 @@ void symm(
                         alpha,  transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_k.eraseRemoteWorkspace();
                     Arow_k.eraseLocalWorkspace();
@@ -241,7 +240,7 @@ void symm(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -252,7 +251,7 @@ void symm(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Acol_k.eraseLocalWorkspace();
 
@@ -334,7 +333,7 @@ void symm(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    default_priority, opts_local);
+                    priority_0, opts_local );
 
                 if (A.mt()-1 > 0) {
                     auto Arow_0 = A.sub( 0, 0, 1, A.mt()-1 );
@@ -342,7 +341,7 @@ void symm(
                         alpha, transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Arow_0.eraseLocalWorkspace();
 
@@ -407,7 +406,7 @@ void symm(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, default_priority, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts_local );
 
                     Acol_k.eraseRemoteWorkspace();
                     Acol_k.eraseLocalWorkspace();
@@ -417,7 +416,7 @@ void symm(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        default_priority, opts_local);
+                        priority_0, opts_local );
 
                     A.eraseRemoteWorkspaceTile( k, k );
                     A.eraseLocalWorkspaceTile( k, k );
@@ -428,7 +427,7 @@ void symm(
                             alpha,  transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, default_priority, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts_local );
 
                         Arow_k.eraseLocalWorkspace();
 

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -63,7 +63,7 @@ void syr2k(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -124,7 +124,7 @@ void syr2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, default_queue, layout, opts_local );
+                default_priority, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -171,7 +171,7 @@ void syr2k(
                     alpha, std::move( A_colk ),
                            std::move( B_colk ),
                     one,   std::move( C ),
-                    default_priority, default_queue, layout, opts_local );
+                    default_priority, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -62,7 +62,7 @@ void syr2k(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -124,7 +124,7 @@ void syr2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                default_priority, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -171,7 +171,7 @@ void syr2k(
                     alpha, std::move( A_colk ),
                            std::move( B_colk ),
                     one,   std::move( C ),
-                    default_priority, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -33,8 +33,10 @@ void syrk(
 {
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -59,8 +61,6 @@ void syrk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int priority_0 = 0;
-    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -59,7 +59,7 @@ void syrk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
-    const int default_priority = 0;
+    const int priority_0 = 0;
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
@@ -111,7 +111,7 @@ void syrk(
             internal::syrk<target>(
                 alpha, std::move( A_col0 ),
                 beta,  std::move( C ),
-                default_priority, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -150,7 +150,7 @@ void syrk(
                 internal::syrk<target>(
                     alpha, std::move( A_colk ),
                     one,   std::move( C ),
-                    default_priority, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -60,7 +60,7 @@ void syrk(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     const int default_priority = 0;
-    const int default_queue = 0;
+    const int queue_0 = 0;
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();
@@ -111,7 +111,7 @@ void syrk(
             internal::syrk<target>(
                 alpha, std::move( A_col0 ),
                 beta,  std::move( C ),
-                default_priority, default_queue, layout, opts_local );
+                default_priority, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
             A_col0.eraseRemoteWorkspace();
@@ -150,7 +150,7 @@ void syrk(
                 internal::syrk<target>(
                     alpha, std::move( A_colk ),
                     one,   std::move( C ),
-                    default_priority, default_queue, layout, opts_local );
+                    default_priority, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
                 A_colk.eraseRemoteWorkspace();

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -45,8 +45,8 @@ void tbsm(
     // op(B) = op(A)^{-1} * op(B)
     if (side == Side::Right) {
         if (A.op() == Op::ConjTrans || B.op() == Op::ConjTrans) {
-            A = conjTranspose(A);
-            B = conjTranspose(B);
+            A = conj_transpose( A );
+            B = conj_transpose( B );
             alpha = conj(alpha);
         }
         else {

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -35,6 +35,7 @@ void tbsm(
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major
+    const int priority_1 = 1;
     const Layout layout = Layout::ColMajor;
 
     // Options
@@ -282,7 +283,7 @@ void tbsm(
                                     -one, A.sub(k, k, i, i),
                                           B.sub(i, i, 0, nt-1),
                                     one,  B.sub(k, k, 0, nt-1),
-                                    layout, 1);
+                                    layout, priority_1 );
                     }
                 }
 

--- a/src/trcondest.cc
+++ b/src/trcondest.cc
@@ -122,7 +122,7 @@ void trcondest(
         }
         else {
             // Multiply by inv(A^H).
-            auto AH = conjTranspose( A );
+            auto AH = conj_transpose( A );
             slate::trsmB(Side::Left, alpha, AH, X, opts);
         }
 

--- a/src/trmm.cc
+++ b/src/trmm.cc
@@ -27,9 +27,9 @@ void trmm(
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0; // use default batch size
-        const int64_t num_arrays_two = 2; // Number of kernels without lookahead
-        B.allocateBatchArrays(batch_size_zero, num_arrays_two);
+        const int64_t batch_size_default = 0; // use default batch size
+        const int num_queues = 2; // Number of kernels without lookahead
+        B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }
 

--- a/src/trsmA.cc
+++ b/src/trsmA.cc
@@ -27,8 +27,6 @@ void trsmA(
     int64_t lookahead = get_option<int64_t>(opts, Option::Lookahead, 1);
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0;
-        const int64_t num_arrays_two = 2; // Number of kernels without lookahead
         // Allocate batch arrays = number of kernels without
         // lookahead + lookahead
         // number of kernels without lookahead = 2
@@ -41,7 +39,9 @@ void trsmA(
         // and the batch_arrays_index starts from
         // the number of kernels without lookahead, and then incremented by 1
         // for every execution for the internal::gemm with lookahead
-        B.allocateBatchArrays(batch_size_zero, num_arrays_two);
+        const int64_t batch_size_default = 0;
+        int num_queues = 2; // Number of kernels without lookahead
+        B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }
 

--- a/src/trsmB.cc
+++ b/src/trsmB.cc
@@ -27,7 +27,6 @@ void trsmB(
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     if (target == Target::Devices) {
-        const int64_t batch_size_zero = 0;
         // Allocate batch arrays = number of kernels without
         // lookahead + lookahead
         // number of kernels without lookahead = 2
@@ -45,8 +44,9 @@ void trsmB(
         // 1) trsm                            (         1 )
         // 2) gemm for trailing matrix update (         1 )
         // 3) lookahead number of gemm's      ( lookahead )
-        const int num_queues = 2 + lookahead;
-        B.allocateBatchArrays( batch_size_zero, num_queues );
+        const int64_t batch_size_default = 0;
+        int num_queues = 2 + lookahead;
+        B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }
 

--- a/src/trtri.cc
+++ b/src/trtri.cc
@@ -36,7 +36,7 @@ void trtri(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 

--- a/src/trtrm.cc
+++ b/src/trtrm.cc
@@ -36,7 +36,7 @@ void trtrm(
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
-        A = conjTranspose(A);
+        A = conj_transpose( A );
     }
     int64_t A_nt = A.nt();
 
@@ -84,7 +84,7 @@ void trtrm(
                 auto H = HermitianMatrix<scalar_t>(A);
                 auto H0 = H.sub(0, k-1);
                 auto Ak = A.sub(k, k, 0, k-1);
-                Ak = conjTranspose(Ak);
+                Ak = conj_transpose( Ak );
 
                 internal::herk<target>(
                     real_t(1.0), std::move(Ak),
@@ -99,7 +99,7 @@ void trtrm(
 
                 // A(k, 0:k-1) = A(k, 0:k-1) * A(k, k)^H
                 auto Akk = A.sub(k, k);
-                Akk = conjTranspose(Akk);
+                Akk = conj_transpose( Akk );
                 internal::trmm<Target::HostTask>(
                     Side::Left,
                     one, std::move( Akk ), A.sub(k, k, 0, k-1) );

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -27,7 +27,6 @@ void unmlq(
     Options const& opts )
 {
     // trace::Block trace_block("unmlq");
-    // const int priority_one = 1;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -27,7 +27,6 @@ void unmqr(
     Options const& opts )
 {
     // trace::Block trace_block("unmqr");
-    // const int priority_one = 1;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -252,8 +252,8 @@ void unmqr(
         C.tileUpdateAllOrigin();
     }
 
-    A.clearWorkspace();
-    C.clearWorkspace();
+    A.releaseWorkspace();
+    C.releaseWorkspace();
 }
 
 } // namespace impl

--- a/src/unmtr_hb2st.cc
+++ b/src/unmtr_hb2st.cc
@@ -12,8 +12,7 @@
 
 namespace slate {
 
-namespace internal {
-namespace specialization {
+namespace impl {
 
 //------------------------------------------------------------------------------
 /// Distributed parallel unmtr_hb2st.
@@ -21,7 +20,7 @@ namespace specialization {
 /// @ingroup heev_specialization
 ///
 template <Target target, typename scalar_t>
-void unmtr_hb2st(slate::internal::TargetType<target>,
+void unmtr_hb2st(
                  Side side, Op op,
                  Matrix<scalar_t>& V,
                  Matrix<scalar_t>& C,
@@ -53,22 +52,8 @@ void unmtr_hb2st(slate::internal::TargetType<target>,
     V.releaseWorkspace();
     C.releaseWorkspace();
 }
-} // namespace specialization
-} // namespace internal
 
-//------------------------------------------------------------------------------
-/// Version with target as template parameter.
-/// @ingroup heev_computational
-///
-template <Target target, typename scalar_t>
-void unmtr_hb2st(Side side, Op op,
-                 Matrix<scalar_t>& V,
-                 Matrix<scalar_t>& C,
-                 const std::map<Option, Value>& opts)
-{
-    internal::specialization::unmtr_hb2st(internal::TargetType<target>(),
-                                          side, op, V, C, opts);
-}
+} // namespace impl
 
 //------------------------------------------------------------------------------
 /// Multiplies the general m-by-n matrix C by Q from `slate::hb2st` as
@@ -130,14 +115,14 @@ void unmtr_hb2st(Side side, Op op,
     switch (target) {
         case Target::Host:
         case Target::HostTask:
-            unmtr_hb2st<Target::HostTask>( side, op, V, C, opts);
+            impl::unmtr_hb2st<Target::HostTask>( side, op, V, C, opts);
             break;
         case Target::HostNest:
             break;
         case Target::HostBatch:
             break;
         case Target::Devices:
-            unmtr_hb2st<Target::Devices>( side, op, V, C, opts);
+            impl::unmtr_hb2st<Target::Devices>( side, op, V, C, opts);
             break;
     }
     // todo: return value for errors?

--- a/src/unmtr_hb2st.cc
+++ b/src/unmtr_hb2st.cc
@@ -29,10 +29,10 @@ void unmtr_hb2st(slate::internal::TargetType<target>,
 {
     if (target == Target::Devices) {
         trace::Block trace_block("quealloc");
-        const int64_t batch_size_zero = 0; // use default batch size
+        const int64_t batch_size_default = 0; // use default batch size
         // use separate queue for each parallel task in internal_unmtr_hb2st
-        const int64_t num_queues = omp_get_max_threads();
-        C.allocateBatchArrays(batch_size_zero, num_queues);
+        int num_queues = omp_get_max_threads();
+        C.allocateBatchArrays( batch_size_default, num_queues );
     }
 
     // set min number for omp nested active parallel regions

--- a/src/version.cc
+++ b/src/version.cc
@@ -8,7 +8,7 @@
 namespace slate {
 
 //------------------------------------------------------------------------------
-/// @return SLATE++ version.
+/// @return SLATE version.
 /// Version is integer of form yyyymmrr, where yyyy is year, mm is month,
 /// and rr is release counter within month, starting at 00.
 ///
@@ -17,15 +17,15 @@ int version()
     return SLATE_VERSION;
 }
 
-// SLATE_ID is the Mercurial or git commit hash ID, either
-// defined by `hg id` or `git rev-parse --short HEAD` in Makefile,
+// SLATE_ID is the git commit hash ID, either
+// defined by `git rev-parse --short HEAD` in Makefile,
 // or defined here by make_release.py for release tar files. DO NOT EDIT.
 #ifndef SLATE_ID
 #define SLATE_ID "unknown"
 #endif
 
 //------------------------------------------------------------------------------
-/// @return SLATE++ Mercurial or git commit hash ID.
+/// @return SLATE git commit hash ID.
 ///
 const char* id()
 {

--- a/src/work/work_trmm.cc
+++ b/src/work/work_trmm.cc
@@ -65,8 +65,12 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     using blas::conj;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
-
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -91,14 +95,9 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    const int priority_0 = 0;
-    const int priority_1 = 1;
-
     // Requires at least 2 queues
     if (target == Target::Devices)
         assert(B.numComputeQueues() >= 2);
-    const int64_t queue_0 = 0;
-    const int64_t queue_1 = 1;
 
     if (A.uplo() == Uplo::Upper) {
         // ----------------------------------------
@@ -189,7 +188,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(0, k-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(0, k-1, 0, nt-1),
-                    layout, priority_0, queue_0);
+                    layout, priority_0, queue_0 );
 
                 internal::trmm<target>(
                     Side::Left,
@@ -292,7 +291,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(k+1, mt-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(k+1, mt-1, 0, nt-1),
-                    layout, priority_0, queue_0);
+                    layout, priority_0, queue_0 );
 
                 // todo: target? needs batch trmm
                 internal::trmm<target>(

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -57,12 +57,17 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     using blas::conj;
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Constants
     const scalar_t one = 1.0;
-
-    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
-
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
+    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
+
+    // Options
+    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     // if on right, change to left by (conj)-transposing A and B to get
     // op(B) = op(A)^{-1} * op(B)
@@ -85,9 +90,6 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    const int priority_one  = 1;
-    const int priority_zero = 0;
-
     Options opts2 = opts;
 
     // Requires 2+lookahead queues
@@ -100,9 +102,6 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
         // clean up tiles.
         opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
     }
-
-    const int64_t queue_0 = 0;
-    const int64_t queue_1 = 1;
 
     if (A.uplo() == Uplo::Lower) {
         // ----------------------------------------
@@ -122,7 +121,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_one, layout, queue_1, opts2);
+                    priority_1, layout, queue_1, opts2 );
 
                 // send A(i=k+1:mt-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -150,7 +149,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, queue_ik1, opts2 );
+                        layout, priority_1, queue_ik1, opts2 );
                 }
             }
 
@@ -168,7 +167,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(k+1+lookahead, mt-1, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(k+1+lookahead, mt-1, 0, nt-1),
-                        layout, priority_zero, queue_0, opts2);
+                        layout, priority_0, queue_0, opts2 );
                 }
             }
 
@@ -207,7 +206,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_one, layout, queue_1, opts2);
+                    priority_1, layout, queue_1, opts2 );
 
                 // send A(i=0:k-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -232,7 +231,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, queue_ikl2, opts2 );
+                        layout, priority_1, queue_ikl2, opts2 );
                 }
             }
 
@@ -249,7 +248,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(0, k-1-lookahead, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(0, k-1-lookahead, 0, nt-1),
-                        layout, priority_zero, queue_0, opts2);
+                        layout, priority_0, queue_0, opts2 );
                 }
             }
 

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -145,11 +145,12 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 #pragma omp task depend(in:row[k]) \
                                  depend(inout:row[i]) priority(1)
                 {
+                    int queue_ik1 = i-k+1;
                     internal::gemm<target>(
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, i-k+1, opts2);
+                        layout, priority_one, queue_ik1, opts2 );
                 }
             }
 
@@ -226,11 +227,12 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 #pragma omp task depend(in:row[k]) \
                                  depend(inout:row[i]) priority(1)
                 {
+                    int queue_ikl2 = i-k+lookahead+2;
                     internal::gemm<target>(
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_one, i-k+lookahead+2, opts2);
+                        layout, priority_one, queue_ikl2, opts2 );
                 }
             }
 

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -60,6 +60,12 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     using std::real;
     using std::imag;
 
+    // Constants
+    const scalar_t one = 1.0;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    //const int queue_0 = 0;
+    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -84,16 +90,9 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    const int priority_one  = 1;
-    const int priority_zero = 0;
-
     // Requires 2 queues
     if (target == Target::Devices)
         assert(B.numComputeQueues() >= 2);
-    //const int64_t queue_0 = 0;
-    const int64_t queue_1 = 1;
-
-    const scalar_t one = 1.0;
 
     if (A.uplo() == Uplo::Lower) {
         // ----------------------------------------
@@ -144,7 +143,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_one, layout, queue_1);
+                        priority_1, layout, queue_1 );
                 }
 
                 // Send the solution back to where it belongs
@@ -200,7 +199,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(i, i, 0, nt-1),
-                        layout, priority_one);
+                        layout, priority_1 );
                 }
             }
 
@@ -232,7 +231,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(k+1+lookahead, mt-1, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(k+1+lookahead, mt-1, 0, nt-1),
-                        layout, priority_zero); //, queue_0);
+                        layout, priority_0 ); //, queue_0 );
                 }
             }
         }
@@ -287,7 +286,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_one, layout, queue_1);
+                        priority_1, layout, queue_1 );
                 }
 
                 // Send the solution back to where it belongs
@@ -343,7 +342,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(i, i, 0, nt-1),
-                        layout, priority_one);
+                        layout, priority_1 );
                 }
             }
 
@@ -375,7 +374,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(0, k-1-lookahead, k, k),
                               B.sub(k, k, 0, nt-1),
                         one,  B.sub(0, k-1-lookahead, 0, nt-1),
-                        layout, priority_zero); //, queue_0);
+                        layout, priority_0 ); //, queue_0 );
                 }
             }
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,7 +124,7 @@ if (slate_is_project)
     add_custom_target(
         "check"
         COMMAND
-            python run_tests.py --quick gesv posv gels heev gesvd
+            python3 run_tests.py --quick gesv posv gels heev gesvd
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
 endif()

--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -24,7 +24,6 @@
 
 // -----------------------------------------------------------------------------
 const int64_t idist_rand  = 1;
-const int64_t idist_rands = 2;
 const int64_t idist_randn = 3;
 
 enum class TestMatrixType {

--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -24,12 +24,13 @@
 
 // -----------------------------------------------------------------------------
 const int64_t idist_rand  = 1;
+const int64_t idist_rands = 2;
 const int64_t idist_randn = 3;
 
 enum class TestMatrixType {
-    rand      = 1,  // maps to larnv idist
-    rands     = 2,  // maps to larnv idist
-    randn     = 3,  // maps to larnv idist
+    rand  = idist_rand,   // 1
+    rands = idist_rands,  // 2
+    randn = idist_randn,  // 3
     randb,
     zero,
     one,
@@ -51,9 +52,9 @@ enum class TestMatrixType {
 };
 
 enum class TestMatrixDist {
-    rand      = 1,  // maps to larnv idist
-    rands     = 2,  // maps to larnv idist
-    randn     = 3,  // maps to larnv idist
+    rand  = idist_rand,   // 1
+    rands = idist_rands,  // 2
+    randn = idist_randn,  // 3
     arith,
     geo,
     cluster0,

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -128,7 +128,6 @@ group_opt.add_argument( '--np',     action='store', help='number of MPI processe
 group_opt.add_argument( '--grid',   action='store', help='use p-by-q MPI process grid', default='' )
 group_opt.add_argument( '--repeat', action='store', help='times to repeat each test', default='' )
 group_opt.add_argument( '--thresh', action='store', help='default=%(default)s', default='1,0.5')
-group_opt.add_argument( '--tee',    action='store_true', help='controls writing to both stdout and stderr' )
 
 parser.add_argument( 'tests', nargs=argparse.REMAINDER )
 opts = parser.parse_args()
@@ -608,9 +607,10 @@ if (opts.aux):
     ]
 
 # ------------------------------------------------------------------------------
-# when output is redirected to file instead of TTY console,
-# print extra messages to stderr on TTY console.
-output_redirected = not sys.stdout.isatty()
+# When stdout is redirected to file instead of TTY console,
+# and  stderr is still going to a TTY console,
+# print extra summary messages to stderr.
+output_redirected = sys.stderr.isatty() and not sys.stdout.isatty()
 
 # ------------------------------------------------------------------------------
 # if output is redirected, prints to both stderr and stdout;
@@ -618,7 +618,7 @@ output_redirected = not sys.stdout.isatty()
 def print_tee( *args ):
     global output_redirected
     print( *args )
-    if (output_redirected and opts.tee):
+    if (output_redirected):
         print( *args, file=sys.stderr )
 # end
 
@@ -681,6 +681,10 @@ def run_test( cmd ):
 
 # ------------------------------------------------------------------------------
 # run each test
+
+start = time.time()
+print_tee( time.ctime() )
+
 failed_tests = []
 passed_tests = []
 ntests = len(opts.tests)
@@ -744,5 +748,9 @@ if opts.xml:
     tree = ET.ElementTree(root)
     tree.write( opts.xml )
 # end
+
+elapsed = time.time() - start
+print_tee( 'Elapsed %.2f sec' % elapsed )
+print_tee( time.ctime() )
 
 exit( nfailed )

--- a/test/scalapack_copy.hh
+++ b/test/scalapack_copy.hh
@@ -73,7 +73,7 @@ void copyTile(
             // Copy from device tile, if it exists, to ScaLAPACK.
             auto Aij = A(i, j, dev);
             blas::Queue queue(dev, 0);
-            blas::device_getmatrix(
+            blas::device_copy_matrix(
                 Aij.mb(), Aij.nb(),
                 Aij.data(), Aij.stride(),
                 &B[ ii_local + jj_local*ldb ], ldb, queue);
@@ -123,7 +123,7 @@ void copyTile(
             A.tileGetForWriting(i, j, dev, slate::LayoutConvert::ColMajor);
             auto Aij = A(i, j, dev);
             blas::Queue queue(dev, 0);
-            blas::device_setmatrix(
+            blas::device_copy_matrix(
                 Aij.mb(), Aij.nb(),
                 &B[ ii_local + jj_local*ldb ], ldb,
                 Aij.data(), Aij.stride(), queue);

--- a/test/scalapack_support_routines.hh
+++ b/test/scalapack_support_routines.hh
@@ -51,7 +51,7 @@ static inline void CORE_plrnt(int64_t m, int64_t n, scalar_t* A, int64_t lda,
         for (i = 0; i < m; ++i) {
             *tmp = 0.5f - ran*RndF_Mul;
             ran  = Rnd64_A*ran + Rnd64_C;
-            tmp++;
+            ++tmp;
         }
         tmp  += lda - i;
         jump += bigM;
@@ -69,34 +69,34 @@ static inline void CORE_plghe(scalar_t bump, int64_t m, int64_t n, scalar_t* A, 
     jump = (ull)m0 + (ull)n0*(ull)gM;
     /* Tile diagonal */
     if (m0 == n0) {
-        for (j = 0; j < n; j++) {
+        for (j = 0; j < n; ++j) {
             ran = Rnd64_jump(jump, seed);
 
-            for (i = j; i < m; i++) {
+            for (i = j; i < m; ++i) {
                 *tmp = 0.5f - ran*RndF_Mul;
                 ran  = Rnd64_A*ran + Rnd64_C;
-                tmp++;
+                ++tmp;
             }
             tmp  += (lda - i + j + 1);
             jump += gM + 1;
         }
-        for (j = 0; j < n; j++) {
+        for (j = 0; j < n; ++j) {
             A[j + j*lda] += bump;
 
-            for (i = 0; i < j; i++)
+            for (i = 0; i < j; ++i)
                 A[lda*j + i] = A[lda*i + j];
         }
     }
 
     /* Lower part */
     else if (m0 > n0) {
-        for (j = 0; j < n; j++) {
+        for (j = 0; j < n; ++j) {
             ran = Rnd64_jump(jump, seed);
 
-            for (i = 0; i < m; i++) {
+            for (i = 0; i < m; ++i) {
                 *tmp = 0.5f - ran*RndF_Mul;
                 ran  = Rnd64_A*ran + Rnd64_C;
-                tmp++;
+                ++tmp;
             }
             tmp  += (lda - i);
             jump += gM;
@@ -108,10 +108,10 @@ static inline void CORE_plghe(scalar_t bump, int64_t m, int64_t n, scalar_t* A, 
         /* Overwrite jump */
         jump = (ull)n0 + (ull)m0*(ull)gM;
 
-        for (i = 0; i < m; i++) {
+        for (i = 0; i < m; ++i) {
             ran = Rnd64_jump(jump, seed);
 
-            for (j = 0; j < n; j++) {
+            for (j = 0; j < n; ++j) {
                 A[j*lda + i] = 0.5f - ran*RndF_Mul;
                 ran = Rnd64_A*ran + Rnd64_C;
             }

--- a/test/test_bdsqr.cc
+++ b/test/test_bdsqr.cc
@@ -180,7 +180,7 @@ void test_bdsqr_work(Params& params, bool run)
             Id.insertLocalTiles();
             set(zero, one, Id);
 
-            auto UT = conjTranspose(U);
+            auto UT = conj_transpose( U );
             slate::gemm(one, UT, U, -one, Id);
             params.ortho_U() = slate::norm(slate::Norm::Fro, Id) / m;
             params.okay() = params.okay() && (params.ortho_U() <= tol);
@@ -191,7 +191,7 @@ void test_bdsqr_work(Params& params, bool run)
             Id.insertLocalTiles();
             set(zero, one, Id);
 
-            auto VTT = conjTranspose(VT);
+            auto VTT = conj_transpose( VT );
             slate::gemm(one, VTT, VT, -one, Id);
             params.ortho_V() = slate::norm(slate::Norm::Fro, Id) / n;
             params.okay() = params.okay() && (params.ortho_V() <= tol);

--- a/test/test_gbmm.cc
+++ b/test/test_gbmm.cc
@@ -147,12 +147,12 @@ void test_gbmm_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         A_band = transpose(A_band);
     else if (transA == slate::Op::ConjTrans)
-        A_band = conjTranspose(A_band);
+        A_band = conj_transpose( A_band );
 
     if (transB == slate::Op::Trans)
         B = transpose(B);
     else if (transB == slate::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     slate_assert(A_band.mt() == C.mt());
     slate_assert(B.nt() == C.nt());
@@ -189,7 +189,7 @@ void test_gbmm_work(Params& params, bool run)
         if (transA == slate::Op::Trans)
             A = transpose(A);
         else if (transA == slate::Op::ConjTrans)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
 
         print_matrix("Cref", Cref, params);
 

--- a/test/test_gbsv.cc
+++ b/test/test_gbsv.cc
@@ -184,7 +184,7 @@ void test_gbsv_work(Params& params, bool run)
             if (trans == slate::Op::Trans)
                 opA = transpose(A);
             else if (trans == slate::Op::ConjTrans)
-                opA = conjTranspose(A);
+                opA = conj_transpose( A );
 
             slate::lu_solve_using_factor(opA, pivots, B, opts);
             // Using traditional BLAS/LAPACK name
@@ -257,7 +257,7 @@ void test_gbsv_work(Params& params, bool run)
         if (trans == slate::Op::Trans)
             opAorig = transpose(Aorig);
         else if (trans == slate::Op::ConjTrans)
-            opAorig = conjTranspose(Aorig);
+            opAorig = conj_transpose( Aorig );
         slate::multiply(-one, opAorig, B, one, Bref);
         // Using traditional BLAS/LAPACK name
         // slate::gbmm(-one, opAorig, B, one, Bref);

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -158,7 +158,7 @@ void test_gels_work(Params& params, bool run)
     if (trans == slate::Op::Trans)
         opA = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (verbose >= 1) {
         printf( "%% A   %6lld-by-%6lld\n", llong(   A.m() ), llong(   A.n() ) );
@@ -207,7 +207,7 @@ void test_gels_work(Params& params, bool run)
         if (trans == slate::Op::Trans)
             opAref = transpose(Aref);
         else if (trans == slate::Op::ConjTrans)
-            opAref = conjTranspose(Aref);
+            opAref = conj_transpose( Aref );
     }
 
     double gflop = lapack::Gflop<scalar_t>::gels(m, n, nrhs);
@@ -269,7 +269,7 @@ void test_gels_work(Params& params, bool run)
             // RA = R^H op(A)
             slate::Matrix<scalar_t> RA(nrhs, opAn, nb, p, q, MPI_COMM_WORLD);
             RA.insertLocalTiles();
-            auto RT = conjTranspose(Bref);
+            auto RT = conj_transpose( Bref );
             slate::multiply(one, RT, opA, zero, RA);
             // Using traditional BLAS/LAPACK name
             // slate::gemm(one, RT, opA, zero, RA);

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -160,12 +160,12 @@ void test_gemm_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         A = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     if (transB == slate::Op::Trans)
         B = transpose(B);
     else if (transB == slate::Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     slate_assert(A.mt() == C.mt());
     slate_assert(B.nt() == C.nt());

--- a/test/test_genorm.cc
+++ b/test/test_genorm.cc
@@ -98,7 +98,7 @@ void test_genorm_work(Params& params, bool run)
     if (trans == slate::Op::Trans)
         A = transpose(A);
     else if (trans == slate::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     print_matrix("A", A, params);
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -303,7 +303,7 @@ void test_gesv_work(Params& params, bool run)
             if (trans == slate::Op::Trans)
                 opA = transpose(A);
             else if (trans == slate::Op::ConjTrans)
-                opA = conjTranspose(A);
+                opA = conj_transpose( A );
 
             if (params.routine == "getrs"
                 || params.routine == "getrf")
@@ -350,7 +350,7 @@ void test_gesv_work(Params& params, bool run)
         if (trans == slate::Op::Trans)
             opAref = slate::transpose(Aref);
         else if (trans == slate::Op::ConjTrans)
-            opAref = slate::conj_transpose(Aref);
+            opAref = slate::conj_transpose( Aref );
         else
             opAref = Aref;
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -148,7 +148,7 @@ void test_gesv_work(Params& params, bool run)
 
     // To generate matrix with non-uniform tile size using the Lambda constructor
     std::function< int64_t (int64_t j) >
-    tileNb = [n, nb](int64_t j) {
+    tileNb = [nb](int64_t j) {
         // for non-uniform tile size
         return (j % 2 != 0 ? nb/2 : nb);
     };

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -156,8 +156,8 @@ void test_her2k_work(Params& params, bool run)
         opB = transpose(B);
     }
     else if (trans == slate::Op::ConjTrans) {
-        opA = conjTranspose(A);
-        opB = conjTranspose(B);
+        opA = conj_transpose( A );
+        opB = conj_transpose( B );
     }
     slate_assert(A.mt() == C.mt());
     slate_assert(B.mt() == C.mt());
@@ -187,12 +187,12 @@ void test_her2k_work(Params& params, bool run)
         // Y = beta C X
         slate::multiply( scalar_t(beta), C, X, zero, Y, opts );
         // Z = A^H X
-        auto AH = conjTranspose( opA );
+        auto AH = conj_transpose( opA );
         slate::multiply( one, AH, X, zero, Z, opts );
         // Y = conj(alpha) B Z + Y
         slate::multiply( conj( alpha ), opB, Z, one, Y, opts );
         // Z = B^H X
-        auto BH = conjTranspose( opB );
+        auto BH = conj_transpose( opB );
         slate::multiply( one, BH, X, zero, Z, opts );
         // Y = alpha A Z + Y
         slate::multiply( alpha, opA, Z, one, Y, opts );

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -139,7 +139,7 @@ void test_herk_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         opA = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
     slate_assert(opA.mt() == C.mt());
 
     if (trace) slate::trace::Trace::on();
@@ -162,7 +162,7 @@ void test_herk_work(Params& params, bool run)
         // Y = beta C X
         slate::multiply( scalar_t(beta), C, X, zero, Y, opts );
         // Z = A^H X
-        auto AH = conjTranspose( opA );
+        auto AH = conj_transpose( opA );
         slate::multiply( one, AH, X, zero, Z, opts );
         // Y = alpha A Z + Y
         slate::multiply( scalar_t(alpha), opA, Z, one, Y, opts );

--- a/test/test_steqr2.cc
+++ b/test/test_steqr2.cc
@@ -154,7 +154,7 @@ void test_steqr2_work(Params& params, bool run)
         //
         //==================================================
         if (wantz) {
-            auto ZT = conjTranspose(Z);
+            auto ZT = conj_transpose( Z );
             set(zero, one, A);
             slate::gemm(one, ZT, Z, -one, A);
             params.ortho() = slate::norm(slate::Norm::Fro, A) / n;

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -159,8 +159,8 @@ void test_syr2k_work(Params& params, bool run)
         opB = transpose(B);
     }
     else if (trans == slate::Op::ConjTrans) {
-        opA = conjTranspose(A);
-        opB = conjTranspose(B);
+        opA = conj_transpose( A );
+        opB = conj_transpose( B );
     }
     slate_assert(opA.mt() == C.mt());
     slate_assert(opB.mt() == C.mt());

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -137,7 +137,7 @@ void test_syrk_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         opA = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
     slate_assert(opA.mt() == C.mt());
 
     if (trace) slate::trace::Trace::on();

--- a/test/test_tbsm.cc
+++ b/test/test_tbsm.cc
@@ -150,12 +150,12 @@ void test_tbsm_work(Params& params, bool run)
     if (transA == slate::Op::Trans)
         A = transpose(A);
     else if (transA == slate::Op::ConjTrans)
-        A = conjTranspose(A);
+        A = conj_transpose( A );
 
     //if (transB == slate::Op::Trans)
     //    B = transpose(B);
     //else if (transB == slate::Op::ConjTrans)
-    //    B = conjTranspose(B);
+    //    B = conj_transpose( B );
 
     if (verbose > 1) {
         // todo: print_matrix( A ) calls Matrix version;

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -140,12 +140,12 @@ void test_trmm_work(Params& params, bool run)
     if (transA == Op::Trans)
         opA = transpose(A);
     else if (transA == Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (transB == Op::Trans)
         B = transpose(B);
     else if (transB == Op::ConjTrans)
-        B = conjTranspose(B);
+        B = conj_transpose( B );
 
     // If check run, perform first half of SLATE residual check.
     slate::Matrix<scalar_t> X, X2, Y;

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -149,7 +149,7 @@ void test_trsm_work(Params& params, bool run)
     if (transA == Op::Trans)
         opA = transpose(A);
     else if (transA == Op::ConjTrans)
-        opA = conjTranspose(A);
+        opA = conj_transpose( A );
 
     if (trace) slate::trace::Trace::on();
     else slate::trace::Trace::off();

--- a/tools/c_api/generate_matrix.py
+++ b/tools/c_api/generate_matrix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/tools/c_api/generate_matrix.py
+++ b/tools/c_api/generate_matrix.py
@@ -162,8 +162,8 @@ matrix_routines = [
     ['int64_t',      '_n',                                 'slate_Matrix',                                                  'n()'],
     ['bool',         '_tileIsLocal',                       'slate_Matrix, int64_t i, int64_t j',                            'tileIsLocal(i, j)'],
     ['slate_Tile',   '_at',                                'slate_Matrix, int64_t i, int64_t j',                            'at(i, j)'],
-    ['void',         '_transpose_in_place',                'slate_Matrix',                                                  'transpose(*A_)'],
-    ['void',         '_conjTranspose_in_place',            'slate_Matrix',                                                  'conjTranspose(*A_)'],
+    ['void',         '_transpose_in_place',                'slate_Matrix',                                                  'transpose( *A_ )'],
+    ['void',         '_conj_transpose_in_place',           'slate_Matrix',                                                  'conj_transpose( *A_ )'],
 ]
 
 contents = ''
@@ -231,7 +231,7 @@ for matrix_type in matrix_types:
                 else:
                     if routine[1] == '_destroy':
                         contents0 += '    ' + routine[3] + ' A_;\n'
-                    elif (routine[1] == '_conjTranspose_in_place') or (routine[1] == '_transpose_in_place'):
+                    elif (routine[1] == '_conj_transpose_in_place') or (routine[1] == '_transpose_in_place'):
                         contents0 += '    *A_ = slate::' + routine[3] + ';\n'
                     else:
                         contents0 += '    A_->' + routine[3] + ';\n'

--- a/tools/c_api/generate_util.py
+++ b/tools/c_api/generate_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/tools/c_api/generate_wrappers.py
+++ b/tools/c_api/generate_wrappers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/tools/check-style-hook.py
+++ b/tools/check-style-hook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Rejects commits that violate basic style rules:
 #   - no trailing whitespace

--- a/tools/fortran/generate_fortran_module.py
+++ b/tools/fortran/generate_fortran_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/release.py
+++ b/tools/release.py
@@ -29,8 +29,8 @@ with PROJECT changed to the project's name.
 
 'version.c' is a source file containing the following #define for the id:
 
-    // PROJECT_ID is the Mercurial or git commit hash ID, either
-    // defined by `hg id` or `git rev-parse --short HEAD` in Makefile,
+    // PROJECT_ID is the git commit hash ID, either
+    // defined by `git rev-parse --short HEAD` in Makefile,
     // or defined here by make_release.py for release tar files. DO NOT EDIT.
     #ifndef PROJECT_ID
     #define PROJECT_ID "unknown"

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -32,7 +32,7 @@ if (slate_is_project)
     add_custom_target(
         unit_check
         COMMAND
-            python run_tests.py
+            python3 run_tests.py
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
     add_dependencies( check unit_check )

--- a/unit_test/test_BandMatrix.cc
+++ b/unit_test/test_BandMatrix.cc
@@ -91,11 +91,11 @@ void test_BandMatrix_transpose()
 }
 
 //------------------------------------------------------------------------------
-void test_BandMatrix_conjTranspose()
+void test_BandMatrix_conj_transpose()
 {
     auto A = slate::BandMatrix<double>(m, n, kl, ku, nb, p, q, mpi_comm);
 
-    auto AT = conjTranspose( A );
+    auto AT = conj_transpose( A );
 
     test_assert(AT.mt() == ceildiv(n, nb));
     test_assert(AT.nt() == ceildiv(m, nb));
@@ -447,7 +447,7 @@ void run_tests()
     if (mpi_rank == 0)
         printf("\nMethods\n");
     run_test(test_BandMatrix_transpose,       "transpose",      mpi_comm);
-    run_test(test_BandMatrix_conjTranspose,  "conjTranspose", mpi_comm);
+    run_test(test_BandMatrix_conj_transpose,  "conj_transpose", mpi_comm);
     run_test(test_BandMatrix_swap,            "swap",           mpi_comm);
     run_test(test_BandMatrix_tileInsert_new,  "BandMatrix::tileInsert(i, j, dev) ", mpi_comm);
     run_test(test_BandMatrix_tileInsert_data, "BandMatrix::tileInsert(i, j, dev, data, lda)",  mpi_comm);

--- a/unit_test/test_HermitianMatrix.cc
+++ b/unit_test/test_HermitianMatrix.cc
@@ -1288,7 +1288,7 @@ int main(int argc, char** argv)
         else if (arg == "-seed" && i+1 < argc)
             seed = atoi( argv[++i] );
         else if (arg == "-v")
-            verbose++;
+            ++verbose;
         else {
             printf( "unknown argument: %s\n", argv[i] );
             return 1;

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -2137,7 +2137,7 @@ int main(int argc, char** argv)
         else if (arg == "-seed" && i+1 < argc)
             seed = atoi( argv[++i] );
         else if (arg == "-v")
-            verbose++;
+            ++verbose;
         else {
             printf( "unknown argument: %s\n", argv[i] );
             return 1;

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -805,15 +805,15 @@ void test_Matrix_transpose()
 }
 
 //------------------------------------------------------------------------------
-/// Test conjTranspose(A).
-void test_Matrix_conjTranspose()
+/// Test conj_transpose( A ).
+void test_Matrix_conj_transpose()
 {
     int lda = roundup(m, mb);
     std::vector<double> Ad( lda*n );
     auto A = slate::Matrix<double>::fromLAPACK(
         m, n, Ad.data(), lda, mb, nb, p, q, mpi_comm );
 
-    auto AT = conjTranspose( A );
+    auto AT = conj_transpose( A );
 
     test_assert(AT.mt() == ceildiv(n, nb));
     test_assert(AT.nt() == ceildiv(m, mb));
@@ -1990,7 +1990,7 @@ void test_Matrix_tileReduceFromSet()
                  m, n, Ad.data(), lda, nb, p, q, mpi_comm );
 
     auto AT = transpose( A );
-    auto AH = conjTranspose( A );
+    auto AH = conj_transpose( A );
 
     std::set<int> all_reduce_set;
 
@@ -2067,7 +2067,7 @@ void run_tests()
     run_test(test_Matrix_emptyLikeMbNb,        "Matrix::emptyLikeMbNb",                    mpi_comm);
     run_test(test_Matrix_emptyLikeOp,          "Matrix::emptyLikeOp",                      mpi_comm);
     run_test(test_Matrix_transpose,            "transpose",                                mpi_comm);
-    run_test(test_Matrix_conjTranspose,        "conjTranspose",                            mpi_comm);
+    run_test(test_Matrix_conj_transpose,       "conj_transpose",                           mpi_comm);
     run_test(test_Matrix_swap,                 "swap",                                     mpi_comm);
     run_test(test_Matrix_tileInsert_new,       "Matrix::tileInsert(i, j, dev) ",           mpi_comm);
     run_test(test_Matrix_tileInsert_data,      "Matrix::tileInsert(i, j, dev, data, lda)", mpi_comm);

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -1829,7 +1829,7 @@ void test_Matrix_MOSI()
 /// Test tileLayoutConvert.
 void test_Matrix_tileLayoutConvert()
 {
-    int lda = roundup(m, nb);
+    int lda = roundup(m, mb);
     std::vector<double> Ad( lda*n );
 
     int64_t iseed[4] = { 0, 1, 2, 3 };

--- a/unit_test/test_Memory.cc
+++ b/unit_test/test_Memory.cc
@@ -201,7 +201,6 @@ void test_alloc_device()
     mem.clearHostBlocks();
     for (int dev = 0; dev < mem.num_devices_; ++dev) {
         mem.clearDeviceBlocks(dev, dev_queues[dev] );
-        dev_queues[dev]->sync();
     }
 
     // free the device specific queues
@@ -276,7 +275,6 @@ void test_clearDeviceBlocks()
     // deallocate/clear memory before the slate::Memory destructer
     mem.clearHostBlocks();
     for (int dev = 0; dev < mem.num_devices_; ++dev) {
-       dev_queues[dev]->sync();
         mem.clearDeviceBlocks(dev, dev_queues[dev] );
         dev_queues[dev]->sync();
     }

--- a/unit_test/test_SymmetricMatrix.cc
+++ b/unit_test/test_SymmetricMatrix.cc
@@ -1288,7 +1288,7 @@ int main(int argc, char** argv)
         else if (arg == "-seed" && i+1 < argc)
             seed = atoi( argv[++i] );
         else if (arg == "-v")
-            verbose++;
+            ++verbose;
         else {
             printf( "unknown argument: %s\n", argv[i] );
             return 1;

--- a/unit_test/test_Tile.cc
+++ b/unit_test/test_Tile.cc
@@ -660,8 +660,7 @@ void test_copyData(int align_host, int align_dev)
     setup_data(B);
     clear_data(B);
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 

--- a/unit_test/test_Tile.cc
+++ b/unit_test/test_Tile.cc
@@ -132,8 +132,9 @@ void verify_data_transpose_(slate::Tile<scalar_t>& A, int expect_rank,
 //
 // todo: setup data with imaginary bits.
 template <typename scalar_t>
-void verify_data_conjTranspose_(slate::Tile<scalar_t>& A, int expect_rank,
-                                 const char* file, int line)
+void verify_data_conj_transpose_(
+    slate::Tile<scalar_t>& A, int expect_rank,
+    const char* file, int line)
 {
     try {
         using blas::conj;
@@ -152,8 +153,8 @@ void verify_data_conjTranspose_(slate::Tile<scalar_t>& A, int expect_rank,
     }
 }
 
-#define verify_data_conjTranspose(A, expect_rank) \
-        verify_data_conjTranspose_(A, expect_rank, __FILE__, __LINE__)
+#define verify_data_conj_transpose( A, expect_rank ) \
+        verify_data_conj_transpose_( A, expect_rank, __FILE__, __LINE__ )
 
 //------------------------------------------------------------------------------
 /// Tests Tile() default constructor and simple data accessors.
@@ -330,9 +331,9 @@ void test_transpose_complex()
 }
 
 //------------------------------------------------------------------------------
-/// Tests conjTranspose(Tile).
+/// Tests conj_transpose( Tile ).
 template <typename scalar_t>
-void test_conjTranspose()
+void test_conj_transpose()
 {
     const int m = 20;
     const int n = 30;
@@ -341,8 +342,8 @@ void test_conjTranspose()
     slate::Tile<scalar_t> A(m, n, data, lda, -1, slate::TileKind::UserOwned);
     setup_data(A);
 
-    //----- conjTranspose
-    auto AC = conjTranspose(A);
+    //----- conj_transpose
+    auto AC = conj_transpose( A );
 
     test_assert(AC.mb() == n);  // trans
     test_assert(AC.nb() == m);  // trans
@@ -356,10 +357,10 @@ void test_conjTranspose()
     test_assert(AC.bytes() == sizeof(scalar_t) * m * n);
     test_assert(AC.size() == size_t(m * n));
 
-    verify_data_conjTranspose(AC, mpi_rank);
+    verify_data_conj_transpose( AC, mpi_rank );
 
-    //----- conjTranspose again
-    auto ACC = conjTranspose(AC);
+    //----- conj_transpose again
+    auto ACC = conj_transpose( AC );
 
     test_assert(ACC.mb() == m);  // restored
     test_assert(ACC.nb() == n);  // restored
@@ -377,8 +378,8 @@ void test_conjTranspose()
 
     auto AT = transpose(A);
     if (AT.is_real) {
-        //----- transpose + conjTranspose for real
-        auto ATC = conjTranspose(AT);
+        //----- transpose + conj_transpose for real
+        auto ATC = conj_transpose( AT );
 
         test_assert(ATC.mb() == m);  // restored
         test_assert(ATC.nb() == n);  // restored
@@ -394,7 +395,7 @@ void test_conjTranspose()
 
         verify_data(ATC, mpi_rank);
 
-        //----- conjTranspose + transpose for real
+        //----- conj_transpose + transpose for real
         auto ACT = transpose(AC);
 
         test_assert(ACT.mb() == m);  // restored
@@ -412,20 +413,20 @@ void test_conjTranspose()
         verify_data(ATC, mpi_rank);
     }
     else {
-        //----- transpose + conjTranspose is unsupported for complex
-        test_assert_throw_std(conjTranspose(AT) /* std::exception */);
+        //----- transpose + conj_transpose is unsupported for complex
+        test_assert_throw_std(conj_transpose( AT ) /* std::exception */);
         test_assert_throw_std(transpose(AC)      /* std::exception */);
     }
 }
 
-void test_conjTranspose_double()
+void test_conj_transpose_double()
 {
-    test_conjTranspose< double >();
+    test_conj_transpose< double >();
 }
 
-void test_conjTranspose_complex()
+void test_conj_transpose_complex()
 {
-    test_conjTranspose< std::complex<double> >();
+    test_conj_transpose< std::complex<double> >();
 }
 
 //------------------------------------------------------------------------------
@@ -455,12 +456,12 @@ void test_lower()
     test_assert(ATT.uploLogical()  == blas::Uplo::Lower);
     test_assert(ATT.uploPhysical() == blas::Uplo::Lower);
 
-    auto AC = conjTranspose(A);
+    auto AC = conj_transpose( A );
     test_assert(AC.uplo()         == blas::Uplo::Upper);
     test_assert(AC.uploLogical()  == blas::Uplo::Upper);
     test_assert(AC.uploPhysical() == blas::Uplo::Lower);
 
-    auto ACC = conjTranspose(AC);
+    auto ACC = conj_transpose( AC );
     test_assert(ACC.uplo()         == blas::Uplo::Lower);
     test_assert(ACC.uploLogical()  == blas::Uplo::Lower);
     test_assert(ACC.uploPhysical() == blas::Uplo::Lower);
@@ -503,12 +504,12 @@ void test_upper()
     test_assert(ATT.uploLogical()  == blas::Uplo::Upper);
     test_assert(ATT.uploPhysical() == blas::Uplo::Upper);
 
-    auto AC = conjTranspose(A);
+    auto AC = conj_transpose( A );
     test_assert(AC.uplo()         == blas::Uplo::Lower);
     test_assert(AC.uploLogical()  == blas::Uplo::Lower);
     test_assert(AC.uploPhysical() == blas::Uplo::Upper);
 
-    auto ACC = conjTranspose(AC);
+    auto ACC = conj_transpose( AC );
     test_assert(ACC.uplo()         == blas::Uplo::Upper);
     test_assert(ACC.uploLogical()  == blas::Uplo::Upper);
     test_assert(ACC.uploPhysical() == blas::Uplo::Upper);
@@ -785,11 +786,11 @@ void run_tests()
             test_transpose_complex,
             "transpose, complex");
         run_test(
-            test_conjTranspose_double,
-            "conjTranspose, double");
+            test_conj_transpose_double,
+            "conj_transpose, double");
         run_test(
-            test_conjTranspose_complex,
-            "conjTranspose, complex");
+            test_conj_transpose_complex,
+            "conj_transpose, complex");
         run_test(
             test_lower_double,
             "uplo(lower)");

--- a/unit_test/test_TrapezoidMatrix.cc
+++ b/unit_test/test_TrapezoidMatrix.cc
@@ -1914,7 +1914,7 @@ int main(int argc, char** argv)
         else if (arg == "-seed" && i+1 < argc)
             seed = atoi( argv[++i] );
         else if (arg == "-v")
-            verbose++;
+            ++verbose;
         else {
             printf( "unknown argument: %s\n", argv[i] );
             return 1;

--- a/unit_test/test_TrapezoidMatrix.cc
+++ b/unit_test/test_TrapezoidMatrix.cc
@@ -412,11 +412,6 @@ void test_TrapezoidMatrix_fromDevices()
         }
     }
 
-    for (int dev = 0; dev < num_devices; ++dev) {
-        blas::device_free(Aarray[dev], *dev_queues[dev]);
-    }
-    delete[] Aarray;
-
     //----------
     // uplo=General fails
     test_assert_throw(
@@ -424,6 +419,11 @@ void test_TrapezoidMatrix_fromDevices()
             blas::Uplo::General, blas::Diag::Unit,
             m, n, Aarray, num_devices, lda, nb, p, q, mpi_comm ),
         slate::Exception);
+
+    for (int dev = 0; dev < num_devices; ++dev) {
+        blas::device_free(Aarray[dev], *dev_queues[dev]);
+    }
+    delete[] Aarray;
 
     // free the device specific queues
     for (int dev = 0; dev < num_devices; ++dev)

--- a/unit_test/test_TriangularBandMatrix.cc
+++ b/unit_test/test_TriangularBandMatrix.cc
@@ -357,7 +357,7 @@ int main(int argc, char** argv)
         else if (arg == "-seed" && i+1 < argc)
             seed = atoi( argv[++i] );
         else if (arg == "-v")
-            verbose++;
+            ++verbose;
         else {
             printf( "unknown argument: %s\n", argv[i] );
             return 1;

--- a/unit_test/test_TriangularMatrix.cc
+++ b/unit_test/test_TriangularMatrix.cc
@@ -1425,7 +1425,7 @@ int main(int argc, char** argv)
         else if (arg == "-seed" && i+1 < argc)
             seed = atoi( argv[++i] );
         else if (arg == "-v")
-            verbose++;
+            ++verbose;
         else {
             printf( "unknown argument: %s\n", argv[i] );
             return 1;

--- a/unit_test/test_gecopy.cc
+++ b/unit_test/test_gecopy.cc
@@ -128,9 +128,9 @@ void run_tests()
 {
     if (mpi_rank == 0) {
         //-------------------- genorm_dev
-        for (int i = 0; i < 10; i++)
-        run_test(
-            test_gecopy_dev, "gecopy_dev");
+        for (int i = 0; i < 10; ++i) {
+            run_test( test_gecopy_dev, "gecopy_dev" );
+        }
     }
 }
 

--- a/unit_test/test_internal_blas.cc
+++ b/unit_test/test_internal_blas.cc
@@ -326,7 +326,7 @@ void test_gemm(slate::Target target)
         if (ic == 1)
             C = transpose(C);
         else if (ic == 2)
-            C = conjTranspose(C);
+            C = conj_transpose( C );
         assert(C.mt() == slate::ceildiv(m, nb));
         assert(C.nt() == slate::ceildiv(n, nb));
         if (target == slate::Target::Devices)
@@ -347,7 +347,7 @@ void test_gemm(slate::Target target)
         if (ib == 1)
             B = transpose(B);
         else if (ib == 2)
-            B = conjTranspose(B);
+            B = conj_transpose( B );
         assert(B.mt() == slate::ceildiv(k, nb));
         assert(B.nt() == slate::ceildiv(n, nb));
 
@@ -361,7 +361,7 @@ void test_gemm(slate::Target target)
         if (ia == 1)
             A = transpose(A);
         else if (ia == 2)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
         assert(A.mt() == slate::ceildiv(m, nb));
         assert(A.nt() == slate::ceildiv(k, nb));
 
@@ -497,7 +497,7 @@ void test_syrk(slate::Target target)
         if (ic == 1)
             C = transpose(C);
         else if (ic == 2)
-            C = conjTranspose(C);
+            C = conj_transpose( C );
         assert(C.mt() == slate::ceildiv(n, nb));
         assert(C.nt() == slate::ceildiv(n, nb));
         if (target == slate::Target::Devices)
@@ -529,7 +529,7 @@ void test_syrk(slate::Target target)
         if (ia == 1)
             A = transpose(A);
         else if (ia == 2)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
         assert(A.mt() == slate::ceildiv(n, nb));
         assert(A.nt() == slate::ceildiv(k, nb));
 
@@ -670,7 +670,7 @@ void test_herk(slate::Target target)
         if (ic == 1)
             C = transpose(C);
         else if (ic == 2)
-            C = conjTranspose(C);
+            C = conj_transpose( C );
         assert(C.mt() == slate::ceildiv(n, nb));
         assert(C.nt() == slate::ceildiv(n, nb));
         if (target == slate::Target::Devices)
@@ -702,7 +702,7 @@ void test_herk(slate::Target target)
         if (ia == 1)
             A = transpose(A);
         else if (ia == 2)
-            A = conjTranspose(A);
+            A = conj_transpose( A );
         assert(A.mt() == slate::ceildiv(n, nb));
         assert(A.nt() == slate::ceildiv(k, nb));
 

--- a/unit_test/test_internal_blas.cc
+++ b/unit_test/test_internal_blas.cc
@@ -34,9 +34,12 @@ blas::Diag diags[] = {
 
 slate::Target targets[] = {
     slate::Target::HostTask,
-    slate::Target::HostNest,
-    slate::Target::HostBatch,
     slate::Target::Devices,
+    slate::Target::HostBatch,
+#if not defined SLATE_HAVE_OMPTARGET
+    // OMPTARGET does not support HostNest
+    slate::Target::HostNest,
+#endif
 };
 
 // -----------------------------------------------------------------------------
@@ -838,20 +841,21 @@ int main(int argc, char** argv)
     }
 
     // run tests
+    int numtargets = sizeof(targets)/sizeof(targets[0]);
     if (do_all || do_gemm) {
-        for (int it = 0; it < 4; ++it) {
+        for (int it = 0; it < numtargets; ++it) {
             test_gemm<double>(targets[it]);
             test_gemm< std::complex<double> >(targets[it]);
         }
     }
     if (do_all || do_syrk) {
-        for (int it = 0; it < 4; ++it) {
+        for (int it = 0; it < numtargets; ++it) {
             test_syrk<double>(targets[it]);
             test_syrk< std::complex<double> >(targets[it]);
         }
     }
     if (do_all || do_herk) {
-        for (int it = 0; it < 4; ++it) {
+        for (int it = 0; it < numtargets; ++it) {
             test_herk<double>(targets[it]);
             test_herk< std::complex<double> >(targets[it]);
         }

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -165,8 +165,7 @@ void test_genorm_dev(Norm norm)
     int64_t iseed[4] = { 1, 0, 2, 3 };
     lapack::larnv( idist, iseed, lda * n, A.data() );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -210,6 +209,7 @@ void test_genorm_dev(Norm norm)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {
@@ -387,8 +387,7 @@ void test_synorm_dev(Norm norm, Uplo uplo)
     setup_data(A);
     A.uplo( uplo );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -430,6 +429,7 @@ void test_synorm_dev(Norm norm, Uplo uplo)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -556,8 +556,7 @@ void test_synorm_offdiag_dev(Norm norm)
     slate::Tile<double> A(m, n, Adata, lda, -1, slate::TileKind::UserOwned);
     setup_data(A);
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -593,6 +592,7 @@ void test_synorm_offdiag_dev(Norm norm)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -802,8 +802,7 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
     setup_data(A);
     A.uplo( uplo );
 
-    int device_idx;
-    blas::get_device(&device_idx);
+    int device_idx = 0;
     const int batch_arrays_index = 0;
     blas::Queue queue(device_idx, batch_arrays_index);
 
@@ -848,6 +847,7 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
                         values.size(),
                         blas::MemcpyKind::DeviceToHost,
                         queue);
+    queue.sync(); // sync before looking at values
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {

--- a/unit_test/unit_test.cc
+++ b/unit_test/unit_test.cc
@@ -142,10 +142,10 @@ void printf_gather(int root, MPI_Comm comm, const std::string& str)
                 // todo: guard against buffer overflow
                 assert(bufsize < int(sizeof(buf)));
                 MPI_Recv(buf, bufsize, MPI_CHAR, rank, 0, comm, &status);
-                printf(buf);
+                printf("%s", buf);
             }
             else {
-                printf(str.c_str());
+                printf("%s", str.c_str());
             }
         }
     }
@@ -174,35 +174,35 @@ void printf_gather(int root, MPI_Comm comm, const char* format, ...)
 /// Catches and reports all exceptions.
 void run_test(test_function* func, const char* name)
 {
-    printf(output_test(name).c_str());
+    printf("%s", output_test(name).c_str());
     fflush(stdout);
     ++g_total;
 
     try {
         // run function
         func();
-        printf(output_pass().c_str());
+        printf("%s", output_pass().c_str());
         ++g_pass;
     }
     catch (SkipException& e) {
-        printf(output_skip(e).c_str());
+        printf("%s", output_skip(e).c_str());
         --g_total;
         ++g_skip;
     }
     catch (AssertError& e) {
-        printf(output_fail(e).c_str());
+        printf("%s", output_fail(e).c_str());
         ++g_fail;
     }
     catch (std::exception& e) {
         AssertError err("unexpected exception: " + std::string(e.what()),
                         __FILE__, __LINE__);
-        printf(output_fail(err).c_str());
+        printf("%s", output_fail(err).c_str());
         ++g_fail;
     }
     catch (...) {
         AssertError err("unexpected exception: (unknown type)",
                         __FILE__, __LINE__);
-        printf(output_fail(err).c_str());
+        printf("%s", output_fail(err).c_str());
         ++g_fail;
     }
 }

--- a/unit_test/unit_test.hh
+++ b/unit_test/unit_test.hh
@@ -190,7 +190,7 @@ std::string output_skip(SkipException& e);
 template <typename scalar_t>
 void run_test(test_tpl_function<scalar_t> func, const char* name)
 {
-    printf( output_test(
+    printf( "%s", output_test(
           std::string( name ) + " - " + type_name<scalar_t>() ).c_str() );
     fflush( stdout );
     ++g_total;
@@ -198,28 +198,28 @@ void run_test(test_tpl_function<scalar_t> func, const char* name)
     try {
         // run function
         func();
-        printf( output_pass().c_str() );
+        printf( "%s", output_pass().c_str() );
         ++g_pass;
     }
     catch (SkipException& e) {
-        printf( output_skip(e).c_str() );
+        printf( "%s", output_skip(e).c_str() );
         --g_total;
         ++g_skip;
     }
     catch (AssertError& e) {
-        printf( output_fail(e).c_str() );
+        printf( "%s", output_fail(e).c_str() );
         ++g_fail;
     }
     catch (std::exception& e) {
         AssertError err( "unexpected exception: " + std::string( e.what() ),
                         __FILE__, __LINE__ );
-        printf( output_fail( err ).c_str() );
+        printf( "%s", output_fail( err ).c_str() );
         ++g_fail;
     }
     catch (...) {
         AssertError err( "unexpected exception: (unknown type)",
                         __FILE__, __LINE__ );
-        printf( output_fail( err ).c_str() );
+        printf( "%s", output_fail( err ).c_str() );
         ++g_fail;
     }
 }

--- a/unit_test/util_matrix.hh
+++ b/unit_test/util_matrix.hh
@@ -192,10 +192,6 @@ void get_2d_cyclic_dimensions(
 {
     using namespace test;  // for globals mpi_rank, etc.
 
-    int mpi_rank;
-    slate_mpi_call(
-        MPI_Comm_rank(mpi_comm, &mpi_rank));
-
     assert(p > 0 && q > 0);
     bool columnwise = true;
     int p_rank = (columnwise ? mpi_rank % p : mpi_rank / q);


### PR DESCRIPTION
Updates SLATE's Makefile to use abs_prefix and to install pkg-config file.
Updates examples to query the pkg-config file instead of guessing the libraries to link with.
Updates examples to work for any number of MPI ranks.
Adds examples as smoke tests in Github CI.