### PR TITLE
gbmm: fix zeroOutsideBand in tester

### DIFF
--- a/test/band_utils.hh
+++ b/test/band_utils.hh
@@ -129,15 +129,20 @@ void zeroOutsideBand(
     for (int64_t jj = 0; jj < n; ++jj) {
         int pcol = (jj / nb) % q;
         if (pcol == mycol) {
-            int64_t jlocal = global2local(jj, nb, q, mycol);
+            int64_t jlocal = global2local( jj, nb, q, mycol );
 
             // set rows [0 : k - ku - 1] = 0
-            int64_t i0 = max(global2local(0,       nb, p, myrow), 0);
-            int64_t i1 = min(global2local(jj - ku, nb, p, myrow), m);
+            int64_t i0 = global2local( 0,       nb, p, myrow );
+            int64_t i1 = global2local( jj - ku, nb, p, myrow );
 
             // set rows [k + kl + 1 : m - 1] = 0
-            int64_t i2 = max(global2local(jj + kl + 1, nb, p, myrow), 0);
-            int64_t i3 = min(global2local(m,           nb, p, myrow), m);
+            int64_t i2 = global2local( jj + kl + 1, nb, p, myrow );
+            int64_t i3 = global2local( m,           nb, p, myrow );
+
+            i0 = min( max( i0, 0 ), lldA );
+            i1 = min( max( i1, 0 ), lldA );
+            i2 = min( max( i2, 0 ), lldA );
+            i3 = min( max( i3, 0 ), lldA );
 
             for (int64_t i = i0; i < i1; ++i) {
                 A[ i + jlocal*lldA ] = 0;
@@ -204,37 +209,44 @@ void zeroOutsideBand(
     for (int64_t jj = 0; jj < n; ++jj) {
         int pcol = (jj / nb) % q;
         if (pcol == mycol) {
-            int64_t jlocal = global2local(jj, nb, q, mycol);
+            int64_t jlocal = global2local( jj, nb, q, mycol );
 
             if (uplo == slate::Uplo::Upper) {
                 // set rows [0 : k - kd - 1] = 0
-                int64_t i0 = max(global2local(0,       nb, p, myrow), 0);
-                int64_t i1 = min(global2local(jj - kd, nb, p, myrow), n);
+                int64_t i0 = global2local( 0,          nb, p, myrow );
+                int64_t i1 = global2local( jj - kd,    nb, p, myrow );
+                int64_t i2 = global2local( jj + 0 + 1, nb, p, myrow );
+                int64_t i3 = global2local( n,          nb, p, myrow );
+
+                i0 = min( max( i0, 0 ), lldA );
+                i1 = min( max( i1, 0 ), lldA );
+                i2 = min( max( i2, 0 ), lldA );
+                i3 = min( max( i3, 0 ), lldA );
 
                 for (int64_t i = i0; i < i1; ++i) {
                     A[ i + jlocal*lldA ] = 0;
                 }
-
-                int64_t i2 = max(global2local(jj + 0 + 1, nb, p, myrow), 0);
-                int64_t i3 = min(global2local(n,          nb, p, myrow), n);
-
                 for (int64_t i = i2; i < i3; ++i) {
                     A[ i + jlocal*lldA ] = 0;
                 }
 
             }
             else if (uplo == slate::Uplo::Lower) {
-                int64_t i0 = max(global2local(0,       nb, p, myrow), 0);
-                int64_t i1 = min(global2local(jj - 0,  nb, p, myrow), n);
+                int64_t i0 = global2local( 0,       nb, p, myrow );
+                int64_t i1 = global2local( jj - 0,  nb, p, myrow );
+
+                // set rows [k + kd + 1 : m - 1] = 0
+                int64_t i2 = global2local( jj + kd + 1, nb, p, myrow );
+                int64_t i3 = global2local( n,           nb, p, myrow );
+
+                i0 = min( max( i0, 0 ), lldA );
+                i1 = min( max( i1, 0 ), lldA );
+                i2 = min( max( i2, 0 ), lldA );
+                i3 = min( max( i3, 0 ), lldA );
 
                 for (int64_t i = i0; i < i1; ++i) {
                     A[ i + jlocal*lldA ] = 0;
                 }
-
-                // set rows [k + kd + 1 : m - 1] = 0
-                int64_t i2 = max(global2local(jj + kd + 1, nb, p, myrow), 0);
-                int64_t i3 = min(global2local(n,           nb, p, myrow), n);
-
                 for (int64_t i = i2; i < i3; ++i) {
                     A[ i + jlocal*lldA ] = 0;
                 }


### PR DESCRIPTION
When using multiple MPI ranks (see PR #48), `gbmm` segfaulted. It turned out in the tester, `zeroOutsideBand` was setting values outside the array, because `global2local` returns values outside [ 0, m_local ]. The solution here is to do min and max to keep within range [ 0, lldA ], since lldA is readily available but m_local is not. Tests with 4 MPI ranks pass:
```
pangolin slate/test> ./run_tests.py --type s --quick --np 4 gbmm
Sat May 13 10:48:00 2023
--------------------------------------------------------------------------------
mpirun -np 4 ./tester  --origin s --target t --ref n --nb 8 --type s --lookahead 1 --transA n,t,c --transB n,t,c --dim 100 --dim 100x50 --dim 50x100 --dim 25x50x75 --kl 20,100 --ku 20,100 gbmm
SLATE version 2022.07.00, id 580ccde5
input: ./tester --origin s --target t --ref n --nb 8 --type s --lookahead 1 --transA n,t,c --transB n,t,c --dim 100 --dim 100x50 --dim 50x100 --dim 25x50x75 --kl 20,100 --ku 20,100 gbmm
2023-05-13 10:48:00, MPI size 4, OpenMP threads 4
                                                                                                                                                                                                  
type  origin  target   transA   transB       m       n       k      kl      ku      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
   s  scalpk    task  notrans  notrans     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00210         0.350       0.00481         0.153  pass    
   s  scalpk    task  notrans  notrans     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00210         0.650       0.00324         0.423  pass    
   s  scalpk    task  notrans  notrans     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00154         0.889       0.00379         0.361  pass    
   s  scalpk    task  notrans  notrans     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00176         1.136       0.00334         0.600  pass    
   s  scalpk    task  notrans  notrans     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000424         0.434       0.00207        0.0889  pass    
   s  scalpk    task  notrans  notrans     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000515         0.194       0.00228        0.0439  pass    
   s  scalpk    task  notrans  notrans     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000682         0.669       0.00181         0.252  pass    
   s  scalpk    task  notrans  notrans     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000676         0.551       0.00139         0.268  pass    
   s  scalpk    task  notrans  notrans      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000774         0.475       0.00288         0.128  pass    
   s  scalpk    task  notrans  notrans      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00128         0.714       0.00119         0.770  pass    
   s  scalpk    task  notrans  notrans      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000793         0.252       0.00108         0.185  pass    
   s  scalpk    task  notrans  notrans      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00106         0.703       0.00113         0.658  pass    
   s  scalpk    task  notrans  notrans      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000482         0.169      0.000566         0.144  pass    
   s  scalpk    task  notrans  notrans      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000529         0.291       0.00376        0.0410  pass    
   s  scalpk    task  notrans  notrans      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000441        -0.459      0.000649        -0.312  pass    
   s  scalpk    task  notrans  notrans      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000485        -0.268       0.00190       -0.0683  pass    
   s  scalpk    task  notrans    trans     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00156         0.472       0.00177         0.416  pass    
   s  scalpk    task  notrans    trans     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00137         0.997       0.00439         0.312  pass    
   s  scalpk    task  notrans    trans     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00138         0.991       0.00172         0.794  pass    
   s  scalpk    task  notrans    trans     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00168         1.188       0.00177         1.129  pass    
   s  scalpk    task  notrans    trans     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000541         0.340       0.00161         0.114  pass    
   s  scalpk    task  notrans    trans     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000554         0.181       0.00143        0.0700  pass    
   s  scalpk    task  notrans    trans     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000528         0.865      0.000543         0.841  pass    
   s  scalpk    task  notrans    trans     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00211         0.176       0.00130         0.286  pass    
   s  scalpk    task  notrans    trans      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000735         0.501      0.000937         0.393  pass    
   s  scalpk    task  notrans    trans      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000911         1.002       0.00267         0.342  pass    
   s  scalpk    task  notrans    trans      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000706         0.283      0.000907         0.221  pass    
   s  scalpk    task  notrans    trans      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00142         0.527       0.00100         0.742  pass    
   s  scalpk    task  notrans    trans      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00156        0.0521       0.00495        0.0165  pass    
   s  scalpk    task  notrans    trans      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00169        0.0910       0.00145         0.106  pass    
   s  scalpk    task  notrans    trans      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00133        -0.152       0.00300       -0.0675  pass    
   s  scalpk    task  notrans    trans      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00298       -0.0436       0.00476       -0.0273  pass    
   s  scalpk    task  notrans     conj     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00435         0.169        0.0160        0.0460  pass    
   s  scalpk    task  notrans     conj     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00927         0.148       0.00596         0.229  pass    
   s  scalpk    task  notrans     conj     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00417         0.328       0.00467         0.293  pass    
   s  scalpk    task  notrans     conj     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00330         0.607       0.00328         0.609  pass    
   s  scalpk    task  notrans     conj     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00166         0.111       0.00283        0.0650  pass    
   s  scalpk    task  notrans     conj     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00316        0.0317       0.00420        0.0238  pass    
   s  scalpk    task  notrans     conj     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00409         0.112       0.00591        0.0773  pass    
   s  scalpk    task  notrans     conj     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00254         0.147       0.00773        0.0482  pass    
   s  scalpk    task  notrans     conj      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00831        0.0443       0.00490        0.0752  pass    
   s  scalpk    task  notrans     conj      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00203         0.450       0.00323         0.283  pass    
   s  scalpk    task  notrans     conj      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00145         0.138       0.00323        0.0619  pass    
   s  scalpk    task  notrans     conj      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00217         0.343       0.00303         0.246  pass    
   s  scalpk    task  notrans     conj      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00457        0.0178       0.00269        0.0303  pass    
   s  scalpk    task  notrans     conj      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00440        0.0350       0.00179        0.0861  pass    
   s  scalpk    task  notrans     conj      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000724        -0.280       0.00178        -0.114  pass    
   s  scalpk    task  notrans     conj      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000899        -0.145        0.0102       -0.0127  pass    
   s  scalpk    task    trans  notrans     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00     0.0171        0.0430        0.0151        0.0489  pass    
   s  scalpk    task    trans  notrans     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00697         0.196       0.00375         0.365  pass    
   s  scalpk    task    trans  notrans     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00242         0.566       0.00355         0.385  pass    
   s  scalpk    task    trans  notrans     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00302         0.662       0.00340         0.588  pass    
   s  scalpk    task    trans  notrans     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000912         0.202       0.00176         0.104  pass    
   s  scalpk    task    trans  notrans     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00130        0.0767       0.00220        0.0454  pass    
   s  scalpk    task    trans  notrans     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00105         0.434       0.00182         0.251  pass    
   s  scalpk    task    trans  notrans     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00125         0.297       0.00179         0.209  pass    
   s  scalpk    task    trans  notrans      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00137         0.269       0.00293         0.126  pass    
   s  scalpk    task    trans  notrans      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00142         0.644       0.00277         0.329  pass    
   s  scalpk    task    trans  notrans      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00213        0.0940       0.00239        0.0835  pass    
   s  scalpk    task    trans  notrans      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00191         0.391       0.00330         0.226  pass    
   s  scalpk    task    trans  notrans      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000833        0.0978       0.00184        0.0443  pass    
   s  scalpk    task    trans  notrans      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000650         0.237       0.00133         0.115  pass    
   s  scalpk    task    trans  notrans      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00111        -0.183       0.00169        -0.120  pass    
   s  scalpk    task    trans  notrans      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00100        -0.130       0.00150       -0.0867  pass    
   s  scalpk    task    trans    trans     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00273         0.270       0.00441         0.167  pass    
   s  scalpk    task    trans    trans     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00295         0.463       0.00501         0.273  pass    
   s  scalpk    task    trans    trans     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00269         0.509       0.00420         0.325  pass    
   s  scalpk    task    trans    trans     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00339         0.590       0.00377         0.531  pass    
   s  scalpk    task    trans    trans     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000845         0.218       0.00190        0.0970  pass    
   s  scalpk    task    trans    trans     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00145        0.0691       0.00199        0.0501  pass    
   s  scalpk    task    trans    trans     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00108         0.421       0.00192         0.237  pass    
   s  scalpk    task    trans    trans     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00330         0.113       0.00199         0.187  pass    
   s  scalpk    task    trans    trans      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00161         0.229       0.00326         0.113  pass    
   s  scalpk    task    trans    trans      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00159         0.574       0.00293         0.312  pass    
   s  scalpk    task    trans    trans      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00210        0.0952       0.00308        0.0649  pass    
   s  scalpk    task    trans    trans      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00224         0.332       0.00318         0.234  pass    
   s  scalpk    task    trans    trans      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000850        0.0959       0.00177        0.0459  pass    
   s  scalpk    task    trans    trans      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000748         0.206       0.00204        0.0756  pass    
   s  scalpk    task    trans    trans      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00109        -0.186       0.00354       -0.0571  pass    
   s  scalpk    task    trans    trans      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00438       -0.0297       0.00153       -0.0848  pass    
   s  scalpk    task    trans     conj     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00     0.0179        0.0412        0.0124        0.0595  pass    
   s  scalpk    task    trans     conj     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00888         0.154       0.00427         0.320  pass    
   s  scalpk    task    trans     conj     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00293         0.467       0.00414         0.330  pass    
   s  scalpk    task    trans     conj     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00312         0.642       0.00429         0.467  pass    
   s  scalpk    task    trans     conj     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00110         0.167       0.00210        0.0876  pass    
   s  scalpk    task    trans     conj     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00129        0.0776       0.00197        0.0509  pass    
   s  scalpk    task    trans     conj     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00204         0.224       0.00945        0.0483  pass    
   s  scalpk    task    trans     conj     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00100         0.373       0.00793        0.0470  pass    
   s  scalpk    task    trans     conj      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00167         0.221       0.00490        0.0752  pass    
   s  scalpk    task    trans     conj      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00199         0.459       0.00262         0.349  pass    
   s  scalpk    task    trans     conj      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00275        0.0727       0.00337        0.0593  pass    
   s  scalpk    task    trans     conj      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00227         0.329       0.00307         0.243  pass    
   s  scalpk    task    trans     conj      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000714         0.114       0.00167        0.0488  pass    
   s  scalpk    task    trans     conj      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000702         0.219       0.00186        0.0830  pass    
   s  scalpk    task    trans     conj      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00104        -0.194       0.00171        -0.119  pass    
   s  scalpk    task    trans     conj      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00106        -0.122       0.00187       -0.0694  pass    
   s  scalpk    task     conj  notrans     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00191         0.386       0.00307         0.240  pass    
   s  scalpk    task     conj  notrans     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00224         0.611       0.00501         0.273  pass    
   s  scalpk    task     conj  notrans     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00289         0.473       0.00486         0.281  pass    
   s  scalpk    task     conj  notrans     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00333         0.600       0.00506         0.395  pass    
   s  scalpk    task     conj  notrans     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00183         0.101       0.00272        0.0678  pass    
   s  scalpk    task     conj  notrans     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00110        0.0908       0.00188        0.0531  pass    
   s  scalpk    task     conj  notrans     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00123         0.371       0.00227         0.201  pass    
   s  scalpk    task     conj  notrans     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00163         0.228       0.00230         0.162  pass    
   s  scalpk    task     conj  notrans      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00154         0.238       0.00292         0.126  pass    
   s  scalpk    task     conj  notrans      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00163         0.562       0.00443         0.206  pass    
   s  scalpk    task     conj  notrans      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00291        0.0686       0.00398        0.0502  pass    
   s  scalpk    task     conj  notrans      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00282         0.264       0.00345         0.216  pass    
   s  scalpk    task     conj  notrans      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00103        0.0792       0.00183        0.0446  pass    
   s  scalpk    task     conj  notrans      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00152         0.102       0.00154        0.0998  pass    
   s  scalpk    task     conj  notrans      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00105        -0.193       0.00198        -0.102  pass    
   s  scalpk    task     conj  notrans      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00150       -0.0868       0.00182       -0.0714  pass    
   s  scalpk    task     conj    trans     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00254         0.290       0.00557         0.132  pass    
   s  scalpk    task     conj    trans     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00307         0.446       0.00411         0.333  pass    
   s  scalpk    task     conj    trans     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00274         0.500       0.00468         0.292  pass    
   s  scalpk    task     conj    trans     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00313         0.639       0.00399         0.501  pass    
   s  scalpk    task     conj    trans     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00119         0.155       0.00236        0.0779  pass    
   s  scalpk    task     conj    trans     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00149        0.0670       0.00234        0.0427  pass    
   s  scalpk    task     conj    trans     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00181         0.252       0.00200         0.228  pass    
   s  scalpk    task     conj    trans     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00127         0.293       0.00295         0.126  pass    
   s  scalpk    task     conj    trans      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00202         0.182       0.00426        0.0864  pass    
   s  scalpk    task     conj    trans      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00212         0.430       0.00462         0.197  pass    
   s  scalpk    task     conj    trans      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00397        0.0504       0.00430        0.0465  pass    
   s  scalpk    task     conj    trans      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00483         0.154       0.00328         0.227  pass    
   s  scalpk    task     conj    trans      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00110        0.0744       0.00234        0.0349  pass    
   s  scalpk    task     conj    trans      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00115         0.133       0.00210        0.0732  pass    
   s  scalpk    task     conj    trans      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00148        -0.137       0.00191        -0.106  pass    
   s  scalpk    task     conj    trans      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00130       -0.0998       0.00201       -0.0647  pass    
   s  scalpk    task     conj     conj     100     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00375         0.196       0.00370         0.199  pass    
   s  scalpk    task     conj     conj     100     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00400         0.342       0.00597         0.229  pass    
   s  scalpk    task     conj     conj     100     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00333         0.411       0.00466         0.294  pass    
   s  scalpk    task     conj     conj     100     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00534         0.375       0.00453         0.441  pass    
   s  scalpk    task     conj     conj     100      50      50      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00104         0.177       0.00242        0.0760  pass    
   s  scalpk    task     conj     conj     100      50      50      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00215        0.0465       0.00322        0.0310  pass    
   s  scalpk    task     conj     conj     100      50      50     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00169         0.270       0.00243         0.188  pass    
   s  scalpk    task     conj     conj     100      50      50     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00136         0.275       0.00248         0.150  pass    
   s  scalpk    task     conj     conj      50     100     100      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00186         0.198       0.00406        0.0906  pass    
   s  scalpk    task     conj     conj      50     100     100      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00162         0.562       0.00394         0.232  pass    
   s  scalpk    task     conj     conj      50     100     100     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00319        0.0628       0.00452        0.0443  pass    
   s  scalpk    task     conj     conj      50     100     100     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00287         0.259       0.00333         0.224  pass    
   s  scalpk    task     conj     conj      25      50      75      20      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000771         0.106       0.00176        0.0464  pass    
   s  scalpk    task     conj     conj      25      50      75      20     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00   0.000955         0.161       0.00167        0.0923  pass    
   s  scalpk    task     conj     conj      25      50      75     100      20   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00148        -0.137       0.00191        -0.106  pass    
   s  scalpk    task     conj     conj      25      50      75     100     100   3.1+1.4i   2.7+1.7i     8    2    2   1   0.00e+00    0.00139       -0.0938       0.00202       -0.0644  pass    
All tests passed: gbmm
```