### PR TITLE
For Intel/SYCL omptarget and CMake build 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,12 @@ if (gpu_backend MATCHES "^(sycl|auto)$")
         # enable the omptarget offload kernels in SLATE
         set( omptarget 1 )
 
+        # Avoid "comparison with NaN" warnings from the SYCL
+        # Intel-IntelLLVM compiler while compiling omptarget offload
+        # routines. (the compiler uses fast floating point mode by
+        # default).
+        target_compile_options( slate PRIVATE -fp-model=precise )
+
         file(
             GLOB libslate_omptarget_src
             CONFIGURE_DEPENDS  # glob at build time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ option( c_api "Build C API" false )
 
 set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
-              auto cuda hip onemkl none )
+              auto cuda hip sycl none )
 
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
@@ -98,7 +98,7 @@ set_property( CACHE CMAKE_CUDA_ARCHITECTURES PROPERTY STRINGS
 #-----------------------------------
 # BLAS options
 # SLATE defaults to single-threaded BLAS.
-set( blas_threaded "false" CACHE STRING
+set( blas_threaded "auto" CACHE STRING
      "Multi-threaded BLAS? (Passed to BLAS++.)" )
 set_property(
     CACHE blas_threaded PROPERTY STRINGS
@@ -583,17 +583,17 @@ else()
 endif()
 
 #-------------------------------------------------------------------------------
-# OneMKL support.
+# SYCL support.
 message( "" )
-message( "---------------------------------------- OneMKL: gpu_backend = ${gpu_backend}" )
-set( slate_use_onemkl false )  # output in slateConfig.cmake.in
-if (gpu_backend MATCHES "^(onemkl|auto)$")
-    message( STATUS "Looking for OneMKL" )
+message( "---------------------------------------- oneMKL-SYCL: gpu_backend = ${gpu_backend}" )
+set( slate_use_sycl false )  # output in slateConfig.cmake.in
+if (gpu_backend MATCHES "^(sycl|auto)$")
+    message( STATUS "Looking for oneMKL-SYCL" )
     if ( TARGET MKL::MKL_DPCPP ) # Search for MKL only if not already been found
         set( MKL_FOUND true )
     endif()
     if ( NOT MKL_FOUND ) # Search for MKL only if not already been found
-        if (gpu_backend STREQUAL "onemkl")
+        if (gpu_backend STREQUAL "sycl")
             find_package( MKL CONFIG REQUIRED HINTS "$ENV{MKL_ROOT}")
         else()
             find_package( MKL CONFIG QUIET HINTS "$ENV{MKL_ROOT}")
@@ -601,9 +601,14 @@ if (gpu_backend MATCHES "^(onemkl|auto)$")
     endif()
     # message(STATUS "Available targets: ${MKL_IMPORTED_TARGETS}")
 
-    if (MKL_FOUND)
-        set( gpu_backend "onemkl" )
-        set( slate_use_onemkl true )
+    # Check if compiler supports the SYCL flag
+    check_cxx_compiler_flag( "-fsycl" FSYCL_SUPPORT )
+
+    # If oneMKL is found and the compiler supports SYCL then
+    # enable oneMKL-SYCL-device support
+    if (MKL_FOUND AND FSYCL_SUPPORT)
+        set( gpu_backend "sycl" )
+        set( slate_use_sycl true )
         # enable the omptarget offload kernels in SLATE
         set( omptarget 1 )
 
@@ -618,14 +623,12 @@ if (gpu_backend MATCHES "^(onemkl|auto)$")
             ${libslate_omptarget_src}
         )
 
-        # target_compile_options( slate PUBLIC -fsycl )
-        target_compile_options( slate PUBLIC -fp-model=precise )
-        target_compile_options( slate PUBLIC -fiopenmp -fopenmp-targets=spir64 )
-        target_link_options( slate PUBLIC -fiopenmp -fopenmp-targets=spir64 )
         target_link_libraries( slate PUBLIC -lmkl_sycl -lsycl -lOpenCL )
-        message( STATUS "Building OneMKL (omptarget) support in SLATE" )
+        message( STATUS "Building OneMKL-SYCL device support" )
+    elseif (gpu_backend STREQUAL "sycl")
+        message( FATAL_ERROR "SYCL compiler not found" )
     else()
-        message( STATUS "Not building OneMKL support in SLATE" )
+        message( STATUS "No oneMKL-SYCL device support: oneMKL or SYCL compiler not found" )
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ option( c_api "Build C API" false )
 
 set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
-              auto cuda hip none )
+              auto cuda hip onemkl none )
 
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
@@ -580,6 +580,53 @@ if (HIP_FOUND)
     endforeach()
 else()
     message( STATUS "Not building HIP/ROCm support in SLATE" )
