### PR TITLE
Release tiles

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3258,7 +3258,7 @@ void BaseMatrix<scalar_t>::tileGetAndHoldAll(int device, LayoutConvert layout)
                 tiles_set.insert({i, j});
             }
 
-    tileGetAndHold(tiles_set, layout, device);
+    tileGetAndHold( tiles_set, device, layout );
 }
 
 //------------------------------------------------------------------------------

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -131,13 +131,13 @@ void gemmA(
                               shared( B, C )
             {
                 auto B_col_0 = B.sub( 0, B.mt()-1, 0, 0 );
-                B_col_0.eraseRemoteWorkspace();
-                B_col_0.eraseLocalWorkspace();
+                B_col_0.releaseRemoteWorkspace();
+                B_col_0.releaseLocalWorkspace();
 
                 auto C_col_0 = C.sub( 0, C.mt()-1, 0, 0 );
-                C_col_0.eraseRemoteWorkspace();
+                C_col_0.releaseRemoteWorkspace();
                 C_col_0.tileUpdateAllOrigin();
-                C_col_0.eraseLocalWorkspace();
+                C_col_0.releaseLocalWorkspace();
             }
         }
 
@@ -195,13 +195,13 @@ void gemmA(
                                   firstprivate( k )
                 {
                     auto B_col_k = B.sub( 0, B.mt()-1, k, k );
-                    B_col_k.eraseRemoteWorkspace();
-                    B_col_k.eraseLocalWorkspace();
+                    B_col_k.releaseRemoteWorkspace();
+                    B_col_k.releaseLocalWorkspace();
 
                     auto C_col_k = C.sub( 0, C.mt()-1, k, k );
-                    C_col_k.eraseRemoteWorkspace();
+                    C_col_k.releaseRemoteWorkspace();
                     C_col_k.tileUpdateAllOrigin();
-                    C_col_k.eraseLocalWorkspace();
+                    C_col_k.releaseLocalWorkspace();
                 }
             }
         }
@@ -210,7 +210,7 @@ void gemmA(
         // TODO add an if statement similar to potrf on device.
         // Reason: this should be called only when needed.
         C.tileUpdateAllOrigin();
-        A.eraseLocalWorkspace();
+        A.releaseLocalWorkspace();
     }
 }
 

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -129,12 +129,12 @@ void gemmC(
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
 
             // Erase remote tiles on all devices including host
-            A_colblock.eraseRemoteWorkspace();
-            B_rowblock.eraseRemoteWorkspace();
+            A_colblock.releaseRemoteWorkspace();
+            B_rowblock.releaseRemoteWorkspace();
 
             // Erase local workspace on devices.
-            A_colblock.eraseLocalWorkspace();
-            B_rowblock.eraseLocalWorkspace();
+            A_colblock.releaseLocalWorkspace();
+            B_rowblock.releaseLocalWorkspace();
         }
 
         for (int64_t k = 1; k < A.nt(); ++k) {
@@ -178,12 +178,12 @@ void gemmC(
                 auto B_rowblock = B.sub(k, k, 0, B.nt()-1);
 
                 // Erase remote tiles on all devices including host
-                A_colblock.eraseRemoteWorkspace();
-                B_rowblock.eraseRemoteWorkspace();
+                A_colblock.releaseRemoteWorkspace();
+                B_rowblock.releaseRemoteWorkspace();
 
                 // Erase local workspace on devices.
-                A_colblock.eraseLocalWorkspace();
-                B_rowblock.eraseLocalWorkspace();
+                A_colblock.releaseLocalWorkspace();
+                B_rowblock.releaseLocalWorkspace();
             }
         }
         #pragma omp taskwait

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -159,9 +159,9 @@ void hemmC(
                     priority_0, opts_local );
 
                 // Erase remote tile on all devices including host
-                A.eraseRemoteWorkspaceTile( 0, 0 );
+                A.releaseRemoteWorkspaceTile( 0, 0 );
                 // Erase local workspace on devices.
