### PR TITLE
Fix example 08

### DIFF
--- a/examples/ex08_linear_system_indefinite.cc
+++ b/examples/ex08_linear_system_indefinite.cc
@@ -21,6 +21,7 @@ void test_hesv()
         A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::Matrix<double> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
+    B.insertLocalTiles();
     random_matrix( A );
     random_matrix( B );
 
@@ -49,6 +50,7 @@ void test_hetrf()
         A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::Matrix<double> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
+    B.insertLocalTiles();
     random_matrix( A );
     random_matrix( B );
 


### PR DESCRIPTION
## Warning
This is based on the PR `Fix compilation issues related to blas deprecated routines`
Otherwise the checking fails.
So it is easier to review if the above mentioned PR is merged first.

### Problem
When running the example 08, we get the error:
``` bash
mpirun -n 1 ./ex08_linear_system_indefinite                                                                                                                                                                                                                                              
                                                                                                                                                
mpi_size 1, grid_p 1, grid_q 1                                                                                                               
rank 0: void test_hesv()                                                                                                                     
terminate called after throwing an instance of 'std::out_of_range'                                                                           
  what():  map::at                                                                                                                           
                                                                                                                                                                                                                                                                                          
===================================================================================                                                          
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES                                                                                     
=   RANK 0 PID 73739 RUNNING AT leconte.icl.utk.edu                                                                                          
=   KILLED BY SIGNAL: 6 (Aborted)                                                                                                                                                                                                                                                         
=================================================================================== 
```

### Solution

There are missing call to `insertLocalTiles` causing this execution error.


