### PR TITLE
Fix compilation on Frontier

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -384,7 +384,7 @@ ifeq ($(hip),1)
     endif
 
     # Generate hipcc target options for all gfx in hip_arch_.
-    offload_arch = $(foreach arch, $(gfx),--offload_arch=$(arch))
+    offload_arch = $(foreach arch, $(gfx),--offload-arch=$(arch))
     HIPCCFLAGS += $(offload_arch)
     FLAGS += -I${ROCM_PATH}/include -D__HIP_PLATFORM_AMD__
     LIBS  += -L$(ROCM_PATH)/lib -Wl,-rpath,${ROCM_PATH}/lib -lrocsolver -lrocblas -lamdhip64


### PR DESCRIPTION
PR #69 had a typo in the `--offload-arch` flag which breaks compilation on Frontier.  (The CI doesn't set `hip_arch`, so it doesn't use this argument.)

Also, should `arch` in the same line be `hip_arch`?  I can't find the variable `arch` anywhere else in the makefile or my configuration,  but it compiles just fine (with `hip_arch=gfx90a` resulting in `offload_arch  = --offload-arch=gfx90a`).