+endif()
+
+#-------------------------------------------------------------------------------
+# OneMKL support.
+message( "" )
+message( "---------------------------------------- OneMKL: gpu_backend = ${gpu_backend}" )
+set( slate_use_onemkl false )  # output in slateConfig.cmake.in
+if (gpu_backend MATCHES "^(onemkl|auto)$")
+    message( STATUS "Looking for OneMKL" )
+    if ( TARGET MKL::MKL_DPCPP ) # Search for MKL only if not already been found
+        set( MKL_FOUND true )
+    endif()
+    if ( NOT MKL_FOUND ) # Search for MKL only if not already been found
+        if (gpu_backend STREQUAL "onemkl")
+            find_package( MKL CONFIG REQUIRED HINTS "$ENV{MKL_ROOT}")
+        else()
+            find_package( MKL CONFIG QUIET HINTS "$ENV{MKL_ROOT}")
+        endif()
+    endif()
+    # message(STATUS "Available targets: ${MKL_IMPORTED_TARGETS}")
+
+    if (MKL_FOUND)
+        set( gpu_backend "onemkl" )
+        set( slate_use_onemkl true )
+        # enable the omptarget offload kernels in SLATE
+        set( omptarget 1 )
+
+        file(
+            GLOB libslate_omptarget_src
+            CONFIGURE_DEPENDS  # glob at build time
+            src/omptarget/*.cc
+        )
+        target_sources(
+            slate
+            PRIVATE
+            ${libslate_omptarget_src}
+        )
+
+        # target_compile_options( slate PUBLIC -fsycl )
+        target_compile_options( slate PUBLIC -fp-model=precise )
+        target_compile_options( slate PUBLIC -fiopenmp -fopenmp-targets=spir64 )
+        target_link_options( slate PUBLIC -fiopenmp -fopenmp-targets=spir64 )
+        target_link_libraries( slate PUBLIC -lmkl_sycl -lsycl -lOpenCL )
+        message( STATUS "Building OneMKL (omptarget) support in SLATE" )
+    else()
+        message( STATUS "Not building OneMKL support in SLATE" )
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,8 +99,8 @@ HIPCCFLAGS += -std=c++11 -DTCE_HIP -fno-gpu-rdc
 
 force: ;
 
-# Auto-detect CUDA, HIP.
-ifneq ($(filter-out auto cuda hip onemkl none, $(gpu_backend)),)
+# Auto-detect CUDA, HIP, SYCL.
+ifneq ($(filter-out auto cuda hip sycl none, $(gpu_backend)),)
     $(error ERROR: gpu_backend = $(gpu_backend) is unknown)
 endif
 
@@ -137,9 +137,9 @@ endif
 omptarget = 0
 ifneq ($(cuda),1)
 ifneq ($(hip),1)
-    ifeq (${gpu_backend},onemkl)
-        # enable the omptarget offload kernels in SLATE
-        $(info Note: enabling onemkl)
+    ifeq (${gpu_backend},sycl)
+        # enable the omptarget offload kernels in SLATE for oneMKL-SYCL devices
+        $(info Note: enabling omp-target-offload kernels)
         omptarget = 1
     endif
 endif
@@ -1420,7 +1420,10 @@ echo:
 	@echo "hip_hdr       = ${hip_hdr}"
 	@echo "md5_files     = $(md5_files)"
 	@echo
-	@echo "---------- oneMKL options"
+	@echo "---------- SYCL options"
+	@echo "sycl          = '$(sycl)'"
+	@echo
+	@echo "---------- OMP target-offload kernel options"
 	@echo "omptarget     = '${omptarget}'"
 	@echo "omptarget_src = ${omptarget_src}"
 	@echo "omptarget_hdr = ${omptarget_hdr}"

--- a/include/slate/internal/device.hh
+++ b/include/slate/internal/device.hh
@@ -66,15 +66,15 @@ namespace slate {
 /// GPU device implementations of kernels.
 namespace device {
 
-// For the present, use omptarget-kernels when OneMKL is used
-#if defined( BLAS_HAVE_ONEMKL )
+// Use omp-target-kernels when OneMKL-SYCL is used
+#if defined( BLAS_HAVE_SYCL )
     #define SLATE_HAVE_OMPTARGET
 #endif
 
-// Simplify checking for GPU device support (CUDA / ROCm / OneMKL).
+// Simplify checking for GPU device support (CUDA / ROCm / SYCL).
 #if defined( BLAS_HAVE_CUBLAS ) \
     || defined( BLAS_HAVE_ROCBLAS ) \
-    || defined( SLATE_HAVE_OMPTARGET )
+    || defined( BLAS_HAVE_SYCL )
     #define SLATE_HAVE_DEVICE
 #endif
 

--- a/include/slate/internal/openmp.hh
+++ b/include/slate/internal/openmp.hh
@@ -9,45 +9,29 @@
 #ifndef SLATE_OPENMP_HH
 #define SLATE_OPENMP_HH
 
+// In OpenMP, using "#pragma omp default(none)" to make programmers
+// specify variable usage is good practice.  However some compilers
+// and libraries contain hidden variables that cause unexpected
+// warnings and errors.  SLATE uses a macro that can be defined at
+// compile time for debug building and testing.
+//
+// For example:  CXXFLAGS += -Dslate_omp_default_none='default(none)'
+//
 #ifndef slate_omp_default_none
 #define slate_omp_default_none
 #endif
 
-#ifdef _OPENMP
-    #include <omp.h>
-#else
-
-typedef int omp_lock_t;
-typedef int omp_nest_lock_t;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int omp_get_initial_device();
-int omp_get_max_threads();
-int omp_get_num_devices();
-int omp_get_num_threads(void);
-int omp_get_thread_num(void);
-
-double omp_get_wtime();
-
-void omp_destroy_lock(omp_lock_t* lock);
-void omp_init_lock(omp_lock_t* lock);
-void omp_set_lock(omp_lock_t* lock);
-void omp_set_nested(int nested);
-void omp_unset_lock(omp_lock_t* lock);
-
-void omp_destroy_nest_lock(omp_nest_lock_t* lock);
-void omp_init_nest_lock(omp_nest_lock_t* lock);
-void omp_set_nest_lock(omp_nest_lock_t* lock);
-void omp_unset_nest_lock(omp_nest_lock_t* lock);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif // not _OPENMP
+// Include OpenMP headers
+//
+// Note: There is no _OPENMP guard because SLATE requires OpenMP and
+// checks for it at compile time.
+//
+// todo: On Intel SYCL platforms using both "-fsycl -fiopenmp" flags
+// can leave the _OPENMP macro undefined.  There are 2 sweeps over the
+// code, use ifdefs via __SYCL_DEVICE_ONLY__ macro to make code legal
+// for the SYCL pass.
+//
+#include <omp.h>
 
 // Defines a small class to wrap omp_set_max_active_levels()
 #include "slate/internal/OmpSetMaxActiveLevels.hh"

--- a/slateConfig.cmake.in
+++ b/slateConfig.cmake.in
@@ -3,7 +3,7 @@ cmake_minimum_required( VERSION 3.15 )
 set( slate_use_openmp "@slate_use_openmp@" )
 set( slate_use_cuda   "@slate_use_cuda@" )
 set( slate_use_hip    "@slate_use_hip@" )
-set( slate_use_onemkl "@slate_use_onemkl@" )
+set( slate_use_sycl   "@slate_use_sycl@" )
 set( slate_use_mpi    "@slate_use_mpi@" )
 
 include( CMakeFindDependencyMacro )

--- a/slateConfig.cmake.in
+++ b/slateConfig.cmake.in
@@ -2,7 +2,8 @@ cmake_minimum_required( VERSION 3.15 )
 
 set( slate_use_openmp "@slate_use_openmp@" )
 set( slate_use_cuda   "@slate_use_cuda@" )
-set( slate_use_cuda   "@slate_use_hip@" )
+set( slate_use_hip    "@slate_use_hip@" )
+set( slate_use_onemkl "@slate_use_onemkl@" )
 set( slate_use_mpi    "@slate_use_mpi@" )
 
 include( CMakeFindDependencyMacro )

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -102,8 +102,6 @@ void Memory::clearHostBlocks()
 ///
 void Memory::clearDeviceBlocks(int device, blas::Queue *queue)
 {
-    Debug::checkDeviceMemoryLeaks(*this, device);
-
     while (! free_blocks_[device].empty())
         free_blocks_[device].pop();
 
@@ -113,6 +111,8 @@ void Memory::clearDeviceBlocks(int device, blas::Queue *queue)
         allocated_mem_[device].pop();
     }
     capacity_[device] = 0;
+
+    Debug::checkDeviceMemoryLeaks(*this, device);
 }
 
 //------------------------------------------------------------------------------

--- a/src/omptarget/device_gecopy.cc
+++ b/src/omptarget/device_gecopy.cc
@@ -80,6 +80,8 @@ void gecopy(
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
+
+// float => float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -87,6 +89,7 @@ void gecopy(
     float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// float => double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -94,6 +97,7 @@ void gecopy(
     double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// double => double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -101,6 +105,7 @@ void gecopy(
     double** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// double => float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -108,6 +113,7 @@ void gecopy(
     float** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-float => complex-float
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -115,6 +121,7 @@ void gecopy(
     std::complex<float>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-float => complex-double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -122,6 +129,7 @@ void gecopy(
     std::complex<double>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-double => complex-double
 template
 void gecopy(
     int64_t m, int64_t n,
@@ -129,11 +137,28 @@ void gecopy(
     std::complex<double>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
+// complex-double => complex-float
 template
 void gecopy(
     int64_t m, int64_t n,
     std::complex<double> const* const* Aarray, int64_t lda,
     std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+// float => complex-float
+template
+void gecopy(
+    int64_t m, int64_t n,
+    float const* const* Aarray, int64_t lda,
+    std::complex<float>** Barray, int64_t ldb,
+    int64_t batch_count, blas::Queue &queue);
+
+// double => complex-double
+template
+void gecopy(
+    int64_t m, int64_t n,
+    double const* const* Aarray, int64_t lda,
+    std::complex<double>** Barray, int64_t ldb,
     int64_t batch_count, blas::Queue &queue);
 
 } // namespace device

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,13 @@ set_target_properties(
     CXX_EXTENSIONS false        # prohibit gnu++17
 )
 
+# Avoid "comparison with NaN" warnings from the SYCL Intel-IntelLLVM
+# compiler while compiling test/matrix_generator.cc (the compiler uses
+# fast floating point mode by default).
+if (gpu_backend STREQUAL "sycl" )
+   target_compile_options( ${tester} PRIVATE -fp-model=precise )
+endif()
+
 target_link_libraries(
     ${tester}
     testsweeper


### PR DESCRIPTION
This builds using CMake on Intel (sunspot), building testsweeper, blaspp, lapackpp libraries.
```
cmake ..
-- The CXX compiler identification is IntelLLVM 2023.1.0
   Found BLAS library: -lmkl_intel_lp64;-lmkl_intel_thread;-lmkl_core
-- Looking for oneMKL-SYCL (gpu_backend = auto)
-- Building oneMKL-SYCL device support
nice make -j 2

qsub -l select=1 -l walltime=60:00 -A ACCOUNT -q workq -I  
env ZE_AFFINITY_MASK=0.0 ./run_tests.py --quick   
% SLATE version 2023.06.00, id 0287fd70
% 2023-07-20 17:51:22, 1 MPI ranks, CPU-only MPI, 208 OpenMP threads, 1 GPU devices per MPI rank
3 routines FAILED: heev, stedc, hegv
```


