### PR TITLE
Print complex numbers fix

### DIFF
--- a/src/print.cc
+++ b/src/print.cc
@@ -267,6 +267,7 @@ void send_recv_tile(
     if (tile_rank != 0) {
         if (A.tileIsLocal(i, j)) {
             try {
+                A.tileGetForReading( i, j, LayoutConvert::None );
                 auto T = A(i, j);
                 err = MPI_Send( &flag_exist, 1, MPI_INT, 0, 0, comm );
                 slate_assert(err == 0);

--- a/src/print.cc
+++ b/src/print.cc
@@ -102,8 +102,8 @@ int snprintf_value(
 
         l = snprintf_value( buf, buf_len, width, precision, im );
         len     += l;
-        buf     += len;
-        buf_len -= len;
+        buf     += l;
+        buf_len -= l;
 
         l = snprintf( buf, buf_len, "i" );
         len += l;


### PR DESCRIPTION
When printing complex numbers, the `i` was being left off. The `buf` and `buf_len` were incremented by the wrong value.

**Before:**
```
slate/test> ./tester --dim 2 --verbose 4 --type c gemm
SLATE version 2022.07.00, id cc1215cd
...
C_out = [
     0.8788 +     5.4334    -0.0757 +     4.6075
    -0.2857 +     4.9629    -1.5520 +     8.4006
];
```
**After:**
```
slate/test> ./tester --dim 2 --verbose 4 --type c gemm
SLATE version 2022.07.00, id 82a4b7d9
C_out = [
    -1.8994 +     8.1239i    -1.8884 +     5.9303i
    -0.6405 +     5.4799i     0.7901 +     3.9769i
];
```

Also cleans up the code. `slate::` is unnecessary since `print` is in the `slate` namespace. (At one point it was in the test directory, outside the `slate` namespace.) Options like `width` can be `int` instead of `int64_t`, which avoids the need to cast them when using in `printf`.

Also fixes a hang if tile is on device. It wasn't doing `tileGetForReading`.