-                A.eraseLocalWorkspaceTile( 0, 0 );
+                A.releaseLocalWorkspaceTile( 0, 0 );
 
                 if (A.mt()-1 > 0) {
                     auto Acol_0 = A.sub( 1, A.mt()-1, 0, 0 );
@@ -171,7 +171,7 @@ void hemmC(
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Acol_0.eraseLocalWorkspace();
+                    Acol_0.releaseLocalWorkspace();
 
                     std::set<ij_tuple> tile_set;
                     for (int64_t i = 1; i < A.mt(); ++i) {
@@ -183,11 +183,11 @@ void hemmC(
                             }
                         }
                     }
-                    A.eraseRemoteWorkspace( tile_set );
+                    A.releaseRemoteWorkspace( tile_set );
                 }
 
-                Brow_0.eraseRemoteWorkspace();
-                Brow_0.eraseLocalWorkspace();
+                Brow_0.releaseRemoteWorkspace();
+                Brow_0.releaseLocalWorkspace();
             }
 
             for (int64_t k = 1; k < A.nt(); ++k) {
@@ -241,8 +241,8 @@ void hemmC(
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Arow_k.eraseRemoteWorkspace();
-                    Arow_k.eraseLocalWorkspace();
+                    Arow_k.releaseRemoteWorkspace();
+                    Arow_k.releaseLocalWorkspace();
 
                     internal::hemm<Target::HostTask>(
                         Side::Left,
@@ -251,8 +251,8 @@ void hemmC(
                         one,    C.sub( k, k, 0, C.nt()-1 ),
                         priority_0, opts_local );
 
-                    A.eraseRemoteWorkspaceTile( k, k );
-                    A.eraseLocalWorkspaceTile( k, k );
+                    A.releaseRemoteWorkspaceTile( k, k );
+                    A.releaseLocalWorkspaceTile( k, k );
 
                     if (A.mt()-1 > k) {
                         auto Acol_k = A.sub( k+1, A.mt()-1, k, k );
@@ -262,7 +262,7 @@ void hemmC(
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
                             layout, priority_0, queue_0, opts_local );
 
-                        Acol_k.eraseLocalWorkspace();
+                        Acol_k.releaseLocalWorkspace();
 
                         std::set<ij_tuple> tile_set;
                         for (int64_t i = k+1; i < A.mt(); ++i) {
@@ -274,11 +274,11 @@ void hemmC(
                                 }
                             }
                         }
-                        A.eraseRemoteWorkspace( tile_set );
+                        A.releaseRemoteWorkspace( tile_set );
                     }
 
-                    Brow_k.eraseRemoteWorkspace();
-                    Brow_k.eraseLocalWorkspace();
+                    Brow_k.releaseRemoteWorkspace();
+                    Brow_k.releaseLocalWorkspace();
                 }
             }
         }
@@ -346,8 +346,8 @@ void hemmC(
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
                     priority_0, opts_local );
 
-                A.eraseRemoteWorkspaceTile( 0, 0 );
-                A.eraseLocalWorkspaceTile( 0, 0 );
+                A.releaseRemoteWorkspaceTile( 0, 0 );
+                A.releaseLocalWorkspaceTile( 0, 0 );
 
                 if (A.mt()-1 > 0) {
                     auto Arow_0 = A.sub( 0, 0, 1, A.mt()-1 );
@@ -357,7 +357,7 @@ void hemmC(
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Arow_0.eraseLocalWorkspace();
+                    Arow_0.releaseLocalWorkspace();
 
                     std::set<ij_tuple> tile_set;
                     for (int64_t i = 1; i < A.mt(); ++i) {
@@ -367,11 +367,11 @@ void hemmC(
                             }
                         }
                     }
-                    A.eraseRemoteWorkspace( tile_set );
+                    A.releaseRemoteWorkspace( tile_set );
                 }
 
