### PR TITLE
[gemmA] Fallback to gemmC when target=device and #device > 1.

### DIFF
--- a/include/slate/method.hh
+++ b/include/slate/method.hh
@@ -78,7 +78,15 @@ namespace MethodGemm {
 
     template <typename TA, typename TB>
     inline Method select_algo(TA& A, TB& B, Options& opts) {
+        // TODO replace the default value by a unique value located elsewhere
+        Target target = get_option( opts, Option::Target, Target::HostTask );
+        int n_devices = A.num_devices();
+
         Method method = (B.nt() < 2 ? GemmA : GemmC);
+
+        if (method == GemmA && target == Target::Devices && n_devices > 1)
+          method = GemmC;
+
         return method;
     }
 


### PR DESCRIPTION
## Problem
The `gemmA` routine cannot work on multiple GPUs for now, because of the MOSI protocol.

## Solution
We add a condition in the selection method when `method-gemm` == `auto`.

## Runs
Previously:
``` bash
OMP_NUM_THREADS=5 mpirun -n 1 ./test/tester --grid 1x1 --dim 1000x64 --nb 63 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm                            
SLATE version 2022.07.00, id 57298a90                                                                                                                                                                              
input: ./test/tester --grid 1x1 --dim 1000x64 --nb 63 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm                                                    
2023-04-28 11:12:16, MPI size 1, OpenMP threads 5, GPU devices available 8                                                                                                                                         
                                                                                                                                                                                                                   
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status                        
   d    host    task  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   2.45e-16   0.000375        21.832            NA            NA  pass                          
   d    host     dev  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   9.26e-01    0.00161         5.075            NA            NA  FAILED                        
   d     dev    task  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   2.53e-16    0.00187         4.379            NA            NA  pass                          
terminate called after throwing an instance of 'slate::FalseConditionException'                                                                                                                                    
  what():  SLATE ERROR: Error check 'tile_node[d].stateOn(MOSI::Modified) == false' failed in tileModified at ./include/slate/BaseMatrix.hh:1734                                                                   
                                                                                                                                                                                                                   
===================================================================================                                                                                                                                
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES                                                                                                                                                           
=   RANK 0 PID 71547 RUNNING AT leconte.icl.utk.edu                                                                                                                                                                
=   KILLED BY SIGNAL: 6 (Aborted)                                                                                                                                                                                  
===================================================================================
```

Now:
``` bash
OMP_NUM_THREADS=5 mpirun -n 1 ./test/tester --grid 1x1 --dim 1000x64 --nb 63 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm
SLATE version 2022.07.00, id 57298a90
input: ./test/tester --grid 1x1 --dim 1000x64 --nb 63 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm
2023-04-28 11:22:59, MPI size 1, OpenMP threads 5, GPU devices available 8
                                                                                                                                                                                              
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
   d    host    task  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   2.44e-16   0.000371        22.105            NA            NA  pass    
   d    host     dev  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   1.52e-16    0.00890         0.920            NA            NA  pass    
   d     dev    task  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   2.54e-16    0.00185         4.427            NA            NA  pass    
   d     dev     dev  auto  col  notrans  notrans    1000      64      64   1          2.7+1.7i    63    1    1   0   1.59e-16    0.00619         1.323            NA            NA  pass    
All tests passed: gemm
```

Also, as a comparison, when we have a single GPU, we expect to call `gemmA` internally, and we get better performance, as expected:
``` bash
OMP_NUM_THREADS=5 mpirun -n 1 ./test/tester --grid 1x1 --dim 10000x256 --nb 256 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm                         
SLATE version 2022.07.00, id 57298a90                                                                                                                                                                              
input: ./test/tester --grid 1x1 --dim 10000x256 --nb 256 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm                                                 
2023-04-28 11:23:37, MPI size 1, OpenMP threads 5, GPU devices available 8                                                                                                                                         
                                                                                                                                                                                                                   
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status                        
   d    host    task  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.93e-16    0.00985       133.051            NA            NA  pass                          
   d    host     dev  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.70e-16     0.0218        60.185            NA            NA  pass                          
   d     dev    task  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.90e-16     0.0296        44.345            NA            NA  pass                          
   d     dev     dev  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.71e-16    0.00701       187.099            NA            NA  pass                          
All tests passed: gemm

OMP_NUM_THREADS=5 mpirun -n 1 ./gpu_bind.sh 0 ./test/tester --grid 1x1 --dim 10000x256 --nb 256 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm         
SLATE version 2022.07.00, id 57298a90                                                                                                                                                                              
input: ./test/tester --grid 1x1 --dim 10000x256 --nb 256 --ref n --transA n --transB n --origin h,d --target t,d --lookahead 0 --alpha 1.0 --method-gemm auto gemm                                                 
2023-04-28 11:23:58, MPI size 1, OpenMP threads 5, GPU devices available 1                                                                                                                                         
                                                                                                                                                                                                                   
type  origin  target  gemm   go   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status                        
   d    host    task  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.68e-16     0.0105       124.617            NA            NA  pass                          
   d    host     dev  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.82e-16     0.0114       115.318            NA            NA  pass                          
   d     dev    task  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.67e-16     0.0295        44.385            NA            NA  pass                          
   d     dev     dev  auto  col  notrans  notrans   10000     256     256   1          2.7+1.7i   256    1    1   0   4.61e-16    0.00160       818.183            NA            NA  pass                          
All tests passed: gemm
```