### PR TITLE
Print matrix kind

### DIFF
--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -986,6 +986,9 @@ void decode_matrix(
                  "will not generate SPD matrix; use rand instead.%s\n",
                  ansi_red, kind.c_str(), ansi_normal );
     }
+
+    if (params.marked())
+        params.generate_label();
 }
 
 // -----------------------------------------------------------------------------

--- a/test/matrix_params.cc
+++ b/test/matrix_params.cc
@@ -5,9 +5,15 @@
 
 #include "matrix_params.hh"
 
+#include <climits>
+#include <cmath>
+
+using llong = long long;
 using testsweeper::ParamType;
 
 const double inf = std::numeric_limits<double>::infinity();
+
+std::map< std::string, int > matrix_labels;
 
 // -----------------------------------------------------------------------------
 /// Construct MatrixParams
@@ -19,7 +25,10 @@ MatrixParams::MatrixParams():
     cond      ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix condition number" ),
     cond_used ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "actual condition number used" ),
     condD     ("condD",  0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix D condition number" ),
-    seed      ("seed",   0,    ParamType::List, -1,                        -1, std::numeric_limits<int64_t>::max(), "Randomization seed (-1 randomizes the seed for each matrix)")
+    seed      ("seed",   0,    ParamType::List, -1,                        -1, std::numeric_limits<int64_t>::max(), "Randomization seed (-1 randomizes the seed for each matrix)"),
+    label     ("A",      2,    ParamType::Output, 0,                       0,  INT_MAX, "index labeling matrix" ),
+
+    marked_( false )
 {
 }
 
@@ -27,8 +36,52 @@ MatrixParams::MatrixParams():
 /// Marks matrix params as used.
 void MatrixParams::mark()
 {
+    marked_ = true;
+
     kind();
     cond();
     condD();
     seed();
+    label();
+}
+
+//------------------------------------------------------------------------------
+/// Generates a label string for the current matrix type and sets the
+/// label index. If it's a new matrix type, adds it to the global
+/// `matrix_labels` dictionary of labels.
+///
+void MatrixParams::generate_label()
+{
+    char buf[ 80 ];
+    std::string lbl = kind();
+
+    // Add cond.
+    lbl += ", cond ";
+    if (std::isnan( cond_used() )) {
+        lbl += "unknown";
+    }
+    else {
+        snprintf( buf, sizeof(buf), "= %.5g", cond_used() );
+        lbl += buf;
+    }
+    if (! std::isnan( cond() )
+            && (cond() != cond_used() || std::isnan( cond_used() ))) {
+        lbl += " (ignoring --cond)";
+    }
+
+    // Add condD.
+    if (! std::isnan( condD() )) {
+        snprintf( buf, sizeof(buf), ", cond(D) = %.5g", condD() );
+        lbl += buf;
+    }
+    // todo: warn if condD is set but not used. Add condD_used like cond_used.
+
+    // Get label index from matrix_labels, or add to matrix_labels.
+    if (matrix_labels.count( lbl ) == 1) {  // map::contains is c++20
+        label() = matrix_labels[ lbl ];
+    }
+    else {
+        label() = matrix_labels.size() + 1;
+        matrix_labels[ lbl ] = label();
+    }
 }

--- a/test/matrix_params.hh
+++ b/test/matrix_params.hh
@@ -8,6 +8,11 @@
 
 #include "testsweeper.hh"
 
+#include <map>
+#include <string>
+
+extern std::map< std::string, int > matrix_labels;
+
 // =============================================================================
 class MatrixParams
 {
@@ -16,6 +21,13 @@ public:
 
     void mark();
 
+    bool marked() const
+    {
+        return marked_;
+    }
+
+    void generate_label();
+
     int64_t verbose;
 
     // ---- test matrix generation parameters
@@ -23,6 +35,53 @@ public:
     testsweeper::ParamScientific cond, cond_used;
     testsweeper::ParamScientific condD;
     testsweeper::ParamInt seed;
+    testsweeper::ParamInt label;
+    bool marked_;
+
+    //--------------------------------------------------------------------------
+    /// Copies the value of all members (kind, cond, ...) from y.
+    /// This doesn't copy the iterator index, which would create an infinite
+    /// loop in main tester.
+    ///
+    /// @param[in] y
+    ///     MatrixParams to copy.
+    ///
+    MatrixParams& operator = ( MatrixParams const& y )
+    {
+        verbose     = y.verbose;
+        kind()      = y.kind();
+        cond()      = y.cond();
+        cond_used() = y.cond_used();
+        condD()     = y.condD();
+        seed()      = y.seed();
+        return *this;
+    }
 };
+
+//------------------------------------------------------------------------------
+/// @return true if a and b are bitwise the same. True if a and b are
+/// both the same NaN value, unlike (a == b) which is false for NaNs.
+inline bool same( double a, double b )
+{
+    return memcmp( &a, &b, sizeof(double) ) == 0;
+}
+
+//------------------------------------------------------------------------------
+/// @return true if x and y are equal,
+/// i.e., all members (kind, cond, ...) are equal.
+inline bool operator == ( MatrixParams const& x, MatrixParams const& y )
+{
+    return x.kind() == y.kind()
+           && same( x.cond(),      y.cond()      )
+           && same( x.cond_used(), y.cond_used() )
+           && same( x.condD(),     y.condD()     );
+}
+
+//------------------------------------------------------------------------------
+/// @return true if x and y are not equal.
+inline bool operator != ( MatrixParams const& x, MatrixParams const& y )
+{
+    return ! (x == y);
+}
 
 #endif // SLATE_MATRIX_PARAMS_HH

--- a/test/test.hh
+++ b/test/test.hh
@@ -47,11 +47,6 @@ public:
 
     Params();
 
-    // ----- test matrix parameters
-    MatrixParams matrix;
-    MatrixParams matrixB;
-    MatrixParams matrixC;
-
     // Field members are explicitly public.
     // Order here determines output order.
     // ----- test framework parameters
@@ -94,6 +89,12 @@ public:
     testsweeper::ParamEnum< slate::GridOrder >      grid_order;
     testsweeper::ParamEnum< slate::TileReleaseStrategy > tile_release_strategy;
     testsweeper::ParamEnum< slate::Dist >           dev_dist;
+
+    // ----- test matrix parameters
+    MatrixParams matrix;
+    MatrixParams matrixB;
+    MatrixParams matrixC;
+
     testsweeper::ParamEnum< slate::Layout >         layout;
     testsweeper::ParamEnum< lapack::Job >           jobz;   // heev
     testsweeper::ParamEnum< lapack::Job >           jobvl;  // geev

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -315,16 +315,9 @@ void test_gesv_work(Params& params, bool run)
             else if (trans == slate::Op::ConjTrans)
                 opA = conj_transpose( A );
 
-            if (params.routine == "getrs"
-                || params.routine == "getrf")
-            {
-                slate::lu_solve_using_factor(opA, pivots, B, opts);
-                // Using traditional BLAS/LAPACK name
-                // slate::getrs(opA, pivots, B, opts);
-            }
-            else {
-                slate_error("Unknown routine!");
-            }
+            slate::lu_solve_using_factor( opA, pivots, B, opts );
+            // Using traditional BLAS/LAPACK name
+            // slate::getrs(opA, pivots, B, opts);
 
             // compute and save timing/performance
             time2 = barrier_get_wtime(MPI_COMM_WORLD) - time2;


### PR DESCRIPTION
Currently, if multiple matrix types are set, the tester doesn't print any indication of what the matrix is:
```
sh leconte test> ./tester --matrix zero,one,identity --dim 100:300:100 gemm
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   2.89e-16   0.000378         5.290            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     200     200     200   3.1+1.4i   2.7+1.7i   384    1    1   1   4.48e-16    0.00102        15.734            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     300     300     300   3.1+1.4i   2.7+1.7i   384    1    1   1   2.76e-16    0.00243        22.218            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   6.30e-16   0.000111        18.042            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     200     200     200   3.1+1.4i   2.7+1.7i   384    1    1   1   6.70e-16   0.000794        20.154            NA            NA  FAILED  
   d    host    task  auto  col  notrans  notrans     300     300     300   3.1+1.4i   2.7+1.7i   384    1    1   1   7.58e-16    0.00227        23.810            NA            NA  FAILED  
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   2.67e-16   0.000151        13.281            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     200     200     200   3.1+1.4i   2.7+1.7i   384    1    1   1   4.58e-16    0.00102        15.633            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     300     300     300   3.1+1.4i   2.7+1.7i   384    1    1   1   2.33e-16    0.00211        25.547            NA            NA  pass    
2 tests FAILED: gemm
```
This update prints the matrix kind and cond every time one of them changes:
```
pangolin slate/test> ./tester --matrix zero,one,identity --dim 100:300:100 gemm
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
matrix A: zero, cond = inf
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   3.21e-16   8.40e-05        23.809            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     200     200     200   3.1+1.4i   2.7+1.7i   384    1    1   1   2.33e-16   0.000455        35.165            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     300     300     300   3.1+1.4i   2.7+1.7i   384    1    1   1   1.86e-16    0.00137        39.503            NA            NA  pass    
matrix A: one, cond = inf
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   3.15e-15   8.00e-05        25.000            NA            NA  FAILED  
   d    host    task  auto  col  notrans  notrans     200     200     200   3.1+1.4i   2.7+1.7i   384    1    1   1   2.62e-15   0.000421        38.005            NA            NA  FAILED  
   d    host    task  auto  col  notrans  notrans     300     300     300   3.1+1.4i   2.7+1.7i   384    1    1   1   2.83e-15    0.00123        44.010            NA            NA  FAILED  
matrix A: identity, cond = 1
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   2.81e-16   8.10e-05        24.691            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     200     200     200   3.1+1.4i   2.7+1.7i   384    1    1   1   2.19e-16   0.000432        37.037            NA            NA  pass    
   d    host    task  auto  col  notrans  notrans     300     300     300   3.1+1.4i   2.7+1.7i   384    1    1   1   1.85e-16    0.00134        40.329            NA            NA  pass    
3 tests FAILED: gemm
```
This doesn't follow the usual tabular format. However, the matrix kind can be long, up to at least 24 chars, so adding the 3 kinds and 3 conds for gemm would add about 108 chars to table width, which seems too wide. It's already 192 chars wide.

This also warns if the user requests a cond (`--cond 1e2`) but the matrix type doesn't support setting the cond. The types that support cond are `svd, heev, poev, geev[x]`; only `svd` is implemented.
```
pangolin slate/test> ./tester --matrix zero,one,identity,ij,svd --cond 1e2 --dim 100 gemm
SLATE version 2022.07.00, id a4054aec
input: ./tester --matrix zero,one,identity,ij,svd --cond 1e2 --dim 100 gemm
2023-03-04 10:51:36, MPI size 1, OpenMP threads 4
                                                                                                                                                                                             
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
matrix A: zero, cond = inf (ignored requested cond = 100)
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   3.49e-16   8.80e-05        22.727            NA            NA  pass    
matrix A: one, cond = inf (ignored requested cond = 100)
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   2.73e-15   7.70e-05        25.974            NA            NA  FAILED  
matrix A: identity, cond = 1 (ignored requested cond = 100)
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   2.72e-16   8.20e-05        24.390            NA            NA  pass    
matrix A: ij, cond unknown (ignored requested cond = 100)
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   3.61e-16   7.00e-05        28.571            NA            NA  pass    
matrix A: svd, cond = 100
matrix B: rand, cond unknown
matrix C: rand, cond unknown
   d    host    task  auto  col  notrans  notrans     100     100     100   3.1+1.4i   2.7+1.7i   384    1    1   1   3.69e-16   7.70e-05        25.974            NA            NA  pass    
1 tests FAILED: gemm
```