### PR TITLE
LQ and QR fixes

### DIFF
--- a/src/internal/Tile_tpmlqt.hh
+++ b/src/internal/Tile_tpmlqt.hh
@@ -24,21 +24,19 @@ namespace slate {
 ///
 /// If side == Left:
 ///
-///     C = [ C1 ]  <- k-by-n
-///         [ C2 ]  <- m-by-n
+///     V = [ I  V2 ]      C = [ C1 ]  <== k-by-n
+///      k-by-k  k-by-m        [ C2 ]  <== m-by-n
 ///
 /// and on exit, $C = op(Q) C$.
-/// C is (k+m)-by-n, C1 is k-by-n, C2 is m-by-n, and V2 is k-by-m.
-/// l is the same in tplqt; m = tplqt's n; k = tplqt's m; n here is different.
+/// l, k are the same in tplqt; m = tplqt's n; n here is different.
 ///
 /// If side == Right:
 ///
-///     C = [ C1  C2 ]
-///       m-by-k  m-by-n
+///     C = [ C1  C2 ]      V = [ I  V2 ]
+///       m-by-k  m-by-n     k-by-k  k-by-n
 ///
 /// and on exit, $C = C op(Q)$.
-/// C is m-by-(k+n), C1 is m-by-k, C2 is m-by-n, and V2 is k-by-n.
-/// n, l are the same in tplqt; k = tplqt's m; m here is different.
+/// l, k, n are the same in tplqt; m here is different.
 ///
 /// Q is a product of block reflectors,
 ///
@@ -60,15 +58,17 @@ namespace slate {
 ///
 /// @param[in] l
 ///     The number of columns of the lower trapezoidal part of V2.
-///     - If side = left,  min(m, k) >= l >= 0.
-///     - If side = right, min(n, k) >= l >= 0.
+///     - If side = left,  min( m, k ) >= l >= 0.
+///     - If side = right, min( n, k ) >= l >= 0.
 ///
 /// @param[in] V2
-///     - If side == Left,  the k-by-m lower pentagonal tile V2.
-///     - If side == Right, the k-by-n lower pentagonal tile V2.
+///     The k-by-N, lower pentagonal matrix V2,
+///     in an k-by-N2 tile, where N2 >= N.
+///     - If side == Left,  N = m.
+///     - If side == Right, N = n.
 ///     The i-th row must contain the vector which defines the
 ///     elementary reflector H(i), for i = 1, 2, ..., k, as returned by
-///     tplqt in A2. The left k-by-(m-l) or k-by-(n-l) portion is rectangular,
+///     tplqt in A2. The left k-by-(N-l) portion is rectangular,
 ///     the right k-by-l portion is lower trapezoidal.
 ///     See Further Details in tplqt.
 ///
@@ -77,19 +77,19 @@ namespace slate {
 ///     as returned by tplqt, stored as an ib-by-k tile.
 ///
 /// @param[in,out] C1
-///     - If side == Left,  the k-by-n tile C1.
-///       C1 can be k2-by-n for k2 >= k; only the upper k-by-n portion is used.
-///     - If side == Right, the m-by-k tile C1.
-///       C1 can be m-by-k2 for k2 >= k; only the left m-by-k portion is used.
+///     - If side == Left,  the k-by-n matrix C1, in a  k1-by-n tile, k1 >= k.
+///     - If side == Right, the m-by-k matrix C1, in an m-by-k1 tile, k1 >= k.
 ///     On exit, C1 is overwritten by the corresponding block of
 ///     $op(Q) C$ or $C op(Q)$.
 ///
 /// @param[in,out] C2
-///     The m-by-n tile C2.
+///     The m-by-n matrix C2.
+///     - If side == Left,  C2 is in an m2-by-n tile, m2 >= m.
+///     - If side == Right, C2 is in an m-by-n2 tile, n2 >= n.
 ///     On exit, C2 is overwritten by the corresponding block of
 ///     $op(Q) C$ or $C op(Q)$.
 ///
-/// Note in LAPACK, A = C1, B = C2, V = V2.
+/// Note: compared to LAPACK, A is renamed here => C1, B => C2, V => V2.
 ///
 /// @ingroup gelqf_tile
 ///
@@ -104,26 +104,39 @@ void tpmlqt(
 #if LAPACK_VERSION >= 30700
     trace::Block trace_block("lapack::tpmlqt");
 
-    int64_t k = V2.mb();
-    int64_t m = C2.mb();
-    int64_t n = C2.nb();
-
+    int64_t m, n, k;
     if (side == Side::Left) {
-        assert(C1.mb() >= k);
-        assert(C1.nb() == n);
-        assert(V2.nb() == m);
-        assert(std::min(m, k) >= l);
+        // Lower trapezoid of V2 is k-by-m, with m <= k. Compare tplqt.
+        k = V2.mb();
+        m = std::min( V2.nb(), k );
+        assert( l == m || l == 0 );
+
+        // C1 is k-by-n.
+        assert( C1.mb() >= k );  // k1 >= k
+        n = C1.nb();
+
+        // C2 is m-by-n.
+        assert( C2.mb() >= m );  // m2 >= m
+        assert( C2.nb() == n );
     }
-    else {
-        assert(C1.mb() == m);
-        assert(C1.nb() >= k);
-        assert(V2.nb() == n);
-        assert(std::min(n, k) >= l);
+    else { // Right
+        // Lower trapezoid of V2 is k-by-n, with n <= k. Compare tplqt.
+        k = V2.mb();
+        n = std::min( V2.nb(), k );
+        assert( l == n || l == 0 );
+
+        // C1 is m-by-k.
+        m = C1.mb();
+        assert( C1.nb() >= k );  // k1 >= k
+
+        // C2 is m-by-n.
+        assert( C2.mb() == m );
+        assert( C2.nb() >= n );  // n2 >= n
     }
 
+    // T is ib-by-k with ib <= k.
     int64_t ib = std::min( T.mb(), k );
-    assert(k >= ib);
-    assert(T.nb() == k);
+    assert( T.nb() >= k );
 
     lapack::tpmlqt(side, op, m, n, k, l, ib,
                    V2.data(), V2.stride(),

--- a/src/internal/Tile_tpqrt.hh
+++ b/src/internal/Tile_tpqrt.hh
@@ -27,94 +27,114 @@ namespace slate {
 ///
 /// @param[in] l
 ///     The number of rows of the upper trapezoidal part of A2.
-///     min(m, n) >= l >= 0. See Further Details.
+///     min( m, k ) >= l >= 0. See Further Details.
 ///
 /// @param[in,out] A1
-///     On entry, the n-by-n upper triangular tile A1.
-///     A1 can be k-by-n for k >= n; only the upper n-by-n portion is used.
+///     On entry, the k-by-k upper triangular matrix A1,
+///     in a k1-by-k tile, where k1 >= k.
 ///
 /// @param[in,out] A2
-///     On entry, the m-by-n pentagonal tile A2.
+///     On entry, the m-by-k upper pentagonal matrix A2,
+///     in an m2-by-k tile, where m2 >= m.
 ///     On exit, the columns represent the Householder reflectors.
-///     The top (m-l)-by-n portion is rectangular,
-///     the bottom l-by-n portion is upper trapezoidal.
+///     The top (m-l)-by-k portion is rectangular,
+///     the bottom l-by-k portion is upper trapezoidal.
 ///
 /// @param[out] T
-///     Tile of size ib-by-n, where ib is the internal blocking to use.
-///     n >= ib >= 1.
+///     Array of size ib-by-k, where ib is the internal blocking to use,
+///     1 <= ib <= k, in an ib3-by-k3 tile, ib3 >= ib and k3 >= k.
 ///     On exit, stores a sequence of ib-by-ib upper triangular T matrices
 ///     representing the block Householder reflectors. See Further Details.
 ///
 /// Further Details
 /// ---------------
 ///
-/// Let A be the (n + m)-by-n matrix
+/// Let A be the (k + m)-by-k matrix
 ///
-///     A = [ A1 ]  <- n-by-n upper triangular
-///         [ A2 ]  <- m-by-n upper pentagonal
+///     A = [ A1 ]  <== k-by-k upper triangular
+///         [ A2 ]  <== m-by-k upper pentagonal
 ///
-/// For example, with m = 5, n = 4, l = 3, the non-zeros of A1 and A2 are
+/// For all cases, A1 is upper triangular.
+/// Example with k = 4, with . representing non-zeros.
 ///
-///     A1 = [ . . . . ]  <- n-by-n upper triangular
+///     A1 = [ . . . . ]  <== k-by-k upper triangular
 ///          [   . . . ]
 ///          [     . . ]
 ///          [       . ]
+///          [- - - - -]
+///          [         ]  <== if k1 > k, all-zero rows are ignored
 ///
-///     A2 = [ . . . . ]  <- (m - l)-by-n rectangular
+/// Depending on m, k, l, there are several cases for A2.
+/// Currently, SLATE supports only cases 1, 2, and 3.
+/// It assumes m = min( A2.mb, A2.nb ), and l = m or l = 0.
+///
+/// Case 1: m = k = l, A2 is upper triangular.
+/// Example with m = k = l = 4.
+///
+///     A2 = [ . . . . ]  <== l-by-k upper triangular
+///          [   . . . ]
+///          [     . . ]
+///          [       . ]
+///          [- - - - -]
+///          [         ]  <== if m2 > m, all-zero rows are ignored
+///
+/// Case 2: m < k and l = min( m, k ) = m, A2 is upper trapezoidal (wide).
+/// Example with m = l = 3, k = 4.
+///
+///     A2 = [ . . . . ]  <== l-by-k upper trapezoidal
+///          [   . . . ]
+///          [     . . ]
+///
+/// Case 3: l = 0, A2 is just the rectangular portion.
+/// Currently unused in SLATE, but should work.
+/// Example with m = 3, l = 0, k = 4.
+///
+///     A2 = [ . . . . ]  <== m-by-k rectangular
+///          [ . . . . ]
+///          [ . . . . ]
+///
+/// Case 4: m > k and l = k, A2 is upper trapezoidal (tall).
+/// Currently unsupported in SLATE; would require explicitly passing m.
+/// Example with m = 6, l = k = 4.
+///
+///     A2 = [ . . . . ]  <== (m - l)-by-k rectangular
 ///          [ . . . . ]
 ///          [---------]
-///          [ . . . . ]  <- l-by-n upper trapezoidal
+///          [ . . . . ]  <== l-by-k upper triangular
 ///          [   . . . ]
 ///          [     . . ]
+///          [       . ]
 ///
-/// Depending on m, n, l, there are several cases.
-/// If l < min(m, n), A2 is pentagonal, as shown above.
-/// If l = 0, it becomes just the rectangular portion:
+/// Case 5: 0 < l < min( m, k ), A2 is upper pentagonal.
+/// Currently unsupported in SLATE; would require explicitly passing m.
+/// Example with m = 5, l = 3, k = 4.
 ///
-///     A2 = [ . . . . ]  <- m-by-n rectangular
+///     A2 = [ . . . . ]  <== (m - l)-by-k rectangular
 ///          [ . . . . ]
-///
-/// If m > n and l = min(m, n) = n, it becomes upper trapezoidal (tall):
-///
-///     A2 = [ . . . . ]  <- (m - l)-by-n rectangular
 ///          [---------]
-///          [ . . . . ]  <- l-by-n upper trapezoidal (triangular)
+///          [ . . . . ]  <== l-by-k upper trapezoidal
 ///          [   . . . ]
 ///          [     . . ]
-///          [       . ]
-///
-/// If m < n and l = min(m, n) = m, it becomes upper trapezoidal (wide):
-///
-///     A2 = [ . . . . . ]  <- l-by-n upper trapezoidal
-///          [   . . . . ]
-///          [     . . . ]
-///          [       . . ]
-///
-/// If m = n = l, it becomes upper triangular:
-///
-///     A2 = [ . . . . ]  <- l-by-n upper trapezoidal (triangular)
-///          [   . . . ]
-///          [     . . ]
-///          [       . ]
 ///
 /// After factoring, the vector representing the elementary reflector H(i) is in
-/// the i-th column of the (m + n)-by-n matrix V:
+/// the i-th column of the (m + k)-by-k matrix V:
 ///
-///     V = [ I  ] <- n-by-n identity
-///         [ V2 ] <- m-by-n pentagonal, same form as A2.
+///     V = [ I  ] <== k-by-k identity
+///         [ V2 ] <== m-by-k pentagonal, same form as A2.
 ///
 /// Thus, all of the information needed for V is contained in V2, which
 /// has the same form as A2 and overwrites A2 on exit.
 ///
-/// The number of blocks is r = ceiling(n/ib), where each
+/// The number of blocks is r = ceiling( k/ib ), where each
 /// block is of order ib except for the last block, which is of order
-/// rb = n - (r-1)*ib. For each of the r blocks, an upper triangular block
+/// rb = k - (r-1)*ib. For each of the r blocks, an upper triangular block
 /// reflector factor is computed: T1, T2, ..., Tr. The ib-by-ib (and rb-by-rb
-/// for the last block) T's are stored in the ib-by-n matrix T as
+/// for the last block) T's are stored in the ib-by-k matrix T as
 ///
 ///     T = [ T1 T2 ... Tr ]
 ///
-/// Note in LAPACK, A = A1, B = A2, W = V, V = V2.
+/// Note: compared to LAPACK, A is renamed here => A1, B => A2, W => V,
+/// V => V2, and n => k. This makes k match k in tpmqrt.
 ///
 /// @ingroup geqrf_tile
 ///
@@ -128,20 +148,23 @@ void tpqrt(
 #if LAPACK_VERSION >= 30400
     trace::Block trace_block("lapack::tpqrt");
 
-    int64_t n = A2.nb();
-    int64_t m = std::min( A2.mb(), A2.nb() ); //A2.mb();
+    // Upper trapezoid of A2 is m-by-k with m <= k.
+    int64_t k = A2.nb();
+    int64_t m = std::min( A2.mb(), k );
+    assert( l == m || l == 0 );
 
-    assert(A1.mb() >= n);  // k >= n
-    assert(A1.nb() == n);
-    assert(std::min(m, n) >= l);
-    assert(T.nb() == n);
+    // Upper triangle of A1 is k-by-k.
+    assert( A1.mb() >= k );  // k1 >= k
+    assert( A1.nb() == k );
 
-    // Normally, ib = T.mb, but limit <= n.
-    int64_t ib = std::min( T.mb(), n );
-    lapack::tpqrt(m, n, l, ib,
-                  A1.data(), A1.stride(),
-                  A2.data(), A2.stride(),
-                  T.data(), T.stride());
+    // T is ib-by-k, with ib <= k.
+    int64_t ib = std::min( T.mb(), k );
+    assert( T.nb() >= k );
+
+    lapack::tpqrt( m, k, l, ib,
+                   A1.data(), A1.stride(),
+                   A2.data(), A2.stride(),
+                   T.data(), T.stride() );
 #else
     slate_not_implemented( "In geqrf: tpqrt requires LAPACK >= 3.4" );
 #endif

--- a/src/internal/internal_ttlqt.cc
+++ b/src/internal/internal_ttlqt.cc
@@ -114,6 +114,7 @@ void ttlqt(internal::TargetType<Target::HostTask>,
 
                 // Factor tiles, which eliminates local tile A(j, 0).
                 T.tileInsert(0, j);
+                T( 0, j ).set( 0 );
                 int64_t l = std::min(A.tileMb(0), A.tileNb(j));
                 tplqt(l, A(0, j_src), A(0, j), T(0, j));
 

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -188,7 +188,7 @@ void ttmqr(internal::TargetType<Target::HostTask>,
 
                         #pragma omp task slate_omp_default_none \
                             shared( A, T, C ) \
-                            firstprivate(i, j, layout, rank_ind, side, op, i1, j1)
+                            firstprivate(i, j, layout, rank_ind, i1, j1, side, op)
                         {
                             A.tileGetForReading(rank_ind, 0, LayoutConvert(layout));
                             T.tileGetForReading(rank_ind, 0, LayoutConvert(layout));

--- a/unit_test/run_tests.py
+++ b/unit_test/run_tests.py
@@ -66,9 +66,9 @@ cmds = [
     'test_gecopy',
     'test_geset',
     'test_internal_blas',
-    #'test_lq', todo hanging on dopamine
+    'test_lq',
     'test_norm',
-    #'test_qr',  # todo: failing
+    'test_qr',
 ]
 
 # ------------------------------------------------------------------------------
@@ -89,6 +89,11 @@ def print_tee( *args ):
 # ------------------------------------------------------------------------------
 # cmd is a string: tester
 def run_test( cmd ):
+    # QR and LQ testers are really slow if GPU devices are present.
+    if (cmd in ('test_qr', 'test_lq')):
+        os.environ['CUDA_VISIBLE_DEVICES'] = ''
+        os.environ['ROCR_VISIBLE_DEVICES'] = ''
+
     print( '-' * 80 )
     cmd = opts.test +' ./' + cmd
     print_tee( cmd )

--- a/unit_test/test_lq.cc
+++ b/unit_test/test_lq.cc
@@ -44,6 +44,8 @@ void test_tplqt_work( int m, int n, int l, int cn, int ib )
     using lapack::Diag;
     using lapack::MatrixType;
 
+    n = blas::min( m, n );
+
     // Unused entries will be set to nan.
     scalar_t nan_ = nan("");
     scalar_t zero = 0;
@@ -241,9 +243,10 @@ void test_tplqt_scalar()
         test_tplqt_work<float>( 16, 12, 12, cn, ib );  // m >  n (tall trapezoid)
 
         // tp triangle-pentagonal cases, l < min(m, n)
-        test_tplqt_work<float>( 12, 12, 6, cn, ib );  // m == n
-        test_tplqt_work<float>(  8, 12, 6, cn, ib );  // m <  n
-        test_tplqt_work<float>( 16, 12, 6, cn, ib );  // m >  n
+        // unsupported in SLATE.
+        // test_tplqt_work<float>( 12, 12, 6, cn, ib );  // m == n
+        // test_tplqt_work<float>(  8, 12, 6, cn, ib );  // m <  n
+        // test_tplqt_work<float>( 16, 12, 6, cn, ib );  // m >  n
     }
 }
 

--- a/unit_test/test_qr.cc
+++ b/unit_test/test_qr.cc
@@ -44,6 +44,8 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
     using lapack::Diag;
     using lapack::MatrixType;
 
+    m = blas::min( m, n );
+
     // Unused entries will be set to nan.
     scalar_t nan_ = nan("");
     scalar_t zero = 0;
@@ -242,9 +244,10 @@ void test_tpqrt_scalar()
         test_tpqrt_work< scalar_t >( 16, 12, 12, cn, ib );  // m >  n (tall trapezoid)
 
         // tp triangle-pentagonal cases, l < min(m, n)
-        test_tpqrt_work< scalar_t >( 12, 12, 6, cn, ib );  // m == n
-        test_tpqrt_work< scalar_t >(  8, 12, 6, cn, ib );  // m <  n
-        test_tpqrt_work< scalar_t >( 16, 12, 6, cn, ib );  // m >  n
+        // unsupported in SLATE.
+        // test_tpqrt_work< scalar_t >( 12, 12, 6, cn, ib );  // m == n
+        // test_tpqrt_work< scalar_t >(  8, 12, 6, cn, ib );  // m <  n
+        // test_tpqrt_work< scalar_t >( 16, 12, 6, cn, ib );  // m >  n
     }
 }
 

--- a/unit_test/test_qr.cc
+++ b/unit_test/test_qr.cc
@@ -28,14 +28,14 @@ int      num_devices = 0;
 MPI_Comm mpi_comm;
 
 //------------------------------------------------------------------------------
-/// Test tpqrt and tpmqrt, QR of 2 tiles and multiply by Q.
+/// Test tile::tpqrt and tile::tpmqrt, QR of 2 tiles and multiply by Q.
 ///
 template <typename scalar_t>
-void test_tpqrt_work( int m, int n, int l, int cn, int ib )
+void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
 {
     if (verbose) {
-        printf( "%s( m=%3d, n=%3d, l=%3d, cn=%3d, ib=%3d )",  // no \n
-                __func__, m, n, l, cn, ib );
+        printf( "%s( m2=%3d, k=%3d, l=%3d, cn=%3d, ib=%3d )",  // no \n
+                __func__, m2, k, l, cn, ib );
     }
 
     using real_t = blas::real_type<scalar_t>;
@@ -44,37 +44,38 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
     using lapack::Diag;
     using lapack::MatrixType;
 
-    m = blas::min( m, n );
+    // Currently SLATE assumes m <= k.
+    int m = blas::min( m2, k );
 
     // Unused entries will be set to nan.
     scalar_t nan_ = nan("");
     scalar_t zero = 0;
 
-    int lda1 = n;
-    int lda2 = m;
-    std::vector< scalar_t > A1data( lda1*n, nan_ );
-    std::vector< scalar_t > A2data( lda2*n, zero ); // not nan, for lange
-    std::vector< scalar_t >  Tdata( ib*n,   nan_ );
+    int lda1 = k;
+    int lda2 = m2;
+    std::vector< scalar_t > A1data( lda1*k, nan_ );
+    std::vector< scalar_t > A2data( lda2*k, zero ); // not nan, for lange
+    std::vector< scalar_t >  Tdata( ib*k,   nan_ );
     slate::Tile< scalar_t >
-        A1( n,  n, A1data.data(), lda1, HostNum, slate::TileKind::UserOwned ),
-        A2( m,  n, A2data.data(), lda2, HostNum, slate::TileKind::UserOwned ),
-        T(  ib, n, Tdata.data(),  ib,   HostNum, slate::TileKind::UserOwned );
+        A1( k,  k, A1data.data(), lda1, HostNum, slate::TileKind::UserOwned ),
+        A2( m2, k, A2data.data(), lda2, HostNum, slate::TileKind::UserOwned ),
+        T(  ib, k, Tdata.data(),  ib,   HostNum, slate::TileKind::UserOwned );
 
-    // A1 is upper triangular, n-by-n.
+    // A1 is upper triangular, k-by-k.
     srand( 1234 );
-    for (int j = 0; j < n; ++j)
-        for (int i = 0; i <= j && i < n; ++i)  // upper
+    for (int j = 0; j < k; ++j)
+        for (int i = 0; i <= j && i < k; ++i)  // upper
             A1.at( i, j ) = rand() / real_t(RAND_MAX);
 
-    // A2 is upper pentagonal, m-by-n.
-    for (int j = 0; j < n; ++j)
+    // A2 is upper pentagonal, m-by-k.
+    for (int j = 0; j < k; ++j)
         for (int i = 0; i <= j + (m - l) && i < m; ++i)  // upper pent.
             A2.at( i, j ) = rand() / real_t(RAND_MAX);
 
     // || A1 ||_1 + || A2 ||_1, bound on || A ||_1.
     auto Anorm = lapack::lantr( Norm::One, Uplo::Upper,
-                                Diag::NonUnit, n, n, A1.data(), A1.stride() )
-               + lapack::lange( Norm::One, m, n, A2.data(), A2.stride() );
+                                Diag::NonUnit, k, k, A1.data(), A1.stride() )
+               + lapack::lange( Norm::One, m, k, A2.data(), A2.stride() );
 
     auto A1save = A1data;
     auto A2save = A2data;
@@ -96,12 +97,12 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
 
     //---------------------
     // Error check || Q R - A ||_1 / || A ||_1 < tol.
-    std::vector< scalar_t > R2data( lda2*n, zero );
+    std::vector< scalar_t > R2data( lda2*k, zero );
     slate::Tile< scalar_t >
-        R2( m, n, R2data.data(), lda2, HostNum, slate::TileKind::UserOwned );
+        R2( m, k, R2data.data(), lda2, HostNum, slate::TileKind::UserOwned );
 
     // Zero out R1 (A1) below diag.
-    lapack::laset( MatrixType::Lower, n-1, n-1, zero, zero,
+    lapack::laset( MatrixType::Lower, k-1, k-1, zero, zero,
                    &A1.at(1, 0), A1.stride() );
 
     // Form Ahat = Q R, where Q = I - V T V^H, V = [ I  ],  R = [ A1 ]
@@ -118,13 +119,14 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
     for (size_t i = 0; i < A2data.size(); ++i)
         R2data[i] -= A2save[i];
     auto err = lapack::lantr( Norm::One, Uplo::Upper,
-                              Diag::NonUnit, n, n, A1.data(), A1.stride() )
-             + lapack::lange( Norm::One, m, n, R2.data(), R2.stride() );
+                              Diag::NonUnit, k, k, A1.data(), A1.stride() )
+             + lapack::lange( Norm::One, m, k, R2.data(), R2.stride() );
     real_t eps = std::numeric_limits< real_t >::epsilon();
     real_t tol = 50*eps;
     if (verbose) {
-        printf( " err %8.2e, Anorm %8.2e, err/Anorm %8.2e, %s\n",
-                err, Anorm, err/Anorm, (err/Anorm < tol ? "pass" : "FAILED") );
+        printf( " err %8.2e, Anorm %8.2e, err/Anorm %8.2e, tol %8.2e, %s\n",
+                err, Anorm, err/Anorm, tol,
+                (err/Anorm < tol ? "pass" : "FAILED") );
     }
     test_assert( err/Anorm < tol );
 
@@ -135,16 +137,16 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
     // segfaults are caught, but doesn't yet check numerical error.
     // Could allocate A1, A2 as one LAPACK matrix, and C1, C2 as one LAPACK
     // matrix, then compare with LAPACK's unmqr output?
-    int ldc1 = n;
+    int ldc1 = k;
     int ldc2 = m;
-    std::vector< scalar_t > C1data( ldc1*cn );  // n-by-cn
+    std::vector< scalar_t > C1data( ldc1*cn );  // k-by-cn
     std::vector< scalar_t > C2data( ldc2*cn );  // m-by-cn
     slate::Tile< scalar_t >
-        C1( n, cn, C1data.data(), ldc1, HostNum, slate::TileKind::UserOwned ),
+        C1( k, cn, C1data.data(), ldc1, HostNum, slate::TileKind::UserOwned ),
         C2( m, cn, C2data.data(), ldc2, HostNum, slate::TileKind::UserOwned );
 
     for (int j = 0; j < cn; ++j)
-        for (int i = 0; i < n; ++i)
+        for (int i = 0; i < k; ++i)
             C1.at( i, j ) = rand() / real_t(RAND_MAX);
 
     for (int j = 0; j < cn; ++j)
@@ -176,6 +178,8 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
         }
     }
     else {
+        // LAPACK xerbla may print error, e.g.,
+        // "On entry to ZTPMQRT parameter number  2 had an illegal value"
         test_assert_throw_std(
             slate::tpmqrt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 ));
     }
@@ -183,13 +187,13 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
     //---------------------
     // Right: C = C op(Q)
     int ldd = cn;
-    std::vector< scalar_t > D1data( ldd*n );  // cn-by-n
+    std::vector< scalar_t > D1data( ldd*k );  // cn-by-k
     std::vector< scalar_t > D2data( ldd*m );  // cn-by-m
     slate::Tile< scalar_t >
-        D1( cn, n, D1data.data(), ldd, HostNum, slate::TileKind::UserOwned ),
+        D1( cn, k, D1data.data(), ldd, HostNum, slate::TileKind::UserOwned ),
         D2( cn, m, D2data.data(), ldd, HostNum, slate::TileKind::UserOwned );
 
-    for (int j = 0; j < n; ++j)
+    for (int j = 0; j < k; ++j)
         for (int i = 0; i < cn; ++i)
             D1.at( i, j ) = rand() / real_t(RAND_MAX);
 
@@ -222,6 +226,8 @@ void test_tpqrt_work( int m, int n, int l, int cn, int ib )
         }
     }
     else {
+        // LAPACK xerbla may print error, e.g.,
+        // "On entry to ZTPMQRT parameter number  2 had an illegal value"
         test_assert_throw_std(
             slate::tpmqrt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
     }
@@ -231,23 +237,23 @@ template <typename scalar_t>
 void test_tpqrt_scalar()
 {
     int cn = 13;
-    // tplqt requires ib <= n.
+    // tplqt requires ib <= k. [fixed?]
     for (int ib = 4; ib <= 8; ++ib) {
         // ts triangle-square (rectangle) kernel cases, l == 0
-        test_tpqrt_work< scalar_t >( 12, 12, 0, cn, ib );  // m == n (square)
-        test_tpqrt_work< scalar_t >(  8, 12, 0, cn, ib );  // m <  n (wide rectangle)
-        test_tpqrt_work< scalar_t >( 16, 12, 0, cn, ib );  // m >  n (tall rectangle)
+        test_tpqrt_work< scalar_t >( 12, 12, 0, cn, ib );  // m == k (square)
+        test_tpqrt_work< scalar_t >(  8, 12, 0, cn, ib );  // m <  k (wide rectangle)
+        test_tpqrt_work< scalar_t >( 16, 12, 0, cn, ib );  // m >  k (tall rectangle)
 
-        // tt triangle-triangle (trapezoid) kernel cases, l == min(m, n)
-        test_tpqrt_work< scalar_t >( 12, 12, 12, cn, ib );  // m == n (triangle)
-        test_tpqrt_work< scalar_t >(  8, 12,  8, cn, ib );  // m <  n (wide trapezoid)
-        test_tpqrt_work< scalar_t >( 16, 12, 12, cn, ib );  // m >  n (tall trapezoid)
+        // tt triangle-triangle (trapezoid) kernel cases, l == min(m, k)
+        test_tpqrt_work< scalar_t >( 12, 12, 12, cn, ib );  // m == k (triangle)
+        test_tpqrt_work< scalar_t >(  8, 12,  8, cn, ib );  // m <  k (wide trapezoid)
+        test_tpqrt_work< scalar_t >( 16, 12, 12, cn, ib );  // m >  k (tall trapezoid)
 
-        // tp triangle-pentagonal cases, l < min(m, n)
+        // tp triangle-pentagonal cases, l < min(m, k)
         // unsupported in SLATE.
-        // test_tpqrt_work< scalar_t >( 12, 12, 6, cn, ib );  // m == n
-        // test_tpqrt_work< scalar_t >(  8, 12, 6, cn, ib );  // m <  n
-        // test_tpqrt_work< scalar_t >( 16, 12, 6, cn, ib );  // m >  n
+        // test_tpqrt_work< scalar_t >( 12, 12, 6, cn, ib );  // m == k
+        // test_tpqrt_work< scalar_t >(  8, 12, 6, cn, ib );  // m <  k
+        // test_tpqrt_work< scalar_t >( 16, 12, 6, cn, ib );  // m >  k
     }
 }
 
@@ -262,7 +268,7 @@ void test_tpqrt()
 
 
 //------------------------------------------------------------------------------
-/// Test ttqrt and ttmqr.
+/// Test internal::ttqrt and internal::ttmqr.
 /// todo: test ttmqr for other sides and ops.
 ///
 template <typename scalar_t>
@@ -442,6 +448,8 @@ void test_ttqrt()
 
 //------------------------------------------------------------------------------
 /// Test unmqr.
+/// C is m-by-n. V is m-by-k (left) or n-by-k (right).
+/// This m, n, k are of the whole C or V matrix, not the individual tiles.
 ///
 template <typename scalar_t>
 void test_unmqr_work( slate::Side side, slate::Op op, int m, int n, int k )
@@ -453,6 +461,7 @@ void test_unmqr_work( slate::Side side, slate::Op op, int m, int n, int k )
                 __func__, char(side), char(op), m, n, k );
     }
 
+    assert( side == slate::Side::Left );
     assert( m >= k ); // assuming left
 
     int64_t idist = 1;
@@ -532,11 +541,13 @@ void test_unmqr_work( slate::Side side, slate::Op op, int m, int n, int k )
     if (verbose >= 2) {
         slate::print( "C - Cref",  C );
     }
-    if (verbose > 0 && mpi_rank == 0) {
-        printf( "error %.2e, Cnorm %.2e\n", error, Cnorm );
-    }
     real_t eps = std::numeric_limits<real_t>::epsilon();
     real_t tol = 50 * eps;
+    if (verbose > 0 && mpi_rank == 0) {
+        printf( "error %8.2e, Cnorm %8.2e, error/Cnorm %8.2e, tol %8.2e, %s\n",
+                error, Cnorm, error/Cnorm, tol,
+                (error/Cnorm < tol ? "pass" : "FAILED") );
+    }
     test_assert( error < tol );
 }
 