-                Brow_0.eraseRemoteWorkspace();
-                Brow_0.eraseLocalWorkspace();
+                Brow_0.releaseRemoteWorkspace();
+                Brow_0.releaseLocalWorkspace();
             }
 
             for (int64_t k = 1; k < A.nt(); ++k) {
@@ -425,8 +425,8 @@ void hemmC(
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Acol_k.eraseRemoteWorkspace();
-                    Acol_k.eraseLocalWorkspace();
+                    Acol_k.releaseRemoteWorkspace();
+                    Acol_k.releaseLocalWorkspace();
 
                     internal::hemm<Target::HostTask>(
                         Side::Left,
@@ -435,8 +435,8 @@ void hemmC(
                         one,    C.sub( k, k, 0, C.nt()-1 ),
                         priority_0, opts_local );
 
-                    A.eraseRemoteWorkspaceTile( k, k );
-                    A.eraseLocalWorkspaceTile( k, k );
+                    A.releaseRemoteWorkspaceTile( k, k );
+                    A.releaseLocalWorkspaceTile( k, k );
 
                     if (A.mt()-1 > k) {
                         auto Arow_k = A.sub( k, k, k+1, A.mt()-1 );
@@ -446,7 +446,7 @@ void hemmC(
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
                             layout, priority_0, queue_0, opts_local );
 
-                        Arow_k.eraseLocalWorkspace();
+                        Arow_k.releaseLocalWorkspace();
 
                         std::set<ij_tuple> tile_set;
                         for (int64_t i = k+1; i < A.mt(); ++i) {
@@ -456,11 +456,11 @@ void hemmC(
                                 }
                             }
                         }
-                        A.eraseRemoteWorkspace( tile_set );
+                        A.releaseRemoteWorkspace( tile_set );
                     }
 
-                    Brow_k.eraseRemoteWorkspace();
-                    Brow_k.eraseLocalWorkspace();
+                    Brow_k.releaseRemoteWorkspace();
+                    Brow_k.releaseLocalWorkspace();
                 }
             }
         }

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -125,12 +125,12 @@ void her2k(
                 priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
-            A_col0.eraseRemoteWorkspace();
-            B_col0.eraseRemoteWorkspace();
+            A_col0.releaseRemoteWorkspace();
+            B_col0.releaseRemoteWorkspace();
 
             // Erase local workspace on devices.
-            A_col0.eraseLocalWorkspace();
-            B_col0.eraseLocalWorkspace();
+            A_col0.releaseLocalWorkspace();
+            B_col0.releaseLocalWorkspace();
         }
 
         for (int64_t k = 1; k < A.nt(); ++k) {
@@ -172,12 +172,12 @@ void her2k(
                     priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
-                A_colk.eraseRemoteWorkspace();
-                B_colk.eraseRemoteWorkspace();
+                A_colk.releaseRemoteWorkspace();
+                B_colk.releaseRemoteWorkspace();
 
                 // Erase local workspace on devices.
-                A_colk.eraseLocalWorkspace();
-                B_colk.eraseLocalWorkspace();
+                A_colk.releaseLocalWorkspace();
+                B_colk.releaseLocalWorkspace();
             }
         }
 

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -111,10 +111,10 @@ void herk(
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
             // Erase remote tiles on all devices including host
-            A_colblock.eraseRemoteWorkspace();
+            A_colblock.releaseRemoteWorkspace();
 
             // Erase local workspace on devices.
-            A_colblock.eraseLocalWorkspace();
+            A_colblock.releaseLocalWorkspace();
         }
 
         for (int64_t k = 1; k < A.nt(); ++k) {
@@ -150,10 +150,10 @@ void herk(
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 
                 // Erase remote tiles on all devices including host
-                A_colblock.eraseRemoteWorkspace();
+                A_colblock.releaseRemoteWorkspace();
 
                 // Erase local workspace on devices.
-                A_colblock.eraseLocalWorkspace();
+                A_colblock.releaseLocalWorkspace();
             }
         }
 

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -291,14 +291,14 @@ void potrf(
                 auto panel = A.sub( k, A_nt-1, k, k );
 
                 // Erase remote tiles on all devices including host
-                panel.eraseRemoteWorkspace();
+                panel.releaseRemoteWorkspace();
 
                 // Update the origin tiles before their
                 // workspace copies on devices are erased.
                 panel.tileUpdateAllOrigin();
 
                 // Erase local workspace on devices.
-                panel.eraseLocalWorkspace();
+                panel.releaseLocalWorkspace();
             }
         }
         #pragma omp taskwait

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -153,9 +153,9 @@ void symm(
                     priority_0, opts_local );
 
                 // Erase remote tile on all devices including host
