### PR TITLE
Fix tzcopy on device

### DIFF
--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -298,8 +298,12 @@ void copy(internal::TargetType<Target::Devices>,
                             B_diag_tiles.insert( { i, j } );
                         }
                         else {
+                            int tile_device =
+                              (A.tileExists( i, j, device ) ? device : HostNum );
+
                             // no need to convert layout
-                            B.tileAcquire(  i, j, device, A(i, j).layout() );
+                            B.tileAcquire(
+                                i, j, device, A( i, j, tile_device ).layout() );
                             B.tileModified( i, j, device, true );
                         }
                     }

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -144,6 +144,10 @@ void test_copy_work(Params& params, bool run)
         if (trace) slate::trace::Trace::on();
         else slate::trace::Trace::off();
 
+        // Force the matrix to reside based on its origin.
+        A.eraseLocalWorkspace();
+        B.eraseLocalWorkspace();
+
         //==================================================
         // Run SLATE test.
         // Copy A to B.


### PR DESCRIPTION
** Problem

When the matrices `A` and `B` have `origin=device` and no copy on the host, the call to `copy` at least in the case of `Hermitian` matrices fails because of a call to `A( i, j ).layout()`.
Also, the problem does not occur in the tester, since the call to generate the matrix moves the matrix onto the host.

** Solution
When we remote the local workspace in the tester and call `hecopy`, commit id 7c0b436cfdb449b37ea0bfdf7f10317c17f52815, we have:
``` bash
OMP_NUM_THREADS=1 mpirun -n 1 ./gpu_bind.sh 0 ./test/tester --origin d --target d --ref n --nb 8 --type d --dim 10 --verbose 0 hecopy                                                                             
SLATE version 2022.07.00, id 7c0b436c                                                                                                                                                                              
input: ./test/tester --origin d --target d --ref n --nb 8 --type d --dim 10 --verbose 0 hecopy
2023-03-28 17:09:08, MPI size 1, OpenMP threads 1, GPU devices available 1
                                                                                                   
type  origin  target    uplo       m    nb    p    q      error   time (s)  ref time (s)  status  
terminate called after throwing an instance of 'slate::FalseConditionException'
  what():  SLATE ERROR: Error check 'tile_node->existsOn(device)' failed in at at ./include/slate/internal/MatrixStorage.hh:399
./gpu_bind.sh: line 30: 26561 Aborted                 (core dumped) $@
```
Therefore, we fix the issue inside `tzcopy` on device.