### PR TITLE
fix include path to testsweeper

### DIFF
--- a/unit_test/test_geadd.cc
+++ b/unit_test/test_geadd.cc
@@ -11,7 +11,7 @@
 #include "slate/internal/util.hh"
 
 #include "unit_test.hh"
-#include "../testsweeper/testsweeper.hh"
+#include "testsweeper.hh"
 
 using slate::roundup;
 

--- a/unit_test/test_gescale.cc
+++ b/unit_test/test_gescale.cc
@@ -11,7 +11,7 @@
 #include "slate/internal/util.hh"
 
 #include "unit_test.hh"
-#include "../testsweeper/testsweeper.hh"
+#include "testsweeper.hh"
 
 using slate::roundup;
 

--- a/unit_test/test_geset.cc
+++ b/unit_test/test_geset.cc
@@ -11,7 +11,7 @@
 #include "slate/internal/util.hh"
 
 #include "unit_test.hh"
-#include "../testsweeper/testsweeper.hh"
+#include "testsweeper.hh"
 
 using slate::roundup;
 


### PR DESCRIPTION
No need to have `../testsweeper/` since the compile command includes the testsweeper directory:
```
slate> make unit_test/test_geadd.o
mpicxx ... -I./testsweeper -c unit_test/test_geadd.cc -o unit_test/test_geadd.o
```
Causes Spack to fail because the testsweeper sub-repo doesn't exist.