### PR TITLE
GPU-aware MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option( use_mpi "Use MPI, if available" true )
 option( use_openmp "Use OpenMP, if available" true )
 option( c_api "Build C API" false )
 # todo: option( fortran_api "Build Fortran API. Requires C API." false )
+option( gpu_aware_mpi "Whether MPI can transfer from GPU memory" false )
 
 set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
@@ -339,6 +340,10 @@ if (MPI_FOUND)
     message( DEBUG "mpi_cxx_defines = '${mpi_cxx_defines}'" )
     set_target_properties( MPI::MPI_CXX PROPERTIES INTERFACE_COMPILE_OPTIONS
                            "${mpi_cxx_defines}" )
+
+    if (gpu_aware_mpi)
+        target_compile_definitions( slate PUBLIC "-DSLATE_HAVE_GPU_AWARE_MPI" )
+    endif()
 else()
     message( STATUS "No MPI support in SLATE" )
     target_sources(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,19 +56,6 @@ set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
               auto cuda hip none )
 
-set( use_cuda "" CACHE STRING "Use CUDA, if available [deprecated: use gpu_backend]" )
-set( use_hip  "" CACHE STRING "Use HIP, if available [deprecated: use gpu_backend]" )
-
-if (use_cuda)
-    message( DEPRECATION "WARNING: Variable `use_cuda=$(use_cuda)` is deprecated; setting `gpu_backend = cuda`" )
-    set( gpu_backend "cuda" CACHE STRING "" )
-endif()
-
-if (use_hip)
-    message( DEPRECATION "WARNING: Variable `use_hip=$(use_hip)` is deprecated; setting `gpu_backend = hip`" )
-    set( gpu_backend "hip" CACHE STRING "" )
-endif()
-
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
     AND slate_is_project)
@@ -132,8 +119,6 @@ BUILD_SHARED_LIBS      = ${BUILD_SHARED_LIBS}
 build_tests            = ${build_tests}
 color                  = ${color}
 gpu_backend            = ${gpu_backend}
-use_cuda               = ${use_cuda}
-use_hip                = ${use_hip}
 use_mpi                = ${use_mpi}
 use_openmp             = ${use_openmp}
 c_api                  = ${c_api}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,6 +68,7 @@ hipify          ?= hipify-perl
 md5sum          ?= tools/md5sum.pl
 
 gpu_backend     ?= auto
+gpu_aware_mpi   ?= 0
 
 python          ?= python3
 
@@ -196,6 +197,10 @@ else
     FLAGS += -DSLATE_NO_MPI
     libslate_src += src/stubs/mpi_stubs.cc
     fortran_api = 0
+endif
+
+ifeq (${gpu_aware_mpi},1)
+    FLAGS += -DSLATE_HAVE_GPU_AWARE_MPI
 endif
 
 #-------------------------------------------------------------------------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,8 +99,8 @@ for its options, which include:
     blas_threaded
         Whether to search for multi-threaded or sequential BLAS.
         Currently applies to Intel MKL and IBM ESSL. One of:
-        1               multi-threaded BLAS
-        0               sequential BLAS (default in SLATE)
+        1 (yes)         multi-threaded BLAS
+        0 (no)          sequential BLAS (default in SLATE)
 
     blas_fortran
         Fortran interface to use. Currently applies only to Intel MKL.
@@ -127,6 +127,15 @@ for its options, which include:
         cuda            build with CUDA support
         hip             build with HIP/ROCm support
         none            do not build with GPU backend
+
+    gpu_aware_mpi
+        Whether MPI can transfer directly from GPU memory. Often this has
+        additional runtime requirements, such as
+        using `jsrun --smpiargs="-gpu"` on Summit,
+        or setting `export MPICH_GPU_SUPPORT_ENABLED=1` on Frontier;
+        see your platform's documentation.
+        1 (yes)         enable transfers from GPU memory
+        0 (no)          transfer only from CPU memory (default)
 
     color
         Whether to use ANSI colors in output. One of:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -305,9 +305,6 @@ installed versions, it will use those instead of compiling new versions.
 Besides the Environment variables and Options listed above, additional
 options include:
 
-    use_cuda [deprecated; use gpu_backend]
-    use_hip  [deprecated; use gpu_backend]
-
     CMAKE_CUDA_ARCHITECTURES
         CUDA architectures, as semi-colon delimited list of 2-digit numbers.
         Each number can take optional `-real` or `-virtual` suffix.

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2376,11 +2376,12 @@ void BaseMatrix<scalar_t>::tileIbcastToSet(
                                recv_from, send_to);
 
     int device = HostNum;
-    #if defined(SLATE_WITH_GPU_AWARE_MPI)
-    if (target == Target::Devices) {
-        device = tileDevice(i, j);
-    }
+    #if defined( SLATE_HAVE_GPU_AWARE_MPI )
+        if (target == Target::Devices) {
+            device = tileDevice( i, j );
+        }
     #endif
