### PR TITLE
gemmA, hemmA, trsmA throw with multiple devices

### DIFF
--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -62,6 +62,9 @@ void gemmA(
     const int queue_0 = 0;
 
     if (target == Target::Devices) {
+        if (A.num_devices() > 1)
+            slate_not_implemented( "gemmA doesn't support multiple GPUs" );
+
         A.allocateBatchArrays();
         A.reserveDeviceWorkspace();
     }

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -66,8 +66,10 @@ void hemmA(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
 
-
     if (target == Target::Devices) {
+        if (A.num_devices() > 1)
+            slate_not_implemented( "hemmA doesn't support multiple GPUs" );
+
         C.allocateBatchArrays();
         C.reserveDeviceWorkspace();
     }

--- a/src/trsmA.cc
+++ b/src/trsmA.cc
@@ -30,6 +30,9 @@ void trsmA(
     opts_local[ Option::Lookahead ] = lookahead;
 
     if (target == Target::Devices) {
+        if (A.num_devices() > 1)
+            slate_not_implemented( "trsmA doesn't support multiple GPUs" );
+
         // Allocate batch arrays = number of kernels without
         // lookahead + lookahead
         // number of kernels without lookahead = 2

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -335,27 +335,40 @@ cmds = []
 if (opts.blas3):
     cmds += [
     [ 'gbmm',  gen + dtype + la + transA + transB + mnk + ab + kl + ku ],
+
     [ 'gemm',  gen + dtype + la + transA + transB + mnk + ab ],
-    [ 'gemmA', origin + grid + check + ref + tol + repeat + nb + dtype + la + transA + transB + mnk + ab + ' --target=t' ],
+    [ 'gemmA', gen + dtype + la + transA + transB + mnk + ab ],
+    [ 'gemmC', gen + dtype + la + transA + transB + mnk + ab ],
 
     [ 'hemm',  gen + dtype         + la + side + uplo     + mn + ab ],
+    # todo: hemmA GPU support
+    [ 'hemmA', gen_no_target + dtype + la + side + uplo     + mn + ab ],
+    [ 'hemmC', gen + dtype         + la + side + uplo     + mn + ab ],
+
     [ 'hbmm',  gen + dtype         + la + side + uplo     + mn + ab + kd ],
+
     [ 'herk',  gen + dtype_real    + la + uplo + trans    + mn + ab ],
     [ 'herk',  gen + dtype_complex + la + uplo + trans_nc + mn + ab ],
+
     [ 'her2k', gen + dtype_real    + la + uplo + trans    + mn + ab ],
     [ 'her2k', gen + dtype_complex + la + uplo + trans_nc + mn + ab ],
 
     [ 'symm',  gen + dtype         + la + side + uplo     + mn + ab ],
+
     [ 'syr2k', gen + dtype_real    + la + uplo + trans    + mn + ab ],
     [ 'syr2k', gen + dtype_complex + la + uplo + trans_nt + mn + ab ],
+
     [ 'syrk',  gen + dtype_real    + la + uplo + trans    + mn + ab ],
     [ 'syrk',  gen + dtype_complex + la + uplo + trans_nt + mn + ab ],
 
     # todo: tbsm fails for nb=8 or 16 with --quick.
     [ 'tbsm',  gen_no_nb + ' --nb 32' + dtype + la + side + uplo + transA + diag + mn + a + kd ],
+
     [ 'trmm',  gen + dtype + la + side + uplo + transA + diag + mn + a ],
+
     [ 'trsm',  gen + dtype + la + side + uplo + transA + diag + mn + a ],
     [ 'trsmA', gen + dtype + la + side + uplo + transA + diag + mn + a ],
+    [ 'trsmB', gen + dtype + la + side + uplo + transA + diag + mn + a ],
     ]
 
 # LU

--- a/test/test.cc
+++ b/test/test.cc
@@ -86,11 +86,13 @@ std::vector< testsweeper::routines_t > routines = {
     // Level 3 BLAS
     { "gemm",               test_gemm,         Section::blas3 },
     { "gemmA",              test_gemm,         Section::blas3 },
+    { "gemmC",              test_gemm,         Section::blas3 },
     { "gbmm",               test_gbmm,         Section::blas3 },
     { "",                   nullptr,           Section::newline },
 
     { "hemm",               test_hemm,         Section::blas3 },
     { "hemmA",              test_hemm,         Section::blas3 },
+    { "hemmC",              test_hemm,         Section::blas3 },
     { "hbmm",               test_hbmm,         Section::blas3 },
     { "herk",               test_herk,         Section::blas3 },
     { "her2k",              test_her2k,        Section::blas3 },
@@ -104,6 +106,7 @@ std::vector< testsweeper::routines_t > routines = {
     { "trmm",               test_trmm,         Section::blas3 },
     { "trsm",               test_trsm,         Section::blas3 },
     { "trsmA",              test_trsm,         Section::blas3 },
+    { "trsmB",              test_trsm,         Section::blas3 },
     { "tbsm",               test_tbsm,         Section::blas3 },
 
     // -----

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -28,6 +28,12 @@ void test_gemm_work(Params& params, bool run)
     // Constants
     const scalar_t zero = 0.0, one = 1.0;
 
+    // Decode routine, setting method.
+    if (params.routine == "gemmA")
+        params.method_gemm() = slate::MethodGemm::GemmA;
+    else if (params.routine == "gemmC")
+        params.method_gemm() = slate::MethodGemm::GemmC;
+
     // get & mark input values
     slate::Op transA = params.transA();
     slate::Op transB = params.transB();
@@ -70,8 +76,8 @@ void test_gemm_work(Params& params, bool run)
 
     slate::Options const opts =  {
         {slate::Option::Lookahead, lookahead},
+        {slate::Option::Target, target},
         {slate::Option::MethodGemm, method_gemm},
-        {slate::Option::Target, target}
     };
 
     // Error analysis applies in these norms.
@@ -221,17 +227,9 @@ void test_gemm_work(Params& params, bool run)
         // Run SLATE test.
         // C = alpha A B + beta C.
         //==================================================
-        if (params.routine == "gemm") {
-            slate::multiply(
-                alpha, A, B, beta, C, opts);
-            // Using traditional BLAS/LAPACK name
-            // slate::gemm(
-            //     alpha, A, B, beta, C, opts);
-        }
-        else if (params.routine == "gemmA") {
-            slate::gemmA(
-                alpha, A, B, beta, C, opts);
-        }
+        slate::multiply( alpha, A, B, beta, C, opts );
+        // Using traditional BLAS/LAPACK name
+        // slate::gemm( alpha, A, B, beta, C, opts );
 
         time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -28,6 +28,12 @@ void test_hemm_work(Params& params, bool run)
     // Constants
     const scalar_t zero = 0.0, one = 1.0;
 
+    // Decode routine, setting method.
+    if (params.routine == "hemmA")
+        params.method_hemm() = slate::MethodHemm::HemmA;
+    else if (params.routine == "hemmC")
+        params.method_hemm() = slate::MethodHemm::HemmC;
+
     // get & mark input values
     slate::Side side = params.side();
     slate::Uplo uplo = params.uplo();
@@ -47,6 +53,7 @@ void test_hemm_work(Params& params, bool run)
     int verbose = params.verbose();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
+    slate::Method method_hemm = params.method_hemm();
     params.matrix.mark();
     params.matrixB.mark();
     params.matrixC.mark();
@@ -67,8 +74,9 @@ void test_hemm_work(Params& params, bool run)
     slate::Options const opts =  {
         {slate::Option::Lookahead, lookahead},
         {slate::Option::Target, target},
+        {slate::Option::MethodHemm, method_hemm},
         // TODO fix gemmA on device
-        {slate::Option::MethodGemm, slate::MethodGemm::GemmC}
+        //{slate::Option::MethodGemm, slate::MethodGemm::GemmC}
     };
 
     // Error analysis applies in these norms.
@@ -204,17 +212,12 @@ void test_hemm_work(Params& params, bool run)
     // C = alpha A B + beta C (left) or
     // C = alpha B A + beta C (right).
     //==================================================
-    if (params.routine == "hemm") {
-        if (side == slate::Side::Left)
-            slate::multiply(alpha, A, B, beta, C, opts);
-        else if (side == slate::Side::Right)
-            slate::multiply(alpha, B, A, beta, C, opts);
-        else
-            throw slate::Exception("unknown side");
-    }
-    else if (params.routine == "hemmA") {
-        slate::hemmA(side, alpha, A, B, beta, C, opts);
-    }
+    if (side == slate::Side::Left)
+        slate::multiply(alpha, A, B, beta, C, opts);
+    else if (side == slate::Side::Right)
+        slate::multiply(alpha, B, A, beta, C, opts);
+    else
+        throw slate::Exception("unknown side");
     // Using traditional BLAS/LAPACK name
     // slate::hemm(side, alpha, A, B, beta, C, opts);
 

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -30,6 +30,12 @@ void test_trsm_work(Params& params, bool run)
     // Constants
     const scalar_t one = 1;
 
+    // Decode routine, setting method.
+    if (params.routine == "trsmA")
+        params.method_trsm() = slate::MethodTrsm::TrsmA;
+    else if (params.routine == "trsmB")
+        params.method_trsm() = slate::MethodTrsm::TrsmB;
+
     // get & mark input values
     slate::Side side = params.side();
     slate::Uplo uplo = params.uplo();
@@ -48,6 +54,7 @@ void test_trsm_work(Params& params, bool run)
     bool trace = params.trace() == 'y';
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
+    slate::Method method_trsm = params.method_trsm();
     params.matrix.mark();
     params.matrixB.mark();
 
@@ -67,7 +74,8 @@ void test_trsm_work(Params& params, bool run)
 
     slate::Options const opts =  {
         {slate::Option::Lookahead, lookahead},
-        {slate::Option::Target, target}
+        {slate::Option::Target, target},
+        {slate::Option::MethodTrsm, method_trsm},
     };
 
     // Error analysis applies in these norms.
@@ -161,16 +169,10 @@ void test_trsm_work(Params& params, bool run)
     // Solve AX = alpha B (left) or XA = alpha B (right).
     //==================================================
     if (side == slate::Side::Left) {
-        if (params.routine == "trsmA")
-            slate::trsmA(side, alpha, opA, B, opts);
-        else
-            slate::triangular_solve(alpha, opA, B, opts);
+        slate::triangular_solve( alpha, opA, B, opts );
     }
     else if (side == slate::Side::Right) {
-        if (params.routine == "trsmA")
-            slate::trsmA(side, alpha, opA, B, opts);
-        else
-            slate::triangular_solve(alpha, B, opA, opts);
+        slate::triangular_solve( alpha, B, opA, opts );
     }
     else
         throw slate::Exception("unknown side");


### PR DESCRIPTION
gemmA, hemmA, trsmA don't yet support multiple devices. This PR throws an error to make that obvious, instead of just giving bad results. See results below.

Currently, calling gemm, hemm, trsm with target=Dev, method=Auto and multiple devices will fall back to gemmC, hemmC, trsmB. Possibly in the future it would be better to fall back to target=Host and gemmA, hemmA, trsmA.

I also updated the testers so we can do
```
    ./tester gemm
    ./tester gemmA
    ./tester gemmC
```
and they set the method properly and route through `slate::multiply => slate::gemm`, rather than calling `gemm[AC]` directly. Ditto for hemm and trsm.

With 8 GPU devices:
```
./tester  --origin d --target d --ref n --nb 25 --type s --lookahead 1 --transA n --transB n --dim 25,50 gemmA
% SLATE version 2022.07.00, id 0783c737
% input: ./tester --origin d --target d --ref n --nb 25 --type s --lookahead 1 --transA n --transB n --dim 25,50 gemmA
% 2023-06-06 20:31:01, MPI size 1, OpenMP threads 10, GPU devices available 8
                                                                                                                                                                                                         
type  origin  target  gemm   go   A   B   C   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  

Error on rank 0: SLATE ERROR: Not yet implemented: gemmA doesn't support multiple GPUs in gemmA at src/gemmA.cc:67. (1 ranks had some error.)
   s     dev     dev     A  col   1   1   1  notrans  notrans      25      25      25   3.1+1.4i   2.7+1.7i    25    1    1   1         NA         NA            NA            NA            NA  FAILED  
```

```
./tester  --origin d --target d --ref n --nb 25 --type s --lookahead 1 --side l --uplo l --dim 25,50 hemmA
% SLATE version 2022.07.00, id 0783c737
% input: ./tester --origin d --target d --ref n --nb 25 --type s --lookahead 1 --side l --uplo l --dim 25,50 hemmA
% 2023-06-06 20:31:22, MPI size 1, OpenMP threads 10, GPU devices available 8
                                                                                                                                                                                          
type  origin  target  hemm   A   B   C    side    uplo       m       n      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  

Error on rank 0: SLATE ERROR: Not yet implemented: target not yet supported in hemmA at src/hemmA.cc:633. (1 ranks had some error.)
   s     dev     dev     A   1   1   1    left   lower      25      25   3.1+1.4i   2.7+1.7i    25    1    1   1         NA         NA            NA            NA            NA  FAILED  
```

```
./tester  --origin d --target d --ref n --nb 25 --type s --lookahead 1 --side l --uplo l --transA n --diag n,u --dim 25,50 trsmA
% SLATE version 2022.07.00, id 0783c737
% input: ./tester --origin d --target d --ref n --nb 25 --type s --lookahead 1 --side l --uplo l --transA n --diag n,u --dim 25,50 trsmA
% 2023-06-06 20:31:43, MPI size 1, OpenMP threads 10, GPU devices available 8
                                                                                                                                                                                             
type  origin  target  trsm   A   B    side    uplo   transA     diag       m       n      alpha    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  

Error on rank 0: SLATE ERROR: Not yet implemented: trsmA doesn't support multiple GPUs in trsmA at src/trsmA.cc:35. (1 ranks had some error.)
   s     dev     dev     A   1   2    left   lower  notrans  nonunit      25      25   3.1+1.4i    25    1    1   1         NA         NA            NA            NA            NA  FAILED  
```