-                A.eraseRemoteWorkspaceTile( 0, 0 );
+                A.releaseRemoteWorkspaceTile( 0, 0 );
                 // Erase local workspace on devices.
-                A.eraseLocalWorkspaceTile( 0, 0 );
+                A.releaseLocalWorkspaceTile( 0, 0 );
 
                 if (A.mt()-1 > 0) {
                     auto Acol_0 = A.sub( 1, A.mt()-1, 0, 0 );
@@ -165,7 +165,7 @@ void symm(
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Acol_0.eraseLocalWorkspace();
+                    Acol_0.releaseLocalWorkspace();
 
                     std::set<ij_tuple> tile_set;
                     for (int64_t i = 0; i < A.mt(); ++i) {
@@ -177,11 +177,11 @@ void symm(
                             }
                         }
                     }
-                    A.eraseRemoteWorkspace( tile_set );
+                    A.releaseRemoteWorkspace( tile_set );
                 }
 
-                Brow_0.eraseRemoteWorkspace();
-                Brow_0.eraseLocalWorkspace();
+                Brow_0.releaseRemoteWorkspace();
+                Brow_0.releaseLocalWorkspace();
             }
 
             for (int64_t k = 1; k < A.nt(); ++k) {
@@ -232,8 +232,8 @@ void symm(
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Arow_k.eraseRemoteWorkspace();
-                    Arow_k.eraseLocalWorkspace();
+                    Arow_k.releaseRemoteWorkspace();
+                    Arow_k.releaseLocalWorkspace();
 
                     internal::symm<Target::HostTask>(
                         Side::Left,
@@ -242,8 +242,8 @@ void symm(
                         one,    C.sub( k, k, 0, C.nt()-1 ),
                         priority_0, opts_local );
 
-                    A.eraseRemoteWorkspaceTile( k, k );
-                    A.eraseLocalWorkspaceTile( k, k );
+                    A.releaseRemoteWorkspaceTile( k, k );
+                    A.releaseLocalWorkspaceTile( k, k );
 
                     if (A.mt()-1 > k) {
                         auto Acol_k = A.sub( k+1, A.mt()-1, k, k );
@@ -253,7 +253,7 @@ void symm(
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
                             layout, priority_0, queue_0, opts_local );
 
-                        Acol_k.eraseLocalWorkspace();
+                        Acol_k.releaseLocalWorkspace();
 
                         std::set<ij_tuple> tile_set;
                         for (int64_t i = 0; i < A.mt(); ++i) {
@@ -265,11 +265,11 @@ void symm(
                                 }
                             }
                         }
-                        A.eraseRemoteWorkspace( tile_set );
+                        A.releaseRemoteWorkspace( tile_set );
                     }
 
-                    Brow_k.eraseRemoteWorkspace();
-                    Brow_k.eraseLocalWorkspace();
+                    Brow_k.releaseRemoteWorkspace();
+                    Brow_k.releaseLocalWorkspace();
                 }
             }
         }
@@ -343,7 +343,7 @@ void symm(
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Arow_0.eraseLocalWorkspace();
+                    Arow_0.releaseLocalWorkspace();
 
                     std::set<ij_tuple> tile_set;
                     for (int64_t i = 0; i < A.mt(); ++i) {
@@ -353,11 +353,11 @@ void symm(
                             }
                         }
                     }
-                    A.eraseRemoteWorkspace( tile_set );
+                    A.releaseRemoteWorkspace( tile_set );
                 }
 