+
     // Receive.
     if (! recv_from.empty()) {
         // read tile

--- a/src/internal/internal_swap.cc
+++ b/src/internal/internal_swap.cc
@@ -597,12 +597,12 @@ void permuteRows(
                             remote_count[r] = remote_index[r] - remote_offsets[r];
                         }
 
-                        #if defined(SLATE_WITH_GPU_AWARE_MPI)
-                        scalar_t* remote_rows = remote_rows_dev;
+                        #if defined( SLATE_HAVE_GPU_AWARE_MPI )
+                            scalar_t* remote_rows = remote_rows_dev;
                         #else
-                        int64_t remote_rows_size = remote_offsets[comm_size]*nb;
-                        std::vector<scalar_t> remote_rows_vect (remote_rows_size);
-                        scalar_t* remote_rows = remote_rows_vect.data();
+                            int64_t remote_rows_size = remote_offsets[comm_size]*nb;
+                            std::vector<scalar_t> remote_rows_vect( remote_rows_size );
+                            scalar_t* remote_rows = remote_rows_vect.data();
                         #endif
 
                         // Gather remote rows to root.
@@ -619,9 +619,10 @@ void permuteRows(
                         }
                         MPI_Waitall(request_count, requests.data(), MPI_STATUSES_IGNORE);
 
-                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
-                        blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
-                                                      remote_rows_size, *compute_queue);
+                        #if ! defined( SLATE_HAVE_GPU_AWARE_MPI )
+                            blas::device_memcpy<scalar_t>(
+                                remote_rows_dev, remote_rows,
+                                remote_rows_size, *compute_queue );
                         #endif
 
                         // Swap rows locally.
@@ -656,9 +657,10 @@ void permuteRows(
                         }
                         compute_queue->sync();
 
-                        #if !defined(SLATE_WITH_GPU_AWARE_MPI)
-                        blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
-                                                      remote_rows_size, *compute_queue);
+                        #if ! defined( SLATE_HAVE_GPU_AWARE_MPI )
+                            blas::device_memcpy<scalar_t>(
+                                remote_rows, remote_rows_dev,
+                                remote_rows_size, *compute_queue );
                         #endif
 
                         // Scatter remote rows.
@@ -714,14 +716,15 @@ void permuteRows(
                             compute_queue->sync();
 
                             // Send rows, then recv updated rows.
-                            #if defined(SLATE_WITH_GPU_AWARE_MPI)
-                            scalar_t* remote_rows = remote_rows_dev;
+                            #if defined( SLATE_HAVE_GPU_AWARE_MPI )
+                                scalar_t* remote_rows = remote_rows_dev;
                             #else
-                            int64_t remote_rows_size = remote_length*nb;
-                            std::vector<scalar_t> remote_rows_vect (remote_rows_size);
-                            scalar_t* remote_rows = remote_rows_vect.data();
-                            blas::device_memcpy<scalar_t>(remote_rows, remote_rows_dev,
-                                                          remote_rows_size, *compute_queue);
+                                int64_t remote_rows_size = remote_length*nb;
+                                std::vector<scalar_t> remote_rows_vect( remote_rows_size );
+                                scalar_t* remote_rows = remote_rows_vect.data();
+                                blas::device_memcpy<scalar_t>(
+                                    remote_rows, remote_rows_dev,
+                                    remote_rows_size, *compute_queue );
                             #endif
 
                             MPI_Send(remote_rows, remote_length, row_type,
@@ -729,9 +732,10 @@ void permuteRows(
                             MPI_Recv(remote_rows, remote_length, row_type,
                                      root_rank, tag, comm, MPI_STATUS_IGNORE);
 
-                            #if !defined(SLATE_WITH_GPU_AWARE_MPI)
-                            blas::device_memcpy<scalar_t>(remote_rows_dev, remote_rows,
-                                                          remote_rows_size, *compute_queue);
+                            #if ! defined( SLATE_HAVE_GPU_AWARE_MPI )
+                                blas::device_memcpy<scalar_t>(
+                                    remote_rows_dev, remote_rows,
+                                    remote_rows_size, *compute_queue );
                             #endif
 
                             // Unpack pivot rows from workspace.


### PR DESCRIPTION
Enable GPU-aware MPI with Makefile or CMake option.
Changed to `SLATE_HAVE_GPU_AWARE_MPI` which is consistent with other SLATE options (`SLATE_HAVE_SCALAPACK`, `SLATE_HAVE_DEVICE`, `BLAS_HAVE_CUBLAS`, `BLAS_HAVE_ROCBLAS`, `BLAS_HAVE_MKL`), which comes from the autoconf convention (`HAVE_CONFIG_H`, etc.).

Also cleaned up old deprecated CMake options (deprecated in 2021-04).