### PR TITLE
move to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Pending
+  - Moved repo to <https://github.com/icl-utk-edu/slate>
+  - Fixed `gemm` and `trsm` when n is small
+
 2022.07.00
   - Improved performance of QR factorization on GPUs by moving panel to GPU:
     5.5x faster on tall-skinny problem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,4 @@
-# CMake script for SLATE library
-# repo: http://bitbucket.org/icl/slate
-# Requires BLAS++ library from
-#     http://bitbucket.org/icl/blaspp
-# Requires LAPACK++ library from
-#     http://bitbucket.org/icl/lapackpp
-# Tests require TestSweeper library from
-#     http://bitbucket.org/icl/testsweeper
+# CMake script for SLATE library. See INSTALL.md for directions.
 
 cmake_minimum_required( VERSION 3.18 )
 # 3.1  target_compile_features

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,11 +8,11 @@ Synopsis
 
 Checkout or download. SLATE uses git modules, which require an update step:
 
-    git clone --recursive https://bitbucket.org/icl/slate
+    git clone --recursive https://github.com/icl-utk-edu/slate.git
 
 or
 
-    git clone https://bitbucket.org/icl/slate
+    git clone https://github.com/icl-utk-edu/slate.git
     git submodule update --init
 
 If you have an existing git repository and pull updates, you may need to
@@ -21,8 +21,8 @@ also update submodules, if they changed:
     git pull
     git submodule update
 
-Or download the release tar file, which includes BLAS++ and LAPACK++, from
-[downloads](https://bitbucket.org/icl/slate/downloads/).
+Or download a [release tar file](https://github.com/icl-utk-edu/slate/releases),
+which includes BLAS++ and LAPACK++.
 
 --------------------------------------------------------------------------------
 
@@ -70,7 +70,7 @@ These include:
 Options (Makefile and CMake)
 --------------------------------------------------------------------------------
 
-See the BLAS++ [INSTALL.md](https://bitbucket.org/icl/blaspp/src/master/INSTALL.md)
+See the BLAS++ [INSTALL.md](https://github.com/icl-utk-edu/blaspp/blob/master/INSTALL.md)
 for its options, which include:
 
 (Note: SLATE's Makefile uses 1 or 0 instead of yes or no. CMake can use either.)
@@ -144,7 +144,7 @@ for its options, which include:
         yes             (default with CMake)
         no
 
-See the LAPACK++ [INSTALL.md](https://bitbucket.org/icl/lapackpp/src/master/INSTALL.md)
+See the LAPACK++ [INSTALL.md](https://github.com/icl-utk-edu/lapackpp/blob/master/INSTALL.md)
 for its options, which include:
 
     lapack [CMake only]
@@ -292,9 +292,9 @@ directory under the SLATE root directory:
     make install
 
 SLATE uses the
-[BLAS++](https://bitbucket.org/icl/blaspp),
-[LAPACK++](https://bitbucket.org/icl/lapackpp), and
-[TestSweeper](https://bitbucket.org/icl/testsweeper) libraries.
+[BLAS++](https://github.com/icl-utk-edu/blaspp),
+[LAPACK++](https://github.com/icl-utk-edu/lapackpp), and
+[TestSweeper](https://github.com/icl-utk-edu/testsweeper) libraries.
 These are generally checked out as git submodules in the slate directory,
 so the user does not have to install them beforehand. If CMake finds already
 installed versions, it will use those instead of compiling new versions.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ For assistance, visit the *SLATE User Forum* at
 Join by signing in with your Google credentials, then clicking
 *Join group to post*.
 
-Bug reports can be filed directly on Bitbucket's issue tracker:
-<https://bitbucket.org/icl/slate/issues?status=new&status=open>.
+Bug reports can be filed directly on GitHub's issue tracker:
+<https://github.com/icl-utk-edu/slate/issues>.
 
 * * *
 
@@ -86,9 +86,9 @@ Resources
   for more information about the SLATE project.
 * Visit the [SLATE Working Notes](http://www.icl.utk.edu/publications/series/swans)
   to find out more about ongoing SLATE developments.
-* Visit the [BLAS++ repository](https://bitbucket.org/icl/blaspp)
+* Visit the [BLAS++ repository](https://github.com/icl-utk-edu/blaspp)
   for more information about the C++ API for BLAS.
-* Visit the [LAPACK++ repository](https://bitbucket.org/icl/lapackpp)
+* Visit the [LAPACK++ repository](https://github.com/icl-utk-edu/lapackpp)
   for more information about the C++ API for LAPACK.
 * Visit the [ECP website](https://exascaleproject.org)
   to find out more about the DOE Exascale Computing Initiative.
@@ -99,7 +99,7 @@ Contributing
 --------------------------------------------------------------------------------
 
 The SLATE project welcomes contributions from new developers.
-Contributions can be offered through the standard Bitbucket pull request model.
+Contributions can be offered through the standard GitHub pull request model.
 We strongly encourage you to coordinate large contributions with the SLATE
 development team early in the process.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,7 @@ if (NOT TARGET testsweeper)
                           "${CMAKE_BINARY_DIR}/testsweeper" )
 
     else()
-        set( url "https://bitbucket.org/icl/testsweeper" )
+        set( url "https://github.com/icl-utk-edu/testsweeper.git" )
         message( "" )
         message( "---------- TestSweeper" )
         message( STATUS "Fetching TestSweeper from ${url}" )


### PR DESCRIPTION
Changes URLs from bitbucket.org to github.com.

A few stray pointers remain to bitbucket static files (ignoring the unused sphinx docs):
```
slate> git grep bitbucket.org | grep -v 'sphinx'
README.md:* [Tutorial with sample codes for using SLATE](https://bitbucket.org/icl/slate-tutorial/)
examples/README.md:[SLATE tutorial presentation](https://bitbucket.org/icl/slate/downloads/2023-02-ecp-slate-tutorial.pdf)
tools/check-style-hook.py:# See https://bitbucket.org/icl/style/wiki/ICL_C_CPP_Coding_Style_Guide
unit_test/test_TrapezoidMatrix.cc:/// https://bitbucket.org/icl/slate/issues/45
```