### PR TITLE
Do GETRF left pivoting on origin

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -239,6 +239,8 @@ public:
     Uplo uploPhysical() const;
 
     Tile<scalar_t>* originTile(int64_t i, int64_t j);
+    /// Tile origin
+    Target origin() const { return origin_; }
 
     int64_t tileMb(int64_t i) const;
     int64_t tileNb(int64_t j) const;
@@ -720,6 +722,8 @@ protected:
     Uplo uplo_;         ///< upper or lower storage
     Op op_;             ///< transpose operation with respect to original matrix
     Layout layout_;     ///< intended layout of the matrix. defaults to ColMajor.
+    Target origin_;     ///< Tile origins. defaults to Host
+
 
     /// shared storage of tiles and buffers
     std::shared_ptr< MatrixStorage<scalar_t> > storage_;
@@ -753,6 +757,7 @@ BaseMatrix<scalar_t>::BaseMatrix()
       uplo_(Uplo::General),
       op_(Op::NoTrans),
       layout_(Layout::ColMajor),
+      origin_(Target::Host),
       storage_(nullptr)
 {}
 
@@ -806,6 +811,7 @@ BaseMatrix<scalar_t>::BaseMatrix(
       uplo_(Uplo::General),
       op_(Op::NoTrans),
       layout_(Layout::ColMajor),
+      origin_(Target::Host),
       storage_(std::make_shared< MatrixStorage< scalar_t > >(
           inTileMb, inTileNb, inTileRank, inTileDevice, mpi_comm)),
       mpi_comm_(mpi_comm)
@@ -892,6 +898,7 @@ BaseMatrix<scalar_t>::BaseMatrix(
       uplo_(Uplo::General),
       op_(Op::NoTrans),
       layout_(Layout::ColMajor),
+      origin_(Target::Host),
       storage_(std::make_shared< MatrixStorage< scalar_t > >(
           m, n, mb, nb, order, nprow, npcol, mpi_comm)),
       mpi_comm_(mpi_comm)

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -841,6 +841,7 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
 template <typename scalar_t>
 void BaseTrapezoidMatrix<scalar_t>::insertLocalTiles(Target origin)
 {
+    this->origin_ = origin;
     bool on_devices = (origin == Target::Devices);
     if (on_devices)
         reserveDeviceWorkspace();

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -211,6 +211,7 @@ BaseTrapezoidMatrix<scalar_t>::BaseTrapezoidMatrix(
 {
     slate_error_if(uplo == Uplo::General);
     this->uplo_ = uplo;
+    this->origin_ = Target::Host;
 
     // ii, jj are row, col indices
     // i, j are tile (block row, block col) indices
@@ -314,6 +315,7 @@ BaseTrapezoidMatrix<scalar_t>::BaseTrapezoidMatrix(
     slate_error_if(this->num_devices() != num_devices);
     slate_error_if(uplo == Uplo::General);
     this->uplo_ = uplo;
+    this->origin_ = Target::Devices;
 
     // ii, jj are row, col indices
     // ii_local and jj_local are the local array indices in A

--- a/include/slate/BaseTriangularBandMatrix.hh
+++ b/include/slate/BaseTriangularBandMatrix.hh
@@ -285,6 +285,7 @@ void BaseTriangularBandMatrix<scalar_t>::gather(scalar_t* A, int64_t lda)
 template <typename scalar_t>
 void BaseTriangularBandMatrix<scalar_t>::insertLocalTiles(Target origin)
 {
+    this->origin_ = origin;
     bool on_devices = (origin == Target::Devices);
     auto upper = this->uplo() == Uplo::Upper;
     int64_t mt = this->mt();

--- a/include/slate/Matrix.hh
+++ b/include/slate/Matrix.hh
@@ -487,6 +487,8 @@ Matrix<scalar_t>::Matrix(
     GridOrder order, int p, int q, MPI_Comm mpi_comm, bool is_scalapack)
     : BaseMatrix<scalar_t>( m, n, mb, nb, order, p, q, mpi_comm )
 {
+    this->origin_ = Target::Host;
+
     // ii, jj are row, col indices
     // ii_local and jj_local are the local array indices in A
     // block-cyclic layout (indxg2l)
@@ -529,6 +531,8 @@ Matrix<scalar_t>::Matrix(
     : BaseMatrix<scalar_t>(m, n, mb, nb, p, q, mpi_comm)
 {
     slate_error_if(this->num_devices() != num_devices);
+
+    this->origin_ = Target::Devices;
 
     // ii, jj are row, col indices
     // ii_local and jj_local are the local array indices in A

--- a/include/slate/Matrix.hh
+++ b/include/slate/Matrix.hh
@@ -811,6 +811,8 @@ void Matrix<scalar_t>::gather(scalar_t* A, int64_t lda)
 template <typename scalar_t>
 void Matrix<scalar_t>::insertLocalTiles(Target origin)
 {
+    this->origin_ = origin;
+
     bool on_devices = (origin == Target::Devices);
     if (on_devices)
         reserveDeviceWorkspace();

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -158,9 +158,16 @@ void getrf(
                 {
                     // swap rows in A(k:mt-1, 0:k-1)
                     const int tag_0 = 0;
-                    internal::permuteRows<Target::HostTask>(
-                        Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
-                        host_layout, priority_0, tag_0, queue_0 );
+                    if (A.origin() == Target::Devices && target == Target::Devices) {
+                        internal::permuteRows<Target::Devices>(
+                            Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
+                            target_layout, priority_0, tag_0, queue_0 );
+                    }
+                    else {
+                        internal::permuteRows<Target::HostTask>(
+                            Direction::Forward, A.sub(k, A_mt-1, 0, k-1), pivots.at(k),
+                            host_layout, priority_0, tag_0, queue_0 );
+                    }
                 }
             }
             // update trailing submatrix, normal priority


### PR DESCRIPTION
Here are the changes we talked about at the end of last week to address the performance of getrf with GPU-aware MPI.

I didn't apply the change for `target=Host, origin=devices` since I'm assuming we don't care about the performance of that case and we'd need to add a `gpu_layout`.  I can add it if you guys feel that would be beneficial.

One thing I noticed is that `BandMatrix` doesn't have any form of `insertLocalTiles` or `from(Sca)LAPACK`.  So, there isn't a way to set the origin there.