### PR TITLE
Version 2023.06.00

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -14,7 +14,8 @@ mydir=$(dirname $0)
 source ${mydir}/setup_env.sh
 
 print "======================================== Environment"
-env
+# Show environment variables, excluding functions.
+(set -o posix; set)
 
 print "======================================== Setup build"
 export color=no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
-Pending
-  - Moved repo to <https://github.com/icl-utk-edu/slate>
-  - Fixed `gemm` and `trsm` when n is small
+2023.06.00
+  - Moved repo to GitHub: https://github.com/icl-utk-edu/slate
+  - Added Hermitian eigenvectors using divide and conquer algorithm
+  - Added CALU variant of LU factorization
+  - Added mixed-precision GMRES solver
+  - Added GPU-aware MPI support using `${SLATE_GPU_AWARE_MPI}` environment variable
+  - Improved CALU and QR performance by moving panel operations to the GPU
+  - Update to use BLAS++ queues for all operations, to support oneAPI
+  - Update test matrix generator so random matrices are the same
+    regardless of MPI distribution
+  - Fixed `gemm` and `trsm` when n is small (stationary A case)
+  - Enabled examples to be used as smoke tests to verify library installation
+  - Numerous bug fixes
 
 2022.07.00
   - Improved performance of QR factorization on GPUs by moving panel to GPU:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required( VERSION 3.18 )
 
 project(
     slate
-    VERSION 2022.07.00
+    VERSION 2023.06.00
     LANGUAGES CXX Fortran
 )
 

--- a/docs/doxygen/doxyfile.conf
+++ b/docs/doxygen/doxyfile.conf
@@ -40,7 +40,7 @@ PROJECT_NAME           = "SLATE"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "2022.07.00"
+PROJECT_NUMBER         = "2023.06.00"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -27,8 +27,8 @@
 namespace slate {
 
 // Version is updated by make_release.py; DO NOT EDIT.
-// Version 2022.07.00
-#define SLATE_VERSION 20220700
+// Version 2023.06.00
+#define SLATE_VERSION 20230600
 
 int version();
 const char* id();


### PR DESCRIPTION
PR #48 shows nearly all tests are passing with `mpirun -np 4`. There are a couple failures that still need to be resolved, particularly Cholesky on AMD, but I haven't been able to reproduce it manually. This seems a good cut-off for this release.