### PR TITLE
Replace larnv with Philox PRNG in matrix generator

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -646,6 +646,7 @@ endif
 tester_src += \
         test/matrix_generator.cc \
         test/matrix_params.cc \
+        test/random.cc \
         test/test.cc \
         test/test_add.cc \
         test/test_bdsqr.cc \

--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -1176,7 +1176,6 @@ void generate_matrix(
     int64_t m = A.m();
     int64_t nt = A.nt();
     int64_t mt = A.mt();
-    auto start = testsweeper::get_wtime();
     // ----- generate matrix
     switch (type) {
         case TestMatrixType::zero:
@@ -1536,8 +1535,6 @@ void generate_matrix(
             generate_geevx( params, dist, cond, sigma_max, A, Sigma, seed );
             break;
     }
-    auto end = testsweeper::get_wtime();
-    std::cout << A.mpiRank() << ":" << (end - start) << std::endl;
 
     if (! (type == TestMatrixType::rand  ||
            type == TestMatrixType::rands ||

--- a/test/matrix_params.cc
+++ b/test/matrix_params.cc
@@ -19,7 +19,7 @@ MatrixParams::MatrixParams():
     cond      ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix condition number" ),
     cond_used ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "actual condition number used" ),
     condD     ("condD",  0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix D condition number" ),
-    seed      ("seed",   0,    ParamType::List, -1,                        -1, (int64_t(1)<<47)-1, "Randomization seed (-1 randomizes the seed for each matrix)")
+    seed      ("seed",   0,    ParamType::List, -1,                        -1, std::numeric_limits<int64_t>::max, "Randomization seed (-1 randomizes the seed for each matrix)")
 {
 }
 

--- a/test/matrix_params.cc
+++ b/test/matrix_params.cc
@@ -19,7 +19,7 @@ MatrixParams::MatrixParams():
     cond      ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix condition number" ),
     cond_used ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "actual condition number used" ),
     condD     ("condD",  0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix D condition number" ),
-    seed      ("seed",   0,    ParamType::List, -1,                        -1, std::numeric_limits<int64_t>::max, "Randomization seed (-1 randomizes the seed for each matrix)")
+    seed      ("seed",   0,    ParamType::List, -1,                        -1, std::numeric_limits<int64_t>::max(), "Randomization seed (-1 randomizes the seed for each matrix)")
 {
 }
 

--- a/test/random.cc
+++ b/test/random.cc
@@ -1,0 +1,234 @@
+
+#include "random.hh"
+
+#include <array>
+#include <complex>
+#include "blas.hh"
+#include "blas/util.hh"
+
+
+namespace slate {
+namespace random {
+
+// Compute 128-bit product of 64-bit x 64-bit multiplication
+inline std::array<uint64_t, 2> full_mul(uint64_t val1, uint64_t val2)
+{
+    #ifdef __SIZEOF_INT128__
+        // Some compilers (e.g., GCC) support uint128_t
+        // Such compilers can often compile it to 1-2 instructions
+        auto product = __uint128_t(val1) * __uint128_t(val2);
+        uint64_t product_lo = product;
+        uint64_t product_hi = product >> 64;
+    #else
+        // Slower, portable implementation
+        constexpr uint64_t mask_32 = (uint64_t(1)<<32)-1;
+        uint64_t hi1 = (val1>>32) & mask_32;
+        uint64_t lo1 = (val1    ) & mask_32;
+        uint64_t hi2 = (val2>>32) & mask_32;
+        uint64_t lo2 = (val2    ) & mask_32;
+
+        uint64_t product_mi = hi1*lo2 + lo1*hi2;
+
+        uint64_t product_hi = hi1*hi2 + (product_mi >> 32);
+        uint64_t product_lo = val1*val2;
+    #endif
+    return {product_lo, product_hi};
+}
+
+// Based on Salmon et al. "Parallel Random Numbers: As Easy as 1, 2, 3", 2011
+template<typename T>
+std::array<T, 2> philox_sbox(std::array<T, 2>& state, T multiplier, T seed)
+{
+    T L = state[0];
+    T R = state[1];
+
+    auto product = full_mul(R, multiplier);
+
+    return {product[0], product[1]^seed^L};
+}
+inline std::array<uint64_t, 2> philox_2x64(std::array<uint64_t, 2> state, uint64_t seed)
+{
+    // Constants chosen emperically in the Salmon paper
+    constexpr uint64_t seed_inc = UINT64_C(0xD2B74407B1CE6E93);
+    constexpr uint64_t multiplier = UINT64_C(0x9E3779B97F4A7C15);
+    constexpr int rounds = 10;
+
+    for (int i = 0; i < rounds; ++i) {
+        if (i != 0) {
+            // bump seed
+            seed += seed_inc;
+        }
+        state = philox_sbox( state, multiplier, seed );
+    }
+    return state;
+}
+
+
+// Helper function to make real number in [0, 1) from psuedorandom bits
+template<typename real_t>
+real_t rand_to_real(uint64_t bits)
+{
+    static_assert(std::numeric_limits<real_t>::is_iec559, "Assumes IEEE floats");
+
+    constexpr int digits = std::numeric_limits<real_t>::digits;
+
+    return real_t(bits>>(64-digits)) / real_t(UINT64_C(1)<<digits);
+}
+
+template<typename scalar_t, Dist dist>
+scalar_t generate_float(int64_t seed, int64_t i, int64_t j)
+{
+    using real_t = blas::real_type<scalar_t>;
+
+    // C++20 has std::numbers::pi_v<real_t>
+    constexpr real_t pi = 3.1415926535897932385;
+
+    const auto bits = philox_2x64( {uint64_t(i), uint64_t(j)}, seed );
+    // generate two floats in the range [0, 1)
+    const auto raw_float1 = rand_to_real<real_t>(bits[0]);
+    const auto raw_float2 = rand_to_real<real_t>(bits[1]);
+
+    // unlike larnv, uniform generation is [0, 1)
+    // This is a) easier b) more common in other libraries (e.g., C++, Java, Numpy)
+
+    // Compiler won't compute imaginary part in the real case
+    real_t re = 0, im = 0;
+    switch (dist) {
+        // first 5 are _larnv distributions
+        case Dist::Uniform:
+            re = raw_float1;
+            im = raw_float2;
+            break;
+        case Dist::UniformSigned:
+            re = 2*raw_float1-1;
+            im = 2*raw_float2-1;
+            break;
+        case Dist::Normal:{
+            // Box-Muller, per LAPACK
+            // 1-raw_float1 switches from [0, 1) to (0, 1] to prevent log(0)
+            real_t mag = std::sqrt(-2*std::log(1-raw_float1));
+            real_t arg = 2 * pi * raw_float2;
+            re = mag * std::cos(arg);
+            im = mag * std::sin(arg);
+            break;
+        }
+        case Dist::UnitDisk:{
+            // per LAPACK
+            real_t mag = std::sqrt(raw_float1);
+            real_t arg = 2 * pi * raw_float2;
+            re = mag * std::cos(arg);
+            im = mag * std::sin(arg);
+            break;
+        }
+        case Dist::UnitCircle:{
+            // per LAPACK
+            real_t arg = 2 * pi * raw_float2;
+            re = std::cos(arg);
+            im = std::sin(arg);
+            break;
+        }
+        // Binary and Radamacher distributions
+        case Dist::Binary:
+            re = raw_float1 >= 0.5 ? 1.0 : 0.0;
+            im = raw_float2 >= 0.5 ? 1.0 : 0.0;
+            break;
+        case Dist::BinarySigned:
+            re = raw_float1 >= 0.5 ? 1.0 : -1.0;
+            im = raw_float2 >= 0.5 ? 1.0 : -1.0;
+            break;
+        // default to nothing
+        default:
+            break;
+    }
+
+    return blas::make_scalar<scalar_t>(re, im);
+}
+
+template<Dist dist, typename scalar_t>
+void generate_helper(int64_t seed,
+                          int64_t m, int64_t n, int64_t ioffset, int64_t joffset,
+                          scalar_t* A, int64_t lda)
+{
+    for (int64_t j = 0; j < n; ++j) {
+        for (int64_t i = 0; i < m; ++i) {
+            A[i + j*lda] = generate_float<scalar_t, dist>( seed, i+ioffset, j+joffset );
+        }
+    }
+}
+
+template<typename scalar_t>
+void generate(Dist dist, int64_t seed,
+              int64_t m, int64_t n, int64_t ioffset, int64_t joffset,
+              scalar_t* A, int64_t lda)
+{
+    // dispatch on dist, to avoid large switch within inner loop
+    if (dist == Dist::Uniform) {
+        generate_helper<Dist::Uniform>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else if (dist == Dist::UniformSigned) {
+        generate_helper<Dist::UniformSigned>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else if (dist == Dist::Normal) {
+        generate_helper<Dist::Normal>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else if (dist == Dist::UnitDisk) {
+        generate_helper<Dist::UnitDisk>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else if (dist == Dist::UnitCircle) {
+        generate_helper<Dist::UnitCircle>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else if (dist == Dist::Binary) {
+        generate_helper<Dist::Binary>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else if (dist == Dist::BinarySigned) {
+        generate_helper<Dist::BinarySigned>( seed, m, n, ioffset, joffset, A, lda );
+    }
+    else {
+        throw std::invalid_argument( "Unknown distribution" );
+    }
+}
+
+
+template
+void generate(
+    Dist dist,
+    int64_t seed,
+    int64_t m,
+    int64_t n,
+    int64_t ioffset,
+    int64_t joffset,
+    float* A,
+    int64_t lda);
+template
+void generate(
+    Dist dist,
+    int64_t seed,
+    int64_t m,
+    int64_t n,
+    int64_t ioffset,
+    int64_t joffset,
+    double* A,
+    int64_t lda);
+template
+void generate(
+    Dist dist,
+    int64_t seed,
+    int64_t m,
+    int64_t n,
+    int64_t ioffset,
+    int64_t joffset,
+    std::complex<float>* A,
+    int64_t lda);
+template
+void generate(
+    Dist dist,
+    int64_t seed,
+    int64_t m,
+    int64_t n,
+    int64_t ioffset,
+    int64_t joffset,
+    std::complex<double>* A,
+    int64_t lda);
+
+} // namespace random
+} // namespace slate

--- a/test/random.hh
+++ b/test/random.hh
@@ -7,7 +7,7 @@
 namespace slate {
 namespace random {
 
-enum Dist {
+enum class Dist {
     Uniform=1,
     UniformSigned,
     Normal,

--- a/test/random.hh
+++ b/test/random.hh
@@ -1,0 +1,28 @@
+
+#ifndef SLATE_RANDOM_HH
+#define SLATE_RANDOM_HH
+
+#include <cstdint>
+
+namespace slate {
+namespace random {
+
+enum Dist {
+    Uniform=1,
+    UniformSigned,
+    Normal,
+    UnitDisk,
+    UnitCircle,
+    Binary,
+    BinarySigned
+};
+
+template<class scalar_t>
+void generate(Dist dist, int64_t key,
+                   int64_t m, int64_t n, int64_t ioffset, int64_t joffset,
+                   scalar_t* A, int64_t lda);
+
+} // namespace random
+} // namespace slate
+
+#endif // SLATE_RANDOM_HH


### PR DESCRIPTION
Here's the Philox PRNG code that we discussed.

Philox paper: https://dl.acm.org/doi/pdf/10.1145/2063384.2063405

There's one piece of non-standardized C++ in the 64-bit x 64-bit integer multiplication.  But, it's only used when `__SIZEOF_INT128__` is defined, which implies that there are 128-bit integers available.  Everything I tried on [godbolt](https://gcc.godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIAMz%2BpK4AMngMmAByPgBGmMQSGqQADqgKhE4MHt6%2BAUGp6Y4CYRHRLHEJXEl2mA6ZQgRMxATZPn6Btpj2RQwNTQQlUbHxibaNza25HQrjA%2BFD5SNVAJS2qF7EyOwc5v7hyN5YANQm/m7IM/iCp9gmGgCCu/uHmCdnTcRMAJ43d48PlxAIA%2B31Obi84QIADZJAB9AikI5mG5HKheWi0WEsdEQCGCGHwo4ANzEXEReOhcIIxLEZmWfxMAHYrA8jmyTmY9lQsFQjrDYUIAJIALWwAHkAGKwwWRAAqXDMAA5%2BX92WqjgB6DVHISoNhHNAsZJ0eIKI4QTAAOmAlsRAHE3G5lkcFF5kqlmkcKQrlQRVeq2VqdV5kAgDXrjfRiGbRAwjqgqARGOGjSajoQjkQjlwALRmdMMGbEEM9BT%2BgNMLxZ5LEDAlt4AET5sO9SvhEBJtC4zoAVM3W76O7T6f4WfcA2yKQTqTW6w5YbRUI2jrP0CXTmOJ17IdOV7W1/OEHhl6v679/NgjjCN%2BWOf4ukpb2qg0JFwB3eKIj2NGL0dNG%2Bg2EEJgeifdk0ELJNVBrbd8SpI4WCYBQAGtYX8fNTibXEdypCBuzBMF0OWHMuBvVkJyneCjy4Zchy7c9sCIjkoQQpDUPQsjxwonDCUXGjMPNTsaPZZ1zBYxCULQ5FRzAyceOpI8MP8LDO2k24LyYsTWMkjiZPIgNKN41AlJU2k1VEsxxLYqTONk2DKUJU95xYY8BOontFwwywjj4ntFNs/T1UMmd9xLWEj2XdzFI5CxzScggsVci8USIzit2Cvc5wSxdlyEntVLS9ldlcPAqFvYhMAIDY4yZCx4oXVAv1Cw88CZBtbMZBsOFWWhOAAVl4PwOC0UhUE4NxrGsF11k2V5dh4UgCE0brVmQkA%2BqSXqOEkQbltGzheAUEAkiW4butIOBYCQQ1I0/CgIBuk0EmABUzFILAiTwLYADU8EwN8xWSRhOAWmhaCTaNKBiPaYnCJovhB3hYeYYgvjFGJtFqU6FsNICCDFBhaARs73swRCjHEEn8AquoiUwI6ScwVRairbYFshLpEf0PAYk%2BVGPCwPaCGIPAWER1YqAMYAFF%2B/7AeB7heH4QQRDEdgpBkQRFBUdQSd0MkDCMFBJssbmYiOyBVlQZJS04HMxX8Q6uixzIXAYdxPDaPRQnmMoKj0AoMgESY/DJQOekGP2lk6bp6lmEO9BqOoBD6ZpI%2BGSoxn6BOyRmfp08WSpVgUGatgkHr%2Bt2kmxo4I5VEVKEcxhI5gGQZBszMS18wgXBCBIO9u14U6tGWVb1s2zgdtIIaRprw7jsW5bR/0TgzCr2eDsXs7l7p6NXckIA%3D%3D%3D) used either appropriate assembly instructions or the portable branch.
Doing it this way, GCC, Clang, and ICC can compile it to a single instruction (`mulq`) instead of the ~9 instructions for the portable version.  