@@ -548,8 +559,8 @@ void test_unmqr()
     }
     else {
         // Try various sizes.
-        for (int m = 8; m <= 16; ++m) {
-            for (int n = 8; n <= 16; ++n) {
+        for (int m = 8; m <= 16; m += 4) {
+            for (int n = 8; n <= 16; n += 4) {
                 for (int k = 4; k < 16; k += 4) {
                     if (m >= k) {
                         test_unmqr_work<float>( slate::Side::Left, slate::Op::NoTrans,   m, n, k );
@@ -593,10 +604,10 @@ enum Section {
 
 //------------------------------------------------------------------------------
 std::vector< routines_t > routines = {
-    { "tpqrt",  test_tpqrt,  Section::qr },
-    { "ttqrt",  test_ttqrt,  Section::qr },
-    { "unmqr",  test_unmqr,  Section::qr },
-    { "",       nullptr,     Section::newline },
+    { "tile::tpqrt",     test_tpqrt,  Section::qr },
+    { "internal::ttqrt", test_ttqrt,  Section::qr },
+    { "internal::unmqr", test_unmqr,  Section::qr },
+    { "",                nullptr,     Section::newline },
 };
 
 //------------------------------------------------------------------------------
@@ -690,6 +701,10 @@ int main(int argc, char** argv)
     MPI_Comm_size(mpi_comm, &mpi_size);
 
     num_devices = blas::get_device_count();
+
+    printf( "Note: depending on xerbla implementation, this may print errors like,\n"
+            "\"On entry to CTPMQRT parameter number  2 had an illegal value\".\n"
+            "As long as these errors are caught, this is normal.\n\n" );
 
     int err = unit_test_main(mpi_comm);  // which calls run_tests()
 


### PR DESCRIPTION
When using multiple MPI ranks (see PR #48), LQ failed for certain sizes (m > n, not multiple of block size, but only some sizes):
```
slate/test> ./run_tests.py --np 4 --quick geqrf gelqf
mpirun -np 4 ./tester  --origin s --target t --ref n --nb 8 --type s,d,c,z --lookahead 1 --dim 100 --dim 100x50 --dim 50x100 gelqf
SLATE version 2022.07.00, id cc1215cd
input: ./tester --origin s --target t --ref n --nb 8 --type s,d,c,z --lookahead 1 --dim 100 --dim 100x50 --dim 50x100 gelqf
2023-05-11 22:09:34, MPI size 4, OpenMP threads 4
                                                                                                                                          
type  origin  target       m       n    nb  ib    p    q  la  pt      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
   s  scalpk    task     100     100     8  32    2    2   1   2   7.50e-09    0.00583         0.232            NA            NA  pass    
   s  scalpk    task     100      50     8  32    2    2   1   2   7.11e-09    0.00256         0.167            NA            NA  pass    
Assertion failed: (T.nb() == m), function tplqt, file Tile_tplqt.hh, line 139.
1 routines FAILED: gelqf
```

Several bugs were discovered, both in LQ and QR.
- For trapezoid case, tile life was expiring. Fix cleanup tiles and tile life in LQ, matching QR.
- Compared to QR, T matrix had random non-zero entries. Initialize tile to 0, matching QR.
- `unmlq` was not updating some cleanup tiles correctly. Fix dimensions in `tp{qr,lq,mqr,mlq}t` and update docs.

After these fixes, LQ passes:
```
slate/test> ./run_tests.py --np 4 --quick geqrf gelqf
mpirun -np 4 ./tester  --origin s --target t --ref n --nb 8 --type s,d,c,z --lookahead 1 --dim 100 --dim 100x50 --dim 50x100 gelqf
SLATE version 2022.07.00, id 1c9528fd
input: ./tester --origin s --target t --ref n --nb 8 --type s,d,c,z --lookahead 1 --dim 100 --dim 100x50 --dim 50x100 gelqf
2023-05-11 22:10:17, MPI size 4, OpenMP threads 4
                                                                                                                                          
type  origin  target       m       n    nb  ib    p    q  la  pt      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
   s  scalpk    task     100     100     8  32    2    2   1   2   1.09e-08    0.00582         0.232            NA            NA  pass    
   s  scalpk    task     100      50     8  32    2    2   1   2   8.46e-09    0.00202         0.212            NA            NA  pass    
   s  scalpk    task      50     100     8  32    2    2   1   2   2.90e-08    0.00204         0.210            NA            NA  pass    

   d  scalpk    task     100     100     8  32    2    2   1   2   3.83e-17    0.00488         0.277            NA            NA  pass    
   d  scalpk    task     100      50     8  32    2    2   1   2   1.73e-17    0.00223         0.191            NA            NA  pass    
   d  scalpk    task      50     100     8  32    2    2   1   2   4.45e-17    0.00202         0.211            NA            NA  pass    

   c  scalpk    task     100     100     8  32    2    2   1   2   9.75e-09    0.00358         1.520            NA            NA  pass    
   c  scalpk    task     100      50     8  32    2    2   1   2   9.07e-09    0.00167         1.027            NA            NA  pass    
   c  scalpk    task      50     100     8  32    2    2   1   2   2.99e-08    0.00175         0.982            NA            NA  pass    

   z  scalpk    task     100     100     8  32    2    2   1   2   1.62e-17    0.00330         1.650            NA            NA  pass    
   z  scalpk    task     100      50     8  32    2    2   1   2   1.62e-17    0.00182         0.941            NA            NA  pass    
   z  scalpk    task      50     100     8  32    2    2   1   2   3.88e-17    0.00162         1.064            NA            NA  pass    
All tests passed: gelqf
passed: gelqf
```