-                Brow_0.eraseRemoteWorkspace();
-                Brow_0.eraseLocalWorkspace();
+                Brow_0.releaseRemoteWorkspace();
+                Brow_0.releaseLocalWorkspace();
             }
 
             for (int64_t k = 1; k < A.nt(); ++k) {
@@ -408,8 +408,8 @@ void symm(
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
                         layout, priority_0, queue_0, opts_local );
 
-                    Acol_k.eraseRemoteWorkspace();
-                    Acol_k.eraseLocalWorkspace();
+                    Acol_k.releaseRemoteWorkspace();
+                    Acol_k.releaseLocalWorkspace();
 
                     internal::symm<Target::HostTask>(
                         Side::Left,
@@ -418,8 +418,8 @@ void symm(
                         one,    C.sub( k, k, 0, C.nt()-1 ),
                         priority_0, opts_local );
 
-                    A.eraseRemoteWorkspaceTile( k, k );
-                    A.eraseLocalWorkspaceTile( k, k );
+                    A.releaseRemoteWorkspaceTile( k, k );
+                    A.releaseLocalWorkspaceTile( k, k );
 
                     if (A.mt()-1 > k) {
                         auto Arow_k = A.sub( k, k, k+1, A.mt()-1 );
@@ -429,7 +429,7 @@ void symm(
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
                             layout, priority_0, queue_0, opts_local );
 
-                        Arow_k.eraseLocalWorkspace();
+                        Arow_k.releaseLocalWorkspace();
 
                         std::set<ij_tuple> tile_set;
                         for (int64_t i = 0; i < A.mt(); ++i) {
@@ -439,11 +439,11 @@ void symm(
                                 }
                             }
                         }
-                        A.eraseRemoteWorkspace( tile_set );
+                        A.releaseRemoteWorkspace( tile_set );
                     }
 
-                    Brow_k.eraseRemoteWorkspace();
-                    Brow_k.eraseLocalWorkspace();
+                    Brow_k.releaseRemoteWorkspace();
+                    Brow_k.releaseLocalWorkspace();
                 }
             }
         }

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -127,12 +127,12 @@ void syr2k(
                 priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
-            A_col0.eraseRemoteWorkspace();
-            B_col0.eraseRemoteWorkspace();
+            A_col0.releaseRemoteWorkspace();
+            B_col0.releaseRemoteWorkspace();
 
             // Erase local workspace on devices.
-            A_col0.eraseLocalWorkspace();
-            B_col0.eraseLocalWorkspace();
+            A_col0.releaseLocalWorkspace();
+            B_col0.releaseLocalWorkspace();
         }
 
         for (int64_t k = 1; k < A.nt(); ++k) {
@@ -174,12 +174,12 @@ void syr2k(
                     priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
-                A_colk.eraseRemoteWorkspace();
-                B_colk.eraseRemoteWorkspace();
+                A_colk.releaseRemoteWorkspace();
+                B_colk.releaseRemoteWorkspace();
 
                 // Erase local workspace on devices.
-                A_colk.eraseLocalWorkspace();
-                B_colk.eraseLocalWorkspace();
+                A_colk.releaseLocalWorkspace();
+                B_colk.releaseLocalWorkspace();
             }
         }
 

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -114,10 +114,10 @@ void syrk(
                 priority_0, queue_0, layout, opts_local );
 
             // Erase remote tiles on all devices including host
-            A_col0.eraseRemoteWorkspace();
+            A_col0.releaseRemoteWorkspace();
 
             // Erase local workspace on devices.
