### PR TITLE
Heev D&C

### DIFF
--- a/src/copy.cc
+++ b/src/copy.cc
@@ -151,6 +151,18 @@ void copy(
     Matrix<std::complex<double> >& B,
     Options const& opts);
 
+template
+void copy(
+    Matrix< float >& A,
+    Matrix< std::complex<float> >& B,
+    Options const& opts);
+
+template
+void copy(
+    Matrix< double  >& A,
+    Matrix< std::complex<double> >& B,
+    Options const& opts);
+
 //---------------------------------------
 // template
 // void copy(

--- a/src/cuda/device_gecopy.cu
+++ b/src/cuda/device_gecopy.cu
@@ -116,6 +116,8 @@ void gecopy(
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
+
+// float => float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -123,6 +125,7 @@ void gecopy(
     float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// float => double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -130,6 +133,7 @@ void gecopy(
     double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// double => double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -137,6 +141,7 @@ void gecopy(
     double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// double => float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -144,6 +149,7 @@ void gecopy(
     float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-float => complex-float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -151,6 +157,7 @@ void gecopy(
     cuFloatComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-float => complex-double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -158,6 +165,7 @@ void gecopy(
     cuDoubleComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-double => complex-double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -165,11 +173,28 @@ void gecopy(
     cuDoubleComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-double => complex-float
 template
 void gecopy(
     int64_t m, int64_t n,
     cuDoubleComplex const* const* Aarray, int64_t lda,
     cuFloatComplex** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+// float => complex-float
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    cuFloatComplex** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+// double => complex-double
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    cuDoubleComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 } // namespace device

--- a/src/cuda/device_util.cuh
+++ b/src/cuda/device_util.cuh
@@ -220,6 +220,22 @@ inline void copy(cuDoubleComplex a, cuFloatComplex& b)
     b.y = a.y;
 }
 
+/// Sets b = a, converting from float to complex-float.
+__host__ __device__
+inline void copy( float a, cuFloatComplex& b )
+{
+    b.x = a;
+    b.y = 0;
+}
+
+/// Sets b = a, converting from double to complex-double.
+__host__ __device__
+inline void copy( double a, cuDoubleComplex& b )
+{
+    b.x = a;
+    b.y = 0;
+}
+
 //------------------------------------------------------------------------------
 /// Square of number.
 /// @return x^2

--- a/src/hip/device_gecopy.hip.cc
+++ b/src/hip/device_gecopy.hip.cc
@@ -106,7 +106,7 @@ void gecopy(
 
     hipSetDevice( queue.device() );
 
-    hipLaunchKernelGGL(gecopy_kernel, dim3(batch_count), dim3(nthreads), 0, queue.stream(),
+    gecopy_kernel<<<batch_count, nthreads, 0, queue.stream()>>>(
           m, n,
           Aarray, lda,
           Barray, ldb);
@@ -117,6 +117,8 @@ void gecopy(
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
+
+// float => float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -124,6 +126,7 @@ void gecopy(
     float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// float => double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -131,6 +134,7 @@ void gecopy(
     double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// double => double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -138,6 +142,7 @@ void gecopy(
     double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// double => float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -145,6 +150,7 @@ void gecopy(
     float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-float => complex-float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -152,6 +158,7 @@ void gecopy(
     hipFloatComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-float => complex-double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -159,6 +166,7 @@ void gecopy(
     hipDoubleComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-double => complex-double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -166,11 +174,28 @@ void gecopy(
     hipDoubleComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-double => complex-float
 template
 void gecopy(
     int64_t m, int64_t n,
     hipDoubleComplex const* const* Aarray, int64_t lda,
     hipFloatComplex** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+// float => complex-float
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    hipFloatComplex** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+// double => complex-double
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    hipDoubleComplex** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 } // namespace device

--- a/src/hip/device_gecopy.hip.cc.dep
+++ b/src/hip/device_gecopy.hip.cc.dep
@@ -1,1 +1,1 @@
-4ff058c3821f91a7c3daba02e692c2d1  src/cuda/device_gecopy.cu
+61e9d26912b966b4357fb6449a907b9b  src/cuda/device_gecopy.cu

--- a/src/hip/device_util.hip.hh
+++ b/src/hip/device_util.hip.hh
@@ -220,6 +220,22 @@ inline void copy(hipDoubleComplex a, hipFloatComplex& b)
     b.y = a.y;
 }
 
+/// Sets b = a, converting from float to complex-float.
+__host__ __device__
+inline void copy( float a, hipFloatComplex& b )
+{
+    b.x = a;
+    b.y = 0;
+}
+
+/// Sets b = a, converting from double to complex-double.
+__host__ __device__
+inline void copy( double a, hipDoubleComplex& b )
+{
+    b.x = a;
+    b.y = 0;
+}
+
 //------------------------------------------------------------------------------
 /// Square of number.
 /// @return x^2

--- a/src/hip/device_util.hip.hh.dep
+++ b/src/hip/device_util.hip.hh.dep
@@ -1,1 +1,1 @@
-f07315854e67bc2db88fb48f10382a9a  src/cuda/device_util.cuh
+0978ca7900eeb71e849ef7cae6dcaf9b  src/cuda/device_util.cuh

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -18,6 +18,7 @@ namespace device {
 // CUBLAS/ROCBLAS need complex translation, others do not
 #if ! defined( SLATE_HAVE_OMPTARGET )
 
+// complex-float => complex-float
 template <>
 void gecopy(
     int64_t m, int64_t n,
@@ -39,6 +40,7 @@ void gecopy(
 #endif
 }
 
+// complex-float => complex-double
 template <>
 void gecopy(
     int64_t m, int64_t n,
@@ -60,6 +62,7 @@ void gecopy(
 #endif
 }
 
+// complex-double => complex-double
 template <>
 void gecopy(
     int64_t m, int64_t n,
@@ -81,6 +84,7 @@ void gecopy(
 #endif
 }
 
+// complex-double => complex-float
 template <>
 void gecopy(
     int64_t m, int64_t n,
@@ -99,6 +103,50 @@ void gecopy(
            (hipDoubleComplex**) Aarray, lda,
            (hipFloatComplex**) Barray, ldb,
            batch_count, queue);
+#endif
+}
+
+// float => complex-float
+template <>
+void gecopy(
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+#if defined( BLAS_HAVE_CUBLAS )
+    gecopy( m, n,
+            (float**) Aarray, lda,
+            (cuFloatComplex**) Barray, ldb,
+            batch_count, queue );
+
+#elif defined( BLAS_HAVE_ROCBLAS )
+    gecopy( m, n,
+            (float**) Aarray, lda,
+            (hipFloatComplex**) Barray, ldb,
+            batch_count, queue );
+#endif
+}
+
+// double => complex-double
+template <>
+void gecopy(
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue)
+{
+#if defined( BLAS_HAVE_CUBLAS )
+    gecopy( m, n,
+            (double**) Aarray, lda,
+            (cuDoubleComplex**) Barray, ldb,
+            batch_count, queue );
+
+#elif defined( BLAS_HAVE_ROCBLAS )
+    gecopy( m, n,
+            (double**) Aarray, lda,
+            (hipDoubleComplex**) Barray, ldb,
+            batch_count, queue );
 #endif
 }
 
@@ -350,99 +398,16 @@ void copy(internal::TargetType<Target::Devices>,
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
-// ----------------------------------------
+//-----------------------------------------
+// float => float
 template
 void copy<Target::HostTask, float, float>(
     Matrix<float>&& A, Matrix<float>&& B,
     int priority, int queue_index);
 
 template
-void copy<Target::HostTask, float, double>(
-    Matrix<float>&& A, Matrix<double>&& B,
-    int priority, int queue_index);
-
-template
-void copy<Target::Devices, float, float>(
-    Matrix<float>&& A, Matrix<float>&& B,
-    int priority, int queue_index);
-
-template
-void copy<Target::Devices, float, double>(
-    Matrix<float>&& A, Matrix<double>&& B,
-    int priority, int queue_index);
-
-// ----------------------------------------
-template
-void copy<Target::HostTask, double, double>(
-    Matrix<double>&& A, Matrix<double>&& B,
-    int priority, int queue_index);
-
-template
-void copy<Target::HostTask, double, float>(
-    Matrix<double>&& A, Matrix<float>&& B,
-    int priority, int queue_index);
-
-template
-void copy<Target::Devices, double, double>(
-    Matrix<double>&& A, Matrix<double>&& B,
-    int priority, int queue_index);
-
-template
-void copy<Target::Devices, double, float>(
-    Matrix<double>&& A, Matrix<float>&& B,
-    int priority, int queue_index);
-
-// ----------------------------------------
-template
-void copy< Target::HostTask, std::complex<float>, std::complex<float> >(
-    Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::HostTask, std::complex<float>, std::complex<double> >(
-    Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::Devices, std::complex<float>, std::complex<float>  >(
-    Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::Devices, std::complex<float>, std::complex<double>  >(
-    Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index);
-
-// ----------------------------------------
-template
-void copy< Target::HostTask, std::complex<double>, std::complex<double> >(
-    Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::HostTask, std::complex<double>, std::complex<float> >(
-    Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::Devices, std::complex<double>, std::complex<double> >(
-    Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::Devices, std::complex<double>, std::complex<float> >(
-    Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index);
-
-// ----------------------------------------
-template
 void copy<Target::HostNest, float, float>(
     Matrix<float>&& A, Matrix<float>&& B,
-    int priority, int queue_index);
-
-template
-void copy<Target::HostNest, float, double>(
-    Matrix<float>&& A, Matrix<double>&& B,
     int priority, int queue_index);
 
 template
@@ -451,19 +416,42 @@ void copy<Target::HostBatch, float, float>(
     int priority, int queue_index);
 
 template
+void copy<Target::Devices, float, float>(
+    Matrix<float>&& A, Matrix<float>&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// float => double
+template
+void copy<Target::HostTask, float, double>(
+    Matrix<float>&& A, Matrix<double>&& B,
+    int priority, int queue_index);
+
+template
+void copy<Target::HostNest, float, double>(
+    Matrix<float>&& A, Matrix<double>&& B,
+    int priority, int queue_index);
+
+template
 void copy<Target::HostBatch, float, double>(
     Matrix<float>&& A, Matrix<double>&& B,
     int priority, int queue_index);
 
-// ----------------------------------------
 template
-void copy<Target::HostNest, double, double>(
+void copy<Target::Devices, float, double>(
+    Matrix<float>&& A, Matrix<double>&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// double => double
+template
+void copy<Target::HostTask, double, double>(
     Matrix<double>&& A, Matrix<double>&& B,
     int priority, int queue_index);
 
 template
-void copy<Target::HostNest, double, float>(
-    Matrix<double>&& A, Matrix<float>&& B,
+void copy<Target::HostNest, double, double>(
+    Matrix<double>&& A, Matrix<double>&& B,
     int priority, int queue_index);
 
 template
@@ -472,14 +460,59 @@ void copy<Target::HostBatch, double, double>(
     int priority, int queue_index);
 
 template
+void copy<Target::Devices, double, double>(
+    Matrix<double>&& A, Matrix<double>&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// double => float
+template
+void copy<Target::HostTask, double, float>(
+    Matrix<double>&& A, Matrix<float>&& B,
+    int priority, int queue_index);
+
+template
+void copy<Target::HostNest, double, float>(
+    Matrix<double>&& A, Matrix<float>&& B,
+    int priority, int queue_index);
+
+template
 void copy<Target::HostBatch, double, float>(
     Matrix<double>&& A, Matrix<float>&& B,
     int priority, int queue_index);
 
-// ----------------------------------------
+template
+void copy<Target::Devices, double, float>(
+    Matrix<double>&& A, Matrix<float>&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// complex-float => complex-float
+template
+void copy< Target::HostTask, std::complex<float>, std::complex<float> >(
+    Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
 template
 void copy< Target::HostNest, std::complex<float>, std::complex<float> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::HostBatch, std::complex<float>, std::complex<float> >(
+    Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::Devices, std::complex<float>, std::complex<float> >(
+    Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// complex-float => complex-double
+template
+void copy< Target::HostTask, std::complex<float>, std::complex<double> >(
+    Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
     int priority, int queue_index);
 
 template
@@ -488,24 +521,25 @@ void copy< Target::HostNest, std::complex<float>, std::complex<double> >(
     int priority, int queue_index);
 
 template
-void copy< Target::HostBatch, std::complex<float>, std::complex<float>  >(
-    Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index);
-
-template
-void copy< Target::HostBatch, std::complex<float>, std::complex<double>  >(
+void copy< Target::HostBatch, std::complex<float>, std::complex<double> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
     int priority, int queue_index);
 
-// ----------------------------------------
 template
-void copy< Target::HostNest, std::complex<double>, std::complex<double> >(
+void copy< Target::Devices, std::complex<float>, std::complex<double> >(
+    Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// complex-double => complex-double
+template
+void copy< Target::HostTask, std::complex<double>, std::complex<double> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
     int priority, int queue_index);
 
 template
-void copy< Target::HostNest, std::complex<double>, std::complex<float> >(
-    Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
+void copy< Target::HostNest, std::complex<double>, std::complex<double> >(
+    Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
     int priority, int queue_index);
 
 template
@@ -514,8 +548,75 @@ void copy< Target::HostBatch, std::complex<double>, std::complex<double> >(
     int priority, int queue_index);
 
 template
+void copy< Target::Devices, std::complex<double>, std::complex<double> >(
+    Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// complex-double => complex-float
+template
+void copy< Target::HostTask, std::complex<double>, std::complex<float> >(
+    Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::Devices, std::complex<double>, std::complex<float> >(
+    Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::HostNest, std::complex<double>, std::complex<float> >(
+    Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
 void copy< Target::HostBatch, std::complex<double>, std::complex<float> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
     int priority, int queue_index);
+
+//-----------------------------------------
+// float => complex-float
+template
+void copy< Target::HostTask, float, std::complex<float> >(
+    Matrix< float >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::Devices, float, std::complex<float> >(
+    Matrix< float >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::HostNest, float, std::complex<float> >(
+    Matrix< float >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::HostBatch, float, std::complex<float> >(
+    Matrix< float >&& A, Matrix< std::complex<float> >&& B,
+    int priority, int queue_index);
+
+//-----------------------------------------
+// double => complex-double
+template
+void copy< Target::HostTask, double, std::complex<double> >(
+    Matrix< double >&& A, Matrix< std::complex<double> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::Devices, double, std::complex<double> >(
+    Matrix< double >&& A, Matrix< std::complex<double> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::HostNest, double, std::complex<double> >(
+    Matrix< double >&& A, Matrix< std::complex<double> >&& B,
+    int priority, int queue_index);
+
+template
+void copy< Target::HostBatch, double, std::complex<double> >(
+    Matrix< double >&& A, Matrix< std::complex<double> >&& B,
+    int priority, int queue_index);
+
 } // namespace internal
 } // namespace slate

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -497,11 +497,14 @@ if (opts.rq):
 
 # symmetric/Hermitian eigenvalues
 if (opts.syev):
-    cmds += [
-    # todo: uplo, jobz
-    [ 'heev',  gen + dtype + la + n ],
-    #[ 'ungtr', gen + dtype + la + n + uplo ],
+    # todo: uplo
+    if ('n' in jobz):
+        # Requires ref to check. Only QR.
+        cmds += [[ 'heev', gen + dtype + la + n + ' --jobz n --ref y --method-eig qr' ]]
+    if ('v' in jobz):
+        cmds += [[ 'heev', gen + dtype + la + n + ' --jobz v --method-eig qr,dc' ]]
 
+    cmds += [
     # todo uplo, nk
     [ 'unmtr_he2hb', gen + dtype_real    + side + trans    + n ],  # real does trans = N, T, C
     [ 'unmtr_he2hb', gen + dtype_complex + side + trans_nc + n ],  # complex does trans = N, C

--- a/test/test.cc
+++ b/test/test.cc
@@ -347,7 +347,7 @@ Params::Params():
     method_lu     ("lu",     5, ParamType::List, slate::MethodLU::PartialPiv, str2methodLU, methodLU2str, "PartialPiv, CALU, NoPiv"),
     method_trsm   ("trsm",   4, ParamType::List, 0, str2methodTrsm,   methodTrsm2str,   "auto=auto, A=trsmA, B=trsmB"),
 
-    grid_order("grid-order", 3, ParamType::List, slate::GridOrder::Col,   str2grid_order, grid_order2str, "(go) MPI grid order: c=Col, r=Row"),
+    grid_order("go",      3, ParamType::List, slate::GridOrder::Col,   str2grid_order, grid_order2str, "(go) MPI grid order: c=Col, r=Row"),
     tile_release_strategy ("trs", 3, ParamType::List, slate::TileReleaseStrategy::All, str2tile_release_strategy,   tile_release_strategy2str,   "tile release strategy: n=none, i=only internal routines, s=only top-level routines in slate namespace, a=all routines"),
     dev_dist  ("dev-dist",9,    ParamType::List, slate::Dist::Col,        str2dist,     dist2str,     "matrix tiles distribution across local devices (one-dimensional block-cyclic): col=column, row=row"),
 
@@ -371,10 +371,6 @@ Params::Params():
     equed     ("equed",   5,    ParamType::List, slate::Equed::Both, lapack::char2equed, lapack::equed2char, lapack::equed2str, "row & col scaling (equilibration): b=both, r=row, c=col, n=none"),
     storev    ("storev", 10,    ParamType::List, lapack::StoreV::Columnwise, lapack::char2storev, lapack::storev2char, lapack::storev2str, "store vectors: c=columnwise, r=rowwise"),
 
-    matrixtype( "matrixtype", 10, ParamType::List, lapack::MatrixType::General,
-                lapack::char2matrixtype, lapack::matrixtype2char, lapack::matrixtype2str,
-                "matrix type: g=general, l=lower, u=upper, h=Hessenberg, z=band-general, b=band-lower, q=band-upper" ),
-
     //         name,      w, p, type,        default,   min,     max, help
     dim       ("dim",     6,    ParamType::List,          0, 1000000, "m x n x k dimensions"),
     kd        ("kd",      6,    ParamType::List,  10,     0, 1000000, "bandwidth"),
@@ -395,9 +391,8 @@ Params::Params():
     nb        ("nb",      4,    ParamType::List, 384,     0, 1000000, "block size"),
     ib        ("ib",      2,    ParamType::List, 32,      0, 1000000, "inner blocking"),
     grid      ("grid",    3,    ParamType::List, "1x1",   0, 1000000, "MPI grid p x q dimensions"),
-    lookahead ("lookahead", 2,  ParamType::List, 1,       0, 1000000, "(la) number of lookahead panels"),
-    panel_threads("panel-threads",
-                          2,    ParamType::List, std::max( omp_get_max_threads() / 2, 1 ),
+    lookahead ("la",      2,    ParamType::List, 1,       0, 1000000, "(la) number of lookahead panels"),
+    panel_threads("pt",   2,    ParamType::List, std::max( omp_get_max_threads() / 2, 1 ),
                                                           0, 1000000, "(pt) max number of threads used in panel; default omp_num_threads / 2"),
     align     ("align",   5,    ParamType::List,  32,     1,    1024, "column alignment (sets lda, ldb, etc. to multiple of align)"),
     nonuniform_nb("nonuniform_nb",
@@ -491,6 +486,7 @@ Params::Params():
 
     //  change names of grid elements
     grid.names("p", "q");
+    grid.width( 3 );
 
     // routine's parameters are marked by the test routine; see main
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -339,13 +339,13 @@ Params::Params():
     origin    ("origin",  6,    ParamType::List, slate::Origin::Host,     str2origin,   origin2str,   "origin: h=Host, s=ScaLAPACK, d=Devices"),
     target    ("target",  6,    ParamType::List, slate::Target::HostTask, str2target,   target2str,   "target: t=HostTask, n=HostNest, b=HostBatch, d=Devices"),
 
-    method_cholQR ("method-cholQR", 6, ParamType::List, 0, str2methodCholQR, methodCholQR2str, "method-cholQR: auto=auto, herkC, gemmA, gemmC"),
-    method_eig    ("method_eig",    6, ParamType::List, slate::MethodEig::QR, str2methodEig, methodEig2str, "method_eig: q=QR iteration d=Divide and conquer"),
-    method_gels   ("method-gels",   6, ParamType::List, 0, str2methodGels,   methodGels2str,   "method-gels: auto=auto, qr, cholqr"),
-    method_gemm   ("method-gemm",   4, ParamType::List, 0, str2methodGemm,   methodGemm2str,   "method-gemm: auto=auto, A=gemmA, C=gemmC"),
-    method_hemm   ("method-hemm",   4, ParamType::List, 0, str2methodHemm,   methodHemm2str,   "method-hemm: auto=auto, A=hemmA, C=hemmC"),
-    method_lu     ("method-lu",     5, ParamType::List, slate::MethodLU::PartialPiv, str2methodLU, methodLU2str, "method-lu: PartialPiv, CALU, NoPiv"),
-    method_trsm   ("method-trsm",   4, ParamType::List, 0, str2methodTrsm,   methodTrsm2str,   "method-trsm: auto=auto, A=trsmA, B=trsmB"),
+    method_cholQR ("cholQR", 6, ParamType::List, 0, str2methodCholQR, methodCholQR2str, "auto=auto, herkC, gemmA, gemmC"),
+    method_eig    ("eig",    3, ParamType::List, slate::MethodEig::QR, str2methodEig, methodEig2str, "q=QR iteration, d=Divide and conquer"),
+    method_gels   ("gels",   6, ParamType::List, 0, str2methodGels,   methodGels2str,   "auto=auto, qr, cholqr"),
+    method_gemm   ("gemm",   4, ParamType::List, 0, str2methodGemm,   methodGemm2str,   "auto=auto, A=gemmA, C=gemmC"),
+    method_hemm   ("hemm",   4, ParamType::List, 0, str2methodHemm,   methodHemm2str,   "auto=auto, A=hemmA, C=hemmC"),
+    method_lu     ("lu",     5, ParamType::List, slate::MethodLU::PartialPiv, str2methodLU, methodLU2str, "PartialPiv, CALU, NoPiv"),
+    method_trsm   ("trsm",   4, ParamType::List, 0, str2methodTrsm,   methodTrsm2str,   "auto=auto, A=trsmA, B=trsmB"),
 
     grid_order("grid-order", 3, ParamType::List, slate::GridOrder::Col,   str2grid_order, grid_order2str, "(go) MPI grid order: c=Col, r=Row"),
     tile_release_strategy ("trs", 3, ParamType::List, slate::TileReleaseStrategy::All, str2tile_release_strategy,   tile_release_strategy2str,   "tile release strategy: n=none, i=only internal routines, s=only top-level routines in slate namespace, a=all routines"),
@@ -450,6 +450,7 @@ Params::Params():
 
     // Change name for the methods to use less space in the stdout
     method_cholQR.name("cholQR", "method-cholQR");
+    method_eig.name("eig", "method-eig");
     method_gels.name("gels", "method-gels");
     method_gemm.name("gemm", "method-gemm");
     method_hemm.name("hemm", "method-hemm");

--- a/test/test.hh
+++ b/test/test.hh
@@ -112,7 +112,6 @@ public:
     testsweeper::ParamEnum< slate::Direction >      direction;
     testsweeper::ParamEnum< slate::Equed >          equed;
     testsweeper::ParamEnum< lapack::StoreV >        storev;
-    testsweeper::ParamEnum< lapack::MatrixType >    matrixtype;
 
     testsweeper::ParamInt3   dim;  // m, n, k
     testsweeper::ParamInt    kd;

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -245,7 +245,8 @@ void test_heev_work(Params& params, bool run)
         print_matrix( "Z_out", Z, params ); // Relevant when slate::eig_vals takes Z
     }
 
-    if (check || ref) {
+    // Checking Lambda requires the user to request --ref y.
+    if (ref) {
         #ifdef SLATE_HAVE_SCALAPACK
             // Run reference routine from ScaLAPACK
 
@@ -298,6 +299,7 @@ void test_heev_work(Params& params, bool run)
             slate_assert(info_tst == 0);
             lwork = int64_t( real( work[0] ) );
             work.resize(lwork);
+
             // The lrwork, rwork parameters are only valid for complex
             if (slate::is_complex<scalar_t>::value) {
                 lrwork = int64_t( real( rwork[0] ) );


### PR DESCRIPTION
Add call to divide and conquer (D&C, in `stedc` routine) in heev.

`stedc` takes a real tridiagonal and produces a real Z matrix. When matrix A is complex, we need to copy real => complex, then do the back-transformation. Added copy routines for real => complex.

Also did minor cleanup of methods and other fields in the test framework, to minimize their column width.