### PR TITLE
Panel QR for he2hb and ge2tb on GPUs

### DIFF
--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -386,10 +386,12 @@ void he2hb(
                         }
                     }
                     int64_t i0 = panel_rank_rows[ 0 ];
+                    int dev_i0k = -1;
+                    if (target == Target::Devices)
+                        dev_i0k = A.tileDevice(i0, k);
 
                     #pragma omp task depend( inout:block[ k ] )
                     {
-                        int dev_i0k = A.tileDevice(i0, k);
                         if (A.tileExists( i0, k, dev_i0k)) {
                             A.tileGetForWriting( i0, k, HostNum, layout_conv );
                             // Save V0 and set upper(V0) to identity, to avoid trmm's.
@@ -560,7 +562,6 @@ void he2hb(
                     // Restore V0.
                     #pragma omp task depend( inout:block[ k ] )
                     {
-                        int dev_i0k = A.tileDevice(i0, k);
                         if (A.tileExists( i0, k, dev_i0k )) {
                             A.tileGetForWriting( i0, k, layout_conv );
                             tile::gecopy( Asave( i0, k ), A( i0, k ) );

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -125,7 +125,7 @@ void he2hb(
         int64_t mlocal = 0;
         int64_t first_panel_seen = -1;
         for (int64_t j = 0; j < A.nt(); ++j) {
-            for (int64_t i = j; i < A.mt(); ++i) {
+            for (int64_t i = j+1; i < A.mt(); ++i) {
                 if (A.tileIsLocal(i, j)) {
                     if (first_panel_seen < 0) {
                         first_panel_seen = j;
@@ -389,7 +389,8 @@ void he2hb(
 
                     #pragma omp task depend( inout:block[ k ] )
                     {
-                        if (A.tileExists( i0, k )) {
+                        int dev_i0k = A.tileDevice(i0, k);
+                        if (A.tileExists( i0, k, dev_i0k)) {
                             A.tileGetForWriting( i0, k, HostNum, layout_conv );
                             // Save V0 and set upper(V0) to identity, to avoid trmm's.
                             Asave.tileInsert( i0, k );
@@ -559,7 +560,8 @@ void he2hb(
                     // Restore V0.
                     #pragma omp task depend( inout:block[ k ] )
                     {
-                        if (A.tileExists( i0, k )) {
+                        int dev_i0k = A.tileDevice(i0, k);
+                        if (A.tileExists( i0, k, dev_i0k )) {
                             A.tileGetForWriting( i0, k, layout_conv );
                             tile::gecopy( Asave( i0, k ), A( i0, k ) );
                             Asave.tileErase( i0, k );

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -107,7 +107,6 @@ void he2hb(
     // Since W( 0, 0 ) is otherwise unused, store TVAVT there.
     W.tileInsert( 0, 0 );
     auto TVAVT = W.sub( 0, 0, 0, 0 );
-    int num_queues = 10;
     int     panel_device = -1;
     std::vector< scalar_t* > dwork_array( num_devices, nullptr );
     size_t  work_size    = 0;
@@ -118,7 +117,7 @@ void he2hb(
     if (target == Target::Devices) {
         A.allocateBatchArrays();
         A.reserveDeviceWorkspace();
-        W.allocateBatchArrays( 0, num_queues );
+        W.allocateBatchArrays( batch_size_default, num_queues );
         W.reserveDeviceWorkspace();
 
         // Find largest panel size and device for copying to

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -243,7 +243,7 @@ void test_heev_work(Params& params, bool run)
         print_matrix( "Z_out", Z, params ); // Relevant when slate::eig_vals takes Z
     }
 
-    if (ref) {
+    if (check || ref) {
         #ifdef SLATE_HAVE_SCALAPACK
             // Run reference routine from ScaLAPACK
 


### PR DESCRIPTION
Do the panel QR on gpus in he2hb and ge2tb. 
The changes in he2hb to compute the geqrf on GPUs is similar to the changes made on geqrf. 
For ge2tb, geqrf is applied twice, on the panel (V) and on its transpose (VT), therefore, computing the workspace is done twice.