-            A_col0.eraseLocalWorkspace();
+            A_col0.releaseLocalWorkspace();
         }
 
         for (int64_t k = 1; k < A.nt(); ++k) {
@@ -153,10 +153,10 @@ void syrk(
                     priority_0, queue_0, layout, opts_local );
 
                 // Erase remote tiles on all devices including host
-                A_colk.eraseRemoteWorkspace();
+                A_colk.releaseRemoteWorkspace();
 
                 // Erase local workspace on devices.
-                A_colk.eraseLocalWorkspace();
+                A_colk.releaseLocalWorkspace();
             }
         }
 

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -175,16 +175,16 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
             #pragma omp task depend(inout:row[k])
             {
                 auto A_panel = A.sub(k, mt-1, k, k);
-                A_panel.eraseRemoteWorkspace();
-                A_panel.eraseLocalWorkspace();
+                A_panel.releaseRemoteWorkspace();
+                A_panel.releaseLocalWorkspace();
 
                 auto B_panel = B.sub(k, k, 0, nt-1);
-                B_panel.eraseRemoteWorkspace();
+                B_panel.releaseRemoteWorkspace();
 
                 // Copy back modifications to tiles in the B panel
                 // before they are erased.
                 B_panel.tileUpdateAllOrigin();
-                B_panel.eraseLocalWorkspace();
+                B_panel.releaseLocalWorkspace();
             }
         }
     }
@@ -256,16 +256,16 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
             #pragma omp task depend(inout:row[k])
             {
                 auto A_panel = A.sub(0, k, k, k);
-                A_panel.eraseRemoteWorkspace();
-                A_panel.eraseLocalWorkspace();
+                A_panel.releaseRemoteWorkspace();
+                A_panel.releaseLocalWorkspace();
 
                 auto B_panel = B.sub(k, k, 0, nt-1);
-                B_panel.eraseRemoteWorkspace();
+                B_panel.releaseRemoteWorkspace();
 
                 // Copy back modifications to tiles in the B panel
                 // before they are erased.
                 B_panel.tileUpdateAllOrigin();
-                B_panel.eraseLocalWorkspace();
+                B_panel.releaseLocalWorkspace();
             }
         }
     }

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -286,17 +286,17 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
             #pragma omp task depend(inout:row[k])
             {
                 auto A_col_k = A.sub( k, mt-1, k, k );
-                A_col_k.eraseRemoteWorkspace();
-                A_col_k.eraseLocalWorkspace();
+                A_col_k.releaseRemoteWorkspace();
+                A_col_k.releaseLocalWorkspace();
 
                 auto B_row_k = B.sub( k, k, 0, nt-1 );
 
-                B_row_k.eraseRemoteWorkspace();
+                B_row_k.releaseRemoteWorkspace();
 
                 // Copy back modifications to tiles in the B panel
                 // before they are erased.
                 B_row_k.tileUpdateAllOrigin();
-                B_row_k.eraseLocalWorkspace();
+                B_row_k.releaseLocalWorkspace();
             }
         }
     }
@@ -468,15 +468,15 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
             #pragma omp task depend(inout:row[k])
             {
                 auto A_col_k = A.sub( 0, k, k, k );
-                A_col_k.eraseRemoteWorkspace();
-                A_col_k.eraseLocalWorkspace();
+                A_col_k.releaseRemoteWorkspace();
+                A_col_k.releaseLocalWorkspace();
 
                 auto B_row_k = B.sub( k, k, 0, nt-1 );
-                B_row_k.eraseRemoteWorkspace();
+                B_row_k.releaseRemoteWorkspace();
                 // Copy back modifications to tiles in the B panel
                 // before they are erased.
                 B_row_k.tileUpdateAllOrigin();
-                B_row_k.eraseLocalWorkspace();
+                B_row_k.releaseLocalWorkspace();
             }
         }
     }

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -145,8 +145,8 @@ void test_copy_work(Params& params, bool run)
         else slate::trace::Trace::off();
 
         // Force the matrix to reside based on its origin.
-        A.eraseLocalWorkspace();
-        B.eraseLocalWorkspace();
+        A.releaseLocalWorkspace();
+        B.releaseLocalWorkspace();
 
         //==================================================
         // Run SLATE test.


### PR DESCRIPTION
Change `erase` to `release`, which doesn't delete tiles that are OnHold or Modified. This addresses an issue if origin=Device but target=Host, routines like gemm would compute in host workspace tiles, but then throw the results away! Needed for D&C when origin=Device.