### PR TITLE
make: fix omptarget logic

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -128,9 +128,14 @@ ifneq ($(cuda),1)
 endif
 
 omptarget = 0
-ifneq ($(filter auto onemkl, $(gpu_backend)),)
-    # enable the omptarget offload kernels in SLATE
-    omptarget = 1
+ifneq ($(cuda),1)
+ifneq ($(hip),1)
+    ifeq (${gpu_backend},onemkl)
+        # enable the omptarget offload kernels in SLATE
+        $(info Note: enabling onemkl)
+        omptarget = 1
+    endif
+endif
 endif
 
 # Default LD=ld won't work; use CXX. Can override in make.inc or environment.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1351,6 +1351,11 @@ echo:
 	@echo "hip_hdr       = ${hip_hdr}"
 	@echo "md5_files     = $(md5_files)"
 	@echo
+	@echo "---------- oneMKL options"
+	@echo "omptarget     = '${omptarget}'"
+	@echo "omptarget_src = ${omptarget_src}"
+	@echo "omptarget_hdr = ${omptarget_hdr}"
+	@echo
 	@echo "---------- Fortran compiler"
 	@echo "FC            = $(FC)"
 	@echo "FCFLAGS       = $(FCFLAGS)"


### PR DESCRIPTION
The existing logic enabled omptarget whenever `gpu_target = auto` (the default). Don't enable it if CUDA or HIP was already detected. For `auto`, there needs to be some kind of check, such as checking for nvcc for CUDA or hipcc for ROCm. For now, require `omptarget = onemkl` to enable omptarget.