### PR TITLE
Add gmres IR -- From Neil work

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -585,6 +585,7 @@ ifneq ($(only_unit),1)
         src/pbtrs.cc \
         src/posv.cc \
         src/posvMixed.cc \
+        src/posv_mixed_gmres.cc \
         src/potrf.cc \
         src/potri.cc \
         src/potrs.cc \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -555,6 +555,7 @@ ifneq ($(only_unit),1)
         src/geqrf.cc \
         src/gesv.cc \
         src/gesvMixed.cc \
+        src/gesv_mixed_gmres.cc \
         src/gesv_nopiv.cc \
         src/gesvd.cc \
         src/getrf.cc \

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -499,6 +499,25 @@ void gesvMixed(
     int& iter,
     Options const& opts = Options());
 
+
+//-----------------------------------------
+// gesv_mixed_gmres()
+template <typename scalar_t>
+void gesv_mixed_gmres(
+    Matrix<scalar_t>& A, Pivots& pivots,
+    Matrix<scalar_t>& B,
+    Matrix<scalar_t>& X,
+    int& iter,
+    Options const& opts = Options());
+
+template <typename scalar_hi, typename scalar_lo>
+void gesv_mixed_gmres(
+    Matrix<scalar_hi>& A, Pivots& pivots,
+    Matrix<scalar_hi>& B,
+    Matrix<scalar_hi>& X,
+    int& iter,
+    Options const& opts = Options());
+
 //-----------------------------------------
 // gbtrf()
 template <typename scalar_t>

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -639,6 +639,26 @@ void posvMixed(
 // todo: forward real-symmetric matrices to posvMixed?
 
 //-----------------------------------------
+// posv_mixed_gmres()
+template <typename scalar_t>
+void posv_mixed_gmres(
+    HermitianMatrix<scalar_t>& A,
+             Matrix<scalar_t>& B,
+             Matrix<scalar_t>& X,
+    int& iter,
+    Options const& opts = Options());
+
+template <typename scalar_hi, typename scalar_lo>
+void posv_mixed_gmres(
+    HermitianMatrix<scalar_hi>& A,
+             Matrix<scalar_hi>& B,
+             Matrix<scalar_hi>& X,
+    int& iter,
+    Options const& opts = Options());
+
+// todo: forward real-symmetric matrices to posv_mixed_gmres?
+
+//-----------------------------------------
 // pbtrf()
 template <typename scalar_t>
 void pbtrf(

--- a/src/gesvMixed.cc
+++ b/src/gesvMixed.cc
@@ -35,14 +35,14 @@ namespace slate {
 ///
 /// The iterative refinement process is stopped if iter > itermax or
 /// for all the RHS, $1 \le j \le nrhs$, we have:
-///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon,$
+///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon_{\mathrm{hi}},$
 /// where:
 /// - iter is the number of the current iteration in the iterative refinement
 ///    process
 /// - $\norm{r_j}_{inf}$ is the infinity-norm of the residual, $r_j = Ax_j - b_j$
 /// - $\norm{x_j}_{inf}$ is the infinity-norm of the solution
 /// - $\norm{A}_{inf}$ is the infinity-operator-norm of the matrix $A$
-/// - $\epsilon$ is the machine epsilon.
+/// - $\epsilon_{\mathrm{hi}}$ is the machine epsilon of double precision.
 ///
 /// The value itermax is fixed to 30.
 ///

--- a/src/gesvMixed.cc
+++ b/src/gesvMixed.cc
@@ -8,27 +8,9 @@
 #include "slate/Matrix.hh"
 #include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
+#include "internal/internal_util.hh"
 
 namespace slate {
-
-template <typename scalar_t>
-bool iterRefConverged(std::vector<scalar_t>& colnorms_R,
-                      std::vector<scalar_t>& colnorms_X,
-                      scalar_t cte)
-{
-    assert(colnorms_X.size() == colnorms_R.size());
-    bool value = true;
-    int64_t size = colnorms_X.size();
-
-    for (int64_t i = 0; i < size; ++i) {
-        if (colnorms_R[i] > colnorms_X[i] * cte) {
-            value = false;
-            break;
-        }
-    }
-
-    return value;
-}
 
 //------------------------------------------------------------------------------
 /// Distributed parallel iterative-refinement LU factorization and solve.
@@ -205,7 +187,7 @@ void gesvMixed( Matrix<scalar_hi>& A, Pivots& pivots,
     colNorms( Norm::Max, X, colnorms_X.data(), opts );
     colNorms( Norm::Max, R, colnorms_R.data(), opts );
 
-    if (iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte )) {
+    if (internal::iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte )) {
         iter = 0;
         converged = true;
     }
@@ -236,7 +218,7 @@ void gesvMixed( Matrix<scalar_hi>& A, Pivots& pivots,
         colNorms( Norm::Max, X, colnorms_X.data(), opts );
         colNorms( Norm::Max, R, colnorms_R.data(), opts );
 
-        if (iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte )) {
+        if (internal::iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte )) {
             iter = iiter+1;
             converged = true;
         }

--- a/src/gesv_mixed_gmres.cc
+++ b/src/gesv_mixed_gmres.cc
@@ -1,0 +1,584 @@
+// Copyright (c) 2017-2020, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/slate.hh"
+#include "auxiliary/Debug.hh"
+#include "slate/Matrix.hh"
+#include "slate/Tile_blas.hh"
+#include "internal/internal.hh"
+
+
+namespace slate {
+
+// specialization namespace differentiates, e.g.,
+// internal::gesv_mixed from internal::specialization::gesv_mixed
+namespace internal {
+namespace specialization {
+
+template <typename scalar_t>
+static bool iterRefConverged(std::vector<scalar_t>& colnorms_R,
+                      std::vector<scalar_t>& colnorms_X,
+                      scalar_t cte)
+{
+    assert(colnorms_X.size() == colnorms_R.size());
+    bool value = true;
+    int64_t size = colnorms_X.size();
+
+    for (int64_t i = 0; i < size; i++) {
+        if (colnorms_R[i] > colnorms_X[i] * cte) {
+            value = false;
+            break;
+        }
+    }
+
+    return value;
+}
+
+template<typename scalar_t>
+slate::Matrix<scalar_t> alloc_V(slate::Matrix<scalar_t> A, int64_t n)
+{
+    typedef typename Matrix<scalar_t>::ij_tuple ij_tuple;
+
+    const int64_t m = A.m();
+    const int64_t mt = A.mt();
+    const int64_t nt = A.nt();
+    const MPI_Comm mpi_comm = A.mpiComm();
+
+    std::vector<int64_t> tileMb(mt);
+    for (int64_t i = 0; i < mt; ++i) {
+        tileMb[i] = A.tileMb(i);
+    }
+    std::function<int64_t(int64_t)> tileMb_lambda = [tileMb] (int64_t i) {
+        return tileMb[i];
+    };
+
+    std::vector<int64_t> tileNb(nt);
+    for (int64_t i = 0; i < nt; ++i) {
+        tileNb[i] = A.tileNb(i);
+    }
+    std::function<int64_t(int64_t)> tileNb_lambda = [tileNb] (int64_t i) {
+        return tileNb[i];
+    };
+
+    std::vector<int> tileRank(nt);
+    for (int64_t i = 0; i < mt; ++i) {
+        tileRank[i] = A.tileRank(i, 0);
+    }
+    std::function<int(ij_tuple)> tileRank_lambda = [tileRank] (ij_tuple ij) {
+        return tileRank[std::get<0>(ij)];
+    };
+
+    std::function<int(ij_tuple)> tileDevice_lambda = [] (ij_tuple) {
+        return HostNum;
+    };
+
+
+    Matrix<scalar_t> V(m, n, tileMb_lambda, tileNb_lambda, tileRank_lambda, tileDevice_lambda, mpi_comm);
+    V.insertLocalTiles(Target::Host);
+    return V;
+}
+
+//------------------------------------------------------------------------------
+/// Distributed parallel LU factorization and solve.
+/// Generic implementation for any target.
+/// @ingroup gesv_specialization
+///
+template <Target target, typename scalar_hi, typename scalar_lo>
+void gesv_mixed_gmres( slate::internal::TargetType<target>,
+                     Matrix<scalar_hi>& A, Pivots& pivots,
+                     Matrix<scalar_hi>& B,
+                     Matrix<scalar_hi>& X,
+                     int& iter,
+                     int64_t ib, int max_panel_threads, int64_t lookahead,
+                     int64_t itermax, int64_t depth)
+{
+    // Assumes column major
+    const Layout layout = Layout::ColMajor;
+
+    bool converged = false;
+    using real_hi = blas::real_type<scalar_hi>;
+    const real_hi eps = std::numeric_limits<real_hi>::epsilon();
+    iter = 0;
+    const int64_t restart = std::min(int64_t(30), itermax);
+    const int64_t mpi_rank = A.mpiRank();
+
+    assert(B.mt() == A.mt());
+
+    // Only a single rhs is currently supported; TODO: implement block gmres
+    assert(B.n() == 1);
+
+    // workspace
+    auto R    = B.emptyLike();
+    auto A_lo = A.template emptyLike<scalar_lo>();
+    auto X_lo = X.template emptyLike<scalar_lo>();
+
+    std::vector<real_hi> colnorms_X(X.n());
+    std::vector<real_hi> colnorms_R(R.n());
+
+    auto V = alloc_V(A, itermax+1);
+    auto z = alloc_V(A, 1);
+    // allocate H as a single tile
+    slate::Matrix<scalar_hi> H(itermax+1, itermax+1, itermax+1, 1, 1, A.mpiComm());
+    H.insertLocalTiles(Target::Host);
+    // allocate S as a single tile
+    slate::Matrix<scalar_hi> S(itermax+1, 1, itermax+1, 1, 1, A.mpiComm());
+    S.insertLocalTiles(Target::Host);
+    std::vector<real_hi>   givens_alpha(itermax);
+    std::vector<scalar_hi> givens_beta (itermax);
+
+    // insert local tiles
+    X_lo.insertLocalTiles(target);
+    R.   insertLocalTiles(target);
+    A_lo.insertLocalTiles(target);
+
+    if (target == Target::Devices) {
+        #pragma omp parallel
+        #pragma omp master
+        {
+            #pragma omp task default(shared)
+            {
+                A.tileGetAndHoldAllOnDevices(LayoutConvert(layout));
+            }
+            #pragma omp task default(shared)
+            {
+                B.tileGetAndHoldAllOnDevices(LayoutConvert(layout));
+            }
+            #pragma omp task default(shared)
+            {
+                X.tileGetAndHoldAllOnDevices(LayoutConvert(layout));
+            }
+        }
+    }
+
+    // norm of A
+    real_hi Anorm = norm(Norm::Inf, A,
+                         {{Option::Target, target}});
+
+    // stopping criteria
+    real_hi cte = Anorm * eps * std::sqrt(A.n());
+
+    // Convert B from high to low precision, store result in X_lo.
+    copy(B, X_lo,
+         {{Option::Target, target}});
+
+    //std::cout << "||B|| = " << norm(Norm::Fro, B, {{Option::Target, target}}) << std::endl;
+
+    // Convert A from high to low precision, store result in A_lo.
+    copy(A, A_lo,
+         {{Option::Target, target}});
+
+    // Compute the LU factorization of A_lo.
+    getrf(A_lo,
+          {{Option::InnerBlocking, ib},
+           {Option::Lookahead, lookahead},
+           {Option::Target, target}});
+
+
+    // Solve the system A_lo * X_lo = B_lo.
+    getrs_nopiv(A_lo, X_lo,
+          {{Option::Lookahead, lookahead},
+           {Option::Target, target}});
+
+    // Convert X_lo to high precision.
+    copy(X_lo, X,
+         {{Option::Target, target}});
+    set(scalar_hi(0.0), scalar_hi(0.0), X);
+
+    // Compute R = B - A * X.
+    copy(B, R,
+         {{Option::Target, target}});
+    gemm<scalar_hi>(
+        scalar_hi(-1.0), A,
+                         X,
+        scalar_hi(1.0),  R,
+        {{Option::Lookahead, lookahead},
+         {Option::Target, target}});
+    //std::cout << "||R0|| = " << norm(Norm::Fro, R, {{Option::Target, target}}) << std::endl;
+    //std::cout << "||X0|| = " << norm(Norm::Fro, X, {{Option::Target, target}}) << std::endl;
+
+    // Check whether the nrhs normwise backward error satisfies the
+    // stopping criterion. If yes, set iter=0 and return.
+    colNorms( Norm::Max, X, colnorms_X.data(),
+                {{Option::Target, target}});
+    colNorms( Norm::Max, R, colnorms_R.data(),
+                {{Option::Target, target}});
+
+    {
+        real_hi max_err = colnorms_R[0] / (colnorms_X[0] * cte);
+        real_hi max_x = colnorms_X[0];
+        real_hi max_r = colnorms_R[0];
+        for (int64_t i = 0; i < int64_t(colnorms_R.size()); i++) {
+            max_err = std::max(max_err, colnorms_R[i] / (colnorms_X[i] * cte));
+            max_x = std::max(max_x, colnorms_X[i]);
+            max_r = std::max(max_r, colnorms_R[i]);
+        }
+        if (A.mpiRank() == 0) {
+            //std::cout << "0: max_err = " << max_err << ", max_x = " << max_x << ", max_r = " << max_r << std::endl;
+        }
+    }
+
+    //std::cout << "error: " << (colnorms_R[0]/(colnorms_X[0]*cte)) << std::endl;
+
+    //if (iterRefConverged<real_hi>(colnorms_R, colnorms_X, cte)) {
+    //    iter = 0;
+    //    converged = true;
+    //}
+
+    // IR
+    int iiter = 0;
+    for (; iiter < itermax && ! converged;) {
+        //std::cout << "IR: " << iiter << std::endl;
+        // GMRES
+
+        // Compute initial vector
+        auto v0 = V.slice(0, V.m()-1, 0, 0);
+        copy(R, X_lo,
+             {{Option::Target, target}});
+        getrs(A_lo, X_lo,
+              {{Option::Lookahead, lookahead},
+               {Option::Target, target}});
+        copy(X_lo, v0,
+             {{Option::Target, target}});
+
+        real_hi arnoldi_residual = norm(Norm::Fro, v0, {{Option::Target, target}});
+        //std::cout << "  beta = " << arnoldi_residual << std::endl;
+        if (arnoldi_residual == 0) {
+            // Solver broke down, but residual is not small enough yet.
+            converged = false;
+            break;
+        }
+        scale(1.0, arnoldi_residual, v0, {{Option::Target, target}});
+        if (S.tileRank(0, 0) == mpi_rank) {
+            S.tileGetForWriting(0, 0, LayoutConvert::ColMajor);
+            auto S_00 = S(0, 0);
+            S_00.at(0, 0) = arnoldi_residual;
+            for (int i = 1; i < S_00.mb(); ++i) {
+                S_00.at(i, 0) = 0.0;
+            }
+        }
+
+        real_hi restart_tol = arnoldi_residual*eps*std::sqrt(A.n());
+
+        int j = 0;
+        for (; j < restart && iiter < itermax && arnoldi_residual > restart_tol;
+               j++, iiter++) {
+            auto w = V.slice(0, V.m()-1, j+1, j+1);
+
+            // Compute z = M^-1 vj
+            auto Vj = V.slice(0, V.m()-1, j, j);
+            copy(Vj, X_lo,
+                 {{Option::Target, target}});
+            getrs_nopiv(A_lo, X_lo,
+                  {{Option::Lookahead, lookahead},
+                   {Option::Target, target}});
+            copy(X_lo, z,
+                 {{Option::Target, target}});
+
+            // w = Az
+            gemm<scalar_hi>(
+                scalar_hi(1.0), A,
+                                z,
+                scalar_hi(0.0), w,
+                {{Option::Lookahead, lookahead},
+                 {Option::Target, target}});
+
+            // orthogonalize w/ CGS2
+            auto V0j = V.slice(0, V.m()-1, 0, j);
+            auto V0jT = conjTranspose(V0j);
+            auto Hj = H.slice(0, j, j, j);
+            gemm<scalar_hi>(
+                scalar_hi(1.0), V0jT,
+                                w,
+                scalar_hi(0.0), Hj,
+                {{Option::Lookahead, lookahead},
+                 {Option::Target, target}});
+            gemm<scalar_hi>(
+                scalar_hi(-1.0), V0j,
+                                 Hj,
+                scalar_hi(1.0),  w,
+                {{Option::Lookahead, lookahead},
+                 {Option::Target, target}});
+            auto zj = z.slice(0, j, 0, 0);
+            gemm<scalar_hi>(
+                scalar_hi(1.0), V0jT,
+                                w,
+                scalar_hi(0.0), zj,
+                {{Option::Lookahead, lookahead},
+                 {Option::Target, target}});
+            gemm<scalar_hi>(
+                scalar_hi(-1.0), V0j,
+                                 zj,
+                scalar_hi(1.0),  w,
+                {{Option::Lookahead, lookahead},
+                 {Option::Target, target}});
+            add(scalar_hi(1.0), zj, scalar_hi(1.0), Hj,
+                {{Option::Lookahead, lookahead},
+                 {Option::Target, target}});
+            auto w_norm = norm(Norm::Fro, w, {{Option::Target, target}});
+            scale(1.0, w_norm, w, {{Option::Target, target}});
+            if (H.tileRank(0, 0) == mpi_rank) {
+                H.tileGetForWriting(0, 0, LayoutConvert::ColMajor);
+                auto H_00 = H(0, 0);
+                H_00.at(j+1, j) = w_norm;
+
+                // apply givens rotations
+                for (int64_t i = 0; i < j; ++i) {
+                    blas::rot(1, &H_00.at(i, j), 1, &H_00.at(i+1, j), 1,
+                              givens_alpha[i], givens_beta[i]);
+                }
+                scalar_hi H_jj = H_00.at(j, j), H_j1j = H_00.at(j+1, j);
+                blas::rotg(&H_jj, & H_j1j, &givens_alpha[j], &givens_beta[j]);
+                blas::rot(1, &H_00.at(j, j), 1, &H_00.at(j+1, j), 1,
+                          givens_alpha[j], givens_beta[j]);
+                auto S_00 = S(0, 0);
+                blas::rot(1, &S_00.at(j, 0), 1, &S_00.at(j+1, 0), 1,
+                          givens_alpha[j], givens_beta[j]);
+                arnoldi_residual = cabs1(S_00.at(j+1, 0));
+            }
+            MPI_Bcast(&arnoldi_residual, 1, mpi_type<scalar_hi>::value,
+                      S.tileRank(0, 0), A.mpiComm());
+        }
+        // update X
+        auto H_j = H.slice(0, j-1, 0, j-1);
+        auto S_j = S.slice(0, j-1, 0, 0);
+        auto H_tri = TriangularMatrix<scalar_hi>(Uplo::Upper, Diag::NonUnit, H_j);
+        trsm(Side::Left, scalar_hi(1.0), H_tri, S_j,
+             {{Option::Lookahead, lookahead},
+              {Option::Target, target}});
+        auto V_j = V.slice(0, V.m()-1, 0, j-1);
+        gemm<scalar_hi>(
+            scalar_hi(1.0), V_j,
+                            S_j,
+            scalar_hi(1.0), X,
+            {{Option::Lookahead, lookahead},
+             {Option::Target, target}});
+
+
+        // Check for convergence
+        copy(B, R,
+             {{Option::Target, target}});
+        gemm<scalar_hi>(
+            scalar_hi(-1.0), A,
+                             X,
+            scalar_hi(1.0),  R,
+            {{Option::Lookahead, lookahead},
+             {Option::Target, Target::HostTask}});
+        colNorms( Norm::Max, X, colnorms_X.data(),
+                    {{Option::Target, target}});
+        colNorms( Norm::Max, R, colnorms_R.data(),
+                    {{Option::Target, target}});
+        //std::cout << "error: " << (colnorms_R[0]/(colnorms_X[0]*cte)) << std::endl;
+        if (iterRefConverged<real_hi>(colnorms_R, colnorms_X, cte)) {
+            iter = iiter+1;
+            converged = true;
+        }
+    }
+
+    if (! converged) {
+        // If we are at this place of the code, this is because we have performed
+        // iter = itermax iterations and never satisfied the stopping criterion,
+        // set up the iter flag accordingly and follow up with double precision
+        // routine.
+        iter = -iiter-1;
+
+        // Compute the LU factorization of A.
+        //getrf(A, pivots,
+        //      {{Option::InnerBlocking, ib},
+        //       {Option::Lookahead, lookahead},
+        //       {Option::MaxPanelThreads, int64_t(max_panel_threads)},
+        //       {Option::Target, target}});
+
+        // Solve the system A * X = B.
+        //copy(B, X,
+        //     {{Option::Target, target}});
+        //getrs(A, pivots, X,
+        //      {{Option::Lookahead, lookahead},
+        //       {Option::Target, target}});
+    }
+
+    if (target == Target::Devices) {
+        // clear instead of release due to previous hold
+        A.clearWorkspace();
+        B.clearWorkspace();
+        X.clearWorkspace();
+    }
+}
+
+} // namespace specialization
+} // namespace internal
+
+//------------------------------------------------------------------------------
+/// Version with target as template parameter.
+/// @ingroup gesv_specialization
+///
+template <Target target, typename scalar_hi, typename scalar_lo>
+void gesv_mixed_gmres( Matrix<scalar_hi>& A, Pivots& pivots,
+                    Matrix<scalar_hi>& B,
+                    Matrix<scalar_hi>& X,
+                    int& iter,
+                    Options const& opts)
+{
+    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
+
+    int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
+
+    int64_t itermax = get_option<int64_t>( opts, Option::MaxIterations, 2);
+
+    int64_t depth = get_option<int64_t>( opts, Option::Depth, 2);
+
+    int64_t max_panel_threads  = std::max(omp_get_max_threads()/2, 1);
+    max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads, max_panel_threads );
+
+    internal::specialization::gesv_mixed_gmres<target, scalar_hi, scalar_lo>(
+                                        internal::TargetType<target>(),
+                                        A, pivots, B, X, iter,
+                                        ib, max_panel_threads, lookahead,
+                                        itermax, depth);
+}
+
+//------------------------------------------------------------------------------
+/// Distributed parallel iterative-refinement LU factorization and solve.
+///
+/// Computes the solution to a system of linear equations
+/// \[
+///     A X = B,
+/// \]
+/// where $A$ is an n-by-n matrix and $X$ and $B$ are n-by-nrhs matrices.
+///
+/// gesvMixed first factorizes the matrix using getrf in low precision (single)
+/// and uses this factorization within an iterative refinement procedure to
+/// produce a solution with high precision (double) normwise backward error
+/// quality (see below). If the approach fails, the method falls back to a
+/// high precision (double) factorization and solve.
+///
+/// The iterative refinement is not going to be a winning strategy if
+/// the ratio of low-precision performance over high-precision performance is
+/// too small. A reasonable strategy should take the number of right-hand
+/// sides and the size of the matrix into account. This might be automated
+/// in the future. Up to now, we always try iterative refinement.
+///
+/// The iterative refinement process is stopped if iter > itermax or
+/// for all the RHS, $1 \le j \le nrhs$, we have:
+///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon,$
+/// where:
+/// - iter is the number of the current iteration in the iterative refinement
+///    process
+/// - $\norm{r_j}_{inf}$ is the infinity-norm of the residual, $r_j = Ax_j - b_j$
+/// - $\norm{x_j}_{inf}$ is the infinity-norm of the solution
+/// - $\norm{A}_{inf}$ is the infinity-operator-norm of the matrix $A$
+/// - $\epsilon$ is the machine epsilon.
+///
+/// The value itermax is fixed to 30.
+///
+//------------------------------------------------------------------------------
+/// @tparam scalar_hi
+///     One of double, std::complex<double>.
+///
+/// @tparam scalar_lo
+///     One of float, std::complex<float>.
+//------------------------------------------------------------------------------
+/// @param[in,out] A
+///     On entry, the n-by-n matrix $A$.
+///     On exit, if iterative refinement has been successfully used
+///     (return value = 0 and iter >= 0, see description below), then $A$ is
+///     unchanged. If high precision (double) factorization has been used
+///     (return value = 0 and iter < 0, see description below), then the
+///     array $A$ contains the factors $L$ and $U$ from the
+///     factorization $A = P L U$.
+///
+/// @param[out] pivots
+///     The pivot indices that define the permutation matrix $P$.
+///
+/// @param[in] B
+///     On entry, the n-by-nrhs right hand side matrix $B$.
+///
+/// @param[out] X
+///     On exit, if return value = 0, the n-by-nrhs solution matrix $X$.
+///
+/// @param[out] iter
+///     The number of the iterations in the iterative refinement
+///     process, needed for the convergence. If failed, it is set
+///     to be -(1+itermax), where itermax is controlled by the opts argument.
+///
+/// @param[in] opts
+///     Additional options, as map of name = value pairs. Possible options:
+///     - Option::Lookahead:
+///       Number of panels to overlap with matrix updates.
+///       lookahead >= 0. Default 1.
+///     - Option::MaxIterations
+///       The iteration limit for refinement. Default 30.
+///     - Option::MaxPanelThreads:
+///       Number of threads to use for panel. Default omp_get_max_threads()/2.
+///     - Option::Target:
+///       Implementation to target. Possible values:
+///       - HostTask:  OpenMP tasks on CPU host [default].
+///       - HostNest:  nested OpenMP parallel for loop on CPU host.
+///       - HostBatch: batched BLAS on CPU host.
+///       - Devices:   batched BLAS on GPU device.
+///
+/// TODO: return value
+/// @retval 0 successful exit
+/// @retval >0 for return value = $i$, the computed $U(i,i)$ is exactly zero.
+///         The factorization has been completed, but the factor U is exactly
+///         singular, so the solution could not be computed.
+///
+/// @ingroup gesv
+///
+template <typename scalar_hi, typename scalar_lo>
+void gesv_mixed_gmres( Matrix<scalar_hi>& A, Pivots& pivots,
+                    Matrix<scalar_hi>& B,
+                    Matrix<scalar_hi>& X,
+                    int& iter,
+                    Options const& opts)
+{
+    Target target = get_option( opts, Option::Target, Target::HostTask );
+
+    switch (target) {
+        case Target::Host:
+        case Target::HostTask:
+            gesv_mixed_gmres<Target::HostTask,  scalar_hi, scalar_lo>(
+                     A, pivots, B, X, iter, opts);
+            break;
+        case Target::HostNest:
+            gesv_mixed_gmres<Target::HostNest,  scalar_hi, scalar_lo>(
+                     A, pivots, B, X, iter, opts);
+            break;
+        case Target::HostBatch:
+            gesv_mixed_gmres<Target::HostBatch, scalar_hi, scalar_lo>(
+                     A, pivots, B, X, iter, opts);
+            break;
+        case Target::Devices:
+            gesv_mixed_gmres<Target::Devices,   scalar_hi, scalar_lo>(
+                     A, pivots, B, X, iter, opts);
+            break;
+    }
+    // todo: return value for errors?
+}
+
+//------------------------------------------------------------------------------
+// Explicit instantiations.
+template <>
+void gesv_mixed_gmres<double>(
+    Matrix<double>& A, Pivots& pivots,
+    Matrix<double>& B,
+    Matrix<double>& X,
+    int& iter,
+    Options const& opts)
+{
+    gesv_mixed_gmres<double, float>(A, pivots, B, X, iter, opts);
+}
+
+template <>
+void gesv_mixed_gmres< std::complex<double> >(
+    Matrix< std::complex<double> >& A, Pivots& pivots,
+    Matrix< std::complex<double> >& B,
+    Matrix< std::complex<double> >& X,
+    int& iter,
+    Options const& opts)
+{
+    gesv_mixed_gmres<std::complex<double>, std::complex<float>>(A, pivots, B, X, iter, opts);
+}
+
+} // namespace slate

--- a/src/gesv_mixed_gmres.cc
+++ b/src/gesv_mixed_gmres.cc
@@ -35,14 +35,14 @@ namespace slate {
 ///
 /// GMRES-IR process is stopped if iter > itermax or for all the RHS,
 /// $1 \le j \le nrhs$, we have:
-///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon,$
+///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon_{\mathrm{hi}},$
 /// where:
 /// - iter is the number of the current iteration in the iterative refinement
 ///    process
 /// - $\norm{r_j}_{inf}$ is the infinity-norm of the residual, $r_j = Ax_j - b_j$
 /// - $\norm{x_j}_{inf}$ is the infinity-norm of the solution
 /// - $\norm{A}_{inf}$ is the infinity-operator-norm of the matrix $A$
-/// - $\epsilon$ is the machine epsilon.
+/// - $\epsilon_{\mathrm{hi}}$ is the machine epsilon of double precision.
 ///
 /// The value itermax is fixed to 30.
 ///

--- a/src/gesv_mixed_gmres.cc
+++ b/src/gesv_mixed_gmres.cc
@@ -272,7 +272,7 @@ void gesv_mixed_gmres(
 
             // orthogonalize w/ CGS2
             auto V0j = V.slice( 0, V.m()-1, 0, j );
-            auto V0jT = conjTranspose( V0j );
+            auto V0jT = conj_transpose( V0j );
             auto Hj = H.slice( 0, j, j, j );
             gemm<scalar_hi>(
                 one,  V0jT,

--- a/src/posvMixed.cc
+++ b/src/posvMixed.cc
@@ -37,14 +37,14 @@ namespace slate {
 ///
 /// The iterative refinement process is stopped if iter > itermax or
 /// for all the RHS, $1 \le j \le nrhs$, we have:
-///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon,$
+///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon_{\mathrm{hi}},$
 /// where:
 /// - iter is the number of the current iteration in the iterative refinement
 ///    process
 /// - $\norm{r_j}_{inf}$ is the infinity-norm of the residual, $r_j = Ax_j - b_j$
 /// - $\norm{x_j}_{inf}$ is the infinity-norm of the solution
 /// - $\norm{A}_{inf}$ is the infinity-operator-norm of the matrix $A$
-/// - $\epsilon$ is the machine epsilon.
+/// - $\epsilon_{\mathrm{hi}}$ is the machine epsilon of double precision.
 ///
 /// The value itermax is fixed to 30.
 ///

--- a/src/posvMixed.cc
+++ b/src/posvMixed.cc
@@ -9,27 +9,9 @@
 #include "slate/HermitianMatrix.hh"
 #include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
+#include "internal/internal_util.hh"
 
 namespace slate {
-
-template <typename scalar_t>
-bool iterRefConverged(std::vector<scalar_t>& colnorms_R,
-                      std::vector<scalar_t>& colnorms_X,
-                      scalar_t cte)
-{
-    assert(colnorms_X.size() == colnorms_R.size());
-    bool value = true;
-    int64_t size = colnorms_X.size();
-
-    for (int64_t i = 0; i < size; ++i) {
-        if (colnorms_R[i] > colnorms_X[i] * cte) {
-            value = false;
-            break;
-        }
-    }
-
-    return value;
-}
 
 //------------------------------------------------------------------------------
 /// Distributed parallel iterative-refinement Cholesky factorization and solve.
@@ -206,7 +188,7 @@ void posvMixed( HermitianMatrix<scalar_hi>& A,
     colNorms( Norm::Max, X, colnorms_X.data(), opts );
     colNorms( Norm::Max, R, colnorms_R.data(), opts );
 
-    if (iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte) ) {
+    if (internal::iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte) ) {
         iter = 0;
         converged = true;
     }
@@ -239,7 +221,7 @@ void posvMixed( HermitianMatrix<scalar_hi>& A,
         colNorms( Norm::Max, X, colnorms_X.data(), opts );
         colNorms( Norm::Max, R, colnorms_R.data(), opts );
 
-        if (iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte )) {
+        if (internal::iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte )) {
             iter = iiter+1;
             converged = true;
         }

--- a/src/posv_mixed_gmres.cc
+++ b/src/posv_mixed_gmres.cc
@@ -264,7 +264,7 @@ void posv_mixed_gmres(
 
             // orthogonalize w/ CGS2
             auto V0j = V.slice(0, V.m()-1, 0, j);
-            auto V0jT = conjTranspose(V0j);
+            auto V0jT = conj_transpose(V0j);
             auto Hj = H.slice(0, j, j, j);
             gemm<scalar_hi>(
                 scalar_hi(1.0), V0jT,

--- a/src/posv_mixed_gmres.cc
+++ b/src/posv_mixed_gmres.cc
@@ -37,14 +37,14 @@ namespace slate {
 ///
 /// GMRES-IR process is stopped if iter > itermax or for all the RHS,
 /// $1 \le j \le nrhs$, we have:
-///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon,$
+///     $\norm{r_j}_{inf} < \sqrt{n} \norm{x_j}_{inf} \norm{A}_{inf} \epsilon_{\mathrm{hi}},$
 /// where:
 /// - iter is the number of the current iteration in the iterative refinement
 ///    process
 /// - $\norm{r_j}_{inf}$ is the infinity-norm of the residual, $r_j = Ax_j - b_j$
 /// - $\norm{x_j}_{inf}$ is the infinity-norm of the solution
 /// - $\norm{A}_{inf}$ is the infinity-operator-norm of the matrix $A$
-/// - $\epsilon$ is the machine epsilon.
+/// - $\epsilon_{\mathrm{hi}}$ is the machine epsilon of double precision.
 ///
 /// The value itermax is fixed to 30.
 ///

--- a/src/posv_mixed_gmres.cc
+++ b/src/posv_mixed_gmres.cc
@@ -151,7 +151,7 @@ void posv_mixed_gmres( HermitianMatrix<scalar_hi>& A,
     const real_hi eps = std::numeric_limits<real_hi>::epsilon();
     iter = 0;
     const int64_t itermax = 30;
-    const int64_t restart = std::min(int64_t(30), itermax);
+    const int64_t restart = std::min(std::min(int64_t(30), itermax), A.tileMb(0)-1);
     const int64_t mpi_rank = A.mpiRank();
 
     assert(B.mt() == A.mt());
@@ -173,23 +173,23 @@ void posv_mixed_gmres( HermitianMatrix<scalar_hi>& A,
     std::vector<real_hi> colnorms_R(R.n());
 
     // test basis.  First column corresponds to the residual
-    auto V = alloc_V(A, itermax+1, target);
+    auto V = alloc_V(A, restart+1, target);
     // solution basis.  Columns correspond to those in V.  First column is unused
-    auto W = alloc_V(A, itermax+1, target);
+    auto W = alloc_V(A, restart+1, target);
 
     // workspace vector for the orthogonalization process
     auto z = X.template emptyLike<scalar_hi>();
     z.insertLocalTiles(target);
 
     // Hessenberg Matrix.  Allocate as a single tile
-    slate::Matrix<scalar_hi> H(itermax+1, itermax+1, itermax+1, 1, 1, A.mpiComm());
+    slate::Matrix<scalar_hi> H(restart+1, restart+1, restart+1, 1, 1, A.mpiComm());
     H.insertLocalTiles(Target::Host);
     // least squares RHS.  Allocate as a single tile
-    slate::Matrix<scalar_hi> S(itermax+1, 1, itermax+1, 1, 1, A.mpiComm());
+    slate::Matrix<scalar_hi> S(restart+1, 1, restart+1, 1, 1, A.mpiComm());
     S.insertLocalTiles(Target::Host);
     // Rotations
-    std::vector<real_hi>   givens_alpha(itermax);
-    std::vector<scalar_hi> givens_beta (itermax);
+    std::vector<real_hi>   givens_alpha(restart);
+    std::vector<scalar_hi> givens_beta (restart);
 
 
     if (target == Target::Devices) {

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -381,7 +381,7 @@ if (opts.lu):
     [ 'getriOOP', gen + dtype + la + n ],
     #[ 'gerfs', gen + dtype + la + n + trans ],
     #[ 'geequ', gen + dtype + la + n ],
-	[ 'gesvMixed',  gen + dtype_double + la + n ],
+    [ 'gesvMixed',  gen + dtype_double + la + n ],
     [ 'gesv_mixed_gmres',  gen + dtype_double + la + n + ' --nrhs 1' ],
     ]
 

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -381,7 +381,8 @@ if (opts.lu):
     [ 'getriOOP', gen + dtype + la + n ],
     #[ 'gerfs', gen + dtype + la + n + trans ],
     #[ 'geequ', gen + dtype + la + n ],
-    [ 'gesvMixed',  gen + dtype_double + la + n ],
+	[ 'gesvMixed',  gen + dtype_double + la + n ],
+    [ 'gesv_mixed_gmres',  gen + dtype_double + la + n + ' --nrhs 1' ],
     ]
 
 # LU banded

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -405,6 +405,7 @@ if (opts.chol):
     #[ 'porfs', gen + dtype + la + n + uplo ],
     #[ 'poequ', gen + dtype + la + n ],  # only diagonal elements (no uplo)
     [ 'posvMixed',  gen + dtype_double + la + n + uplo ],
+    [ 'posv_mixed_gmres',  gen + dtype_double + la + n + uplo + ' --nrhs 1' ],
     [ 'trtri', gen + dtype + la + n + uplo + diag ],
     ]
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -111,6 +111,7 @@ std::vector< testsweeper::routines_t > routines = {
     { "gesv_nopiv",         test_gesv,         Section::gesv },
     { "gesv_tntpiv",        test_gesv,         Section::gesv },
     { "gesvMixed",          test_gesv,         Section::gesv },
+    { "gesv_mixed_gmres",   test_gesv,         Section::gesv },
     { "gbsv",               test_gbsv,         Section::gesv },
     { "",                   nullptr,           Section::newline },
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -139,6 +139,7 @@ std::vector< testsweeper::routines_t > routines = {
     // Cholesky
     { "posv",               test_posv,         Section::posv },
     { "posvMixed",          test_posv,         Section::posv },
+    { "posv_mixed_gmres",   test_posv,         Section::posv },
     { "pbsv",               test_pbsv,         Section::posv },
     { "",                   nullptr,           Section::newline },
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -386,7 +386,7 @@ void test_gesv_work(Params& params, bool run)
 
         real_t tol = params.tol() * 0.5 * std::numeric_limits<real_t>::epsilon();
         params.okay() = (params.error() <= tol);
-        if (params.routine == "gesvMixed")
+        if (params.routine == "gesvMixed" || params.routine == "gesv_mixed_gmres")
             params.okay() = params.okay() && params.iters() >= 0;
     }
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -123,15 +123,6 @@ void test_gesv_work(Params& params, bool run)
         return;
     }
 
-    if (params.routine == "gesvMixed"
-        && target == slate::Target::Devices) {
-        params.msg() = "skipping: unsupported mixed precision; no devices support";
-        return;
-    }
-
-    // TODO For now, we force the use of gemmC and trsmB since
-    // gemmA and trsmA have some issues on device.
-    // When both routines are fixed and merged, we will remove this constraints.
     slate::Options const opts =  {
         {slate::Option::Lookahead, lookahead},
         {slate::Option::Target, target},
@@ -139,8 +130,8 @@ void test_gesv_work(Params& params, bool run)
         {slate::Option::InnerBlocking, ib},
         {slate::Option::PivotThreshold, pivot_threshold},
         {slate::Option::MethodLU, method_lu},
-        {slate::Option::MethodGemm, slate::MethodGemm::GemmC},
-        {slate::Option::MethodTrsm, slate::MethodTrsm::TrsmB},
+        {slate::Option::MethodGemm, methodGemm},
+        {slate::Option::MethodTrsm, methodTrsm},
     };
 
     // Matrix A: figure out local size.

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -257,8 +257,7 @@ void test_gesv_work(Params& params, bool run)
     if (params.routine == "gesv"
         || params.routine == "gesv_nopiv"
         || params.routine == "gesvMixed"
-        || params.routine == "gesv_mixed_gmres"
-        || params.routine == "gesv_rbt")
+        || params.routine == "gesv_mixed_gmres")
         gflop = lapack::Gflop<scalar_t>::gesv(n, nrhs);
     else
         gflop = lapack::Gflop<scalar_t>::getrf(m, n);

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -255,7 +255,6 @@ void test_gesv_work(Params& params, bool run)
 
     double gflop;
     if (params.routine == "gesv"
-        || params.routine == "gesv_nopiv"
         || params.routine == "gesvMixed"
         || params.routine == "gesv_mixed_gmres")
         gflop = lapack::Gflop<scalar_t>::gesv(n, nrhs);

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -100,9 +100,9 @@ void test_posv_work(Params& params, bool run)
         return;
     }
 
-    if (params.routine == "posvMixed"
+    if ((params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
         && target == slate::Target::Devices) {
-        params.msg() = "skipping: unsupported mixed precision; no devices support";
+        params.msg() = "skipping: unsupported devices support";
         return;
     }
 

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -66,7 +66,7 @@ void test_posv_work(Params& params, bool run)
     bool do_potrs = (
         (check && params.routine == "potrf") || params.routine == "potrs");
 
-    if (params.routine == "posvMixed") {
+    if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
         params.iters();
     }
 
@@ -94,7 +94,7 @@ void test_posv_work(Params& params, bool run)
         return;
     }
 
-    if (params.routine == "posvMixed"
+    if ((params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
         && ! std::is_same<real_t, double>::value) {
         params.msg() = "skipping: unsupported mixed precision; must be type=d or z";
         return;
@@ -170,7 +170,7 @@ void test_posv_work(Params& params, bool run)
 
         B.insertLocalTiles(origin_target);
 
-        if (params.routine == "posvMixed") {
+        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
             X_data.resize(lldB*nlocB);
             X = slate::Matrix<scalar_t>(n, nrhs, nb, p, q, MPI_COMM_WORLD);
             X.insertLocalTiles(origin_target);
@@ -184,7 +184,7 @@ void test_posv_work(Params& params, bool run)
                 uplo, n, &A_data[0], lldA, nb, p, q, MPI_COMM_WORLD);
         B = slate::Matrix<scalar_t>::fromScaLAPACK(
                 n, nrhs, &B_data[0], lldB, nb, p, q, MPI_COMM_WORLD);
-        if (params.routine == "posvMixed") {
+        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
             X_data.resize(lldB*nlocB);
             X = slate::Matrix<scalar_t>::fromScaLAPACK(
                     n, nrhs, &X_data[0], lldB, nb, p, q, MPI_COMM_WORLD);
@@ -217,7 +217,9 @@ void test_posv_work(Params& params, bool run)
     }
 
     double gflop;
-    if (params.routine == "posv" || params.routine == "posvMixed")
+    if (params.routine == "posv"
+        || params.routine == "posvMixed"
+        || params.routine == "posv_mixed_gmres")
         gflop = lapack::Gflop<scalar_t>::posv(n, nrhs);
     else
         gflop = lapack::Gflop<scalar_t>::potrf(n);
@@ -249,6 +251,13 @@ void test_posv_work(Params& params, bool run)
             if constexpr (std::is_same<real_t, double>::value) {
                 int iters = 0;
                 slate::posvMixed(A, B, X, iters, opts);
+                params.iters() = iters;
+            }
+        }
+        else if (params.routine == "posv_mixed_gmres") {
+            if constexpr (std::is_same<real_t, double>::value) {
+                int iters = 0;
+                slate::posv_mixed_gmres(A, B, X, iters, opts);
                 params.iters() = iters;
             }
         }
@@ -298,13 +307,13 @@ void test_posv_work(Params& params, bool run)
 
         // Norm of updated-rhs/solution matrix: || X ||_1
         real_t X_norm;
-        if (params.routine == "posvMixed")
+        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
             X_norm = slate::norm(slate::Norm::One, X);
         else
             X_norm = slate::norm(slate::Norm::One, B);
 
         // Bref -= Aref*B
-        if (params.routine == "posvMixed") {
+        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres") {
             slate::multiply(-one, Aref, X, one, Bref);
             // Using traditional BLAS/LAPACK name
             // slate::hemm(slate::Side::Left, -one, Aref, X, one, Bref);
@@ -322,7 +331,7 @@ void test_posv_work(Params& params, bool run)
 
         real_t tol = params.tol() * 0.5 * std::numeric_limits<real_t>::epsilon();
         params.okay() = (params.error() <= tol);
-        if (params.routine == "posvMixed")
+        if (params.routine == "posvMixed" || params.routine == "posv_mixed_gmres")
             params.okay() = params.okay() && params.iters() >= 0;
     }
 


### PR DESCRIPTION
## PR duplication From Bitbucket [PR180](https://bitbucket.org/icl/slate-dev/pull-requests/180) from Neil

Here is Neil's GMRES-IR code for doing mixed-precision LU and Cholesky.

The double-complex version of the code does depend on having blaspp provide zrot functionality. With the current blaspp, the code will compile but will error when run. With [include/blas/rot.hh of blaspp's PR#33](https://bitbucket.org/icl/blaspp/pull-requests/33#chg-include/blas/rot.hh), the code works as expected in double-complex.

One thing I found while doing this is that BaseMatrix::tileMbFunc et al. are a little clunky to use with the function constructor for Matrix. The former gives rvalues while the latter needs lvalues, which forces the alloc_V function as a workaround. Should I add another version of the constructor that doesn't take references? Or remove the references from the existing constructor? The bottom of the call stack is a copy anyways, so making a reference to a temporary variable won't cause problems.

I also have a few comments about the existing mixed-precision routines. I can add fixes to this PR, or they can be left for someone else to deal with.

- gesvMixed and posvMixed use an abandoned naming convention which is made more obvious by adding gesv_mixed_gmres and posv_mixed_gmres
   - Should they be replaced with gesv_mixed and posv_mixed?
   - Leaving the old names as thin wrappers would retain backward compatibility
- The gesvMixed and posvMixed testers disallow target device. Is this still necessary? The tests pass on saturn for target device