### PR TITLE
CI for SYCL

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,15 +39,23 @@ set(
     ex05_blas.cc
     ex06_linear_system_lu.cc
     ex07_linear_system_cholesky.cc
-    # ex08_linear_system_indefinite.cc      # failing
+    ex08_linear_system_indefinite.cc
     ex09_least_squares.cc
     ex10_svd.cc
-    # ex11_hermitian_eig.cc                 # failing
-    # ex12_generalized_hermitian_eig.cc     # failing
+    ex11_hermitian_eig.cc
+    ex12_generalized_hermitian_eig.cc
     ex13_non_uniform_block_size.cc
+    # ex14_scalapack_gemm.cc  # requires -lscalapack
 )
 
 enable_testing()
+
+# Get precisions to test. See .github/workflows/test.sh
+set( test_args $ENV{test_args} )
+if (NOT test_args)
+    set( test_args "s d c z" )
+endif()
+string( REPLACE " " ";" test_args ${test_args} ) # convert to list
 
 foreach (src IN LISTS src_list)
     string( REPLACE ".cc" ""     exe "${src}" )
@@ -60,23 +68,11 @@ foreach (src IN LISTS src_list)
     list( APPEND txt_list "${txt}" )
     list( APPEND exe_list "${exe}" )
 
-    # Can use custom targets and add dependency to serialize execution,
-    # but then if a test fails `make run` halts. Otherwise, need to
-    # use `make -k -j1 run`.
-    ## add_custom_target(
-    ##     "${txt}"
-    ##     DEPENDS "${exe}"  ### ${last_txt}
-    ##     COMMAND mpirun -np 4 ./${exe} > ${txt}
-    ## )
-    ### set( last_txt "${txt}" )
-
     # ctest can't redirect the output of each test to a file.
     # It saves all the output to Testing/Temporary/LastTest.log
     # Using `make test ARGS="-V"` prints output to terminal,
     # with test ID prefixed.
-    add_test( NAME "${exe}" COMMAND mpirun -np 4 ./${exe} )
+    add_test( NAME "${exe}" COMMAND mpirun -np 4 ./${exe} ${test_args} )
 endforeach()
 
 set_tests_properties( ${exe_list} PROPERTIES RUN_SERIAL true )
-
-## add_custom_target( run DEPENDS ${txt_list} )

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -48,8 +48,12 @@ ${slate_exe}: %: %.o
 	${CXX} -o $@ $^ \
 		${LDFLAGS} ${slate_libs} ${LIBS}
 
+test_args ?= s d c z
+
+# CMake uses `make test`, GNU autotools uses `make check`; allow both.
+test: check
 check: ${exe}
-	./run_tests.py
+	./run_tests.py --type "${test_args}"
 
 #-------------------------------------------------------------------------------
 # Generic rules.

--- a/examples/ex01_matrix.cc
+++ b/examples/ex01_matrix.cc
@@ -33,34 +33,54 @@ void test_matrix()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    slate_mpi_call(
-        MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_matrix< float >();
+        }
+
+        if (types[ 1 ]) {
+            test_matrix< double >();
+        }
+
+        if (types[ 2 ]) {
+            test_matrix< std::complex<float> >();
+        }
+
+        if (types[ 3 ]) {
+            test_matrix< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_matrix< float >();
-    test_matrix< double >();
-    test_matrix< std::complex<float> >();
-    test_matrix< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex02_conversion.cc
+++ b/examples/ex02_conversion.cc
@@ -38,34 +38,54 @@ void test_conversion()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_conversion< float >();
+        }
+
+        if (types[ 1 ]) {
+            test_conversion< double >();
+        }
+
+        if (types[ 2 ]) {
+            test_conversion< std::complex<float> >();
+        }
+
+        if (types[ 3 ]) {
+            test_conversion< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_conversion< float >();
-    test_conversion< double >();
-    test_conversion< std::complex<float> >();
-    test_conversion< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex03_submatrix.cc
+++ b/examples/ex03_submatrix.cc
@@ -9,7 +9,7 @@ int mpi_rank = 0;
 int grid_p = 0;
 int grid_q = 0;
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 template <typename scalar_type>
 void test_submatrix()
 {
@@ -62,34 +62,45 @@ void test_submatrix()
             mpi_rank, llong(B.mt()), llong(B.nt()), llong(B.m()), llong(B.n()) );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_submatrix< float >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_submatrix< float >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex04_norm.cc
+++ b/examples/ex04_norm.cc
@@ -13,6 +13,8 @@ int grid_q = 0;
 template <typename scalar_type>
 void test_general_norm()
 {
+    using real_type = blas::real_type<scalar_type>;
+
     print_func( mpi_rank );
 
     int64_t m=2000, n=1000, nb=256;
@@ -21,25 +23,20 @@ void test_general_norm()
     A.insertLocalTiles();
     random_matrix( A );
 
-    blas::real_type<scalar_type> A_norm;
-
-    A_norm = slate::norm( slate::Norm::One, A );
-    printf( "rank %d: one norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Inf, A );
-    printf( "rank %d: inf norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Max, A );
-    printf( "rank %d: max norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Fro, A );
-    printf( "rank %d: fro norm %.6f\n", mpi_rank, A_norm );
+    real_type A_norm_one = slate::norm( slate::Norm::One, A );
+    real_type A_norm_inf = slate::norm( slate::Norm::Inf, A );
+    real_type A_norm_max = slate::norm( slate::Norm::Max, A );
+    real_type A_norm_fro = slate::norm( slate::Norm::Fro, A );
+    printf( "rank %d: norms: one %12.6f, inf %12.6f, max %12.6f, fro %12.6f\n",
+            mpi_rank, A_norm_one, A_norm_inf, A_norm_max, A_norm_fro );
 }
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
 void test_symmetric_norm()
 {
+    using real_type = blas::real_type<scalar_type>;
+
     print_func( mpi_rank );
 
     int64_t n=1000, nb=256;
@@ -49,25 +46,20 @@ void test_symmetric_norm()
     A.insertLocalTiles();
     random_matrix( A );
 
-    blas::real_type<scalar_type> A_norm;
-
-    A_norm = slate::norm( slate::Norm::One, A );
-    printf( "rank %d: one norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Inf, A );
-    printf( "rank %d: inf norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Max, A );
-    printf( "rank %d: max norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Fro, A );
-    printf( "rank %d: fro norm %.6f\n", mpi_rank, A_norm );
+    real_type A_norm_one = slate::norm( slate::Norm::One, A );
+    real_type A_norm_inf = slate::norm( slate::Norm::Inf, A );
+    real_type A_norm_max = slate::norm( slate::Norm::Max, A );
+    real_type A_norm_fro = slate::norm( slate::Norm::Fro, A );
+    printf( "rank %d: norms: one %12.6f, inf %12.6f, max %12.6f, fro %12.6f\n",
+            mpi_rank, A_norm_one, A_norm_inf, A_norm_max, A_norm_fro );
 }
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
 void test_hermitian_norm()
 {
+    using real_type = blas::real_type<scalar_type>;
+
     print_func( mpi_rank );
 
     int64_t n=1000, nb=256;
@@ -77,25 +69,20 @@ void test_hermitian_norm()
     A.insertLocalTiles();
     random_matrix( A );
 
-    blas::real_type<scalar_type> A_norm;
-
-    A_norm = slate::norm( slate::Norm::One, A );
-    printf( "rank %d: one norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Inf, A );
-    printf( "rank %d: inf norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Max, A );
-    printf( "rank %d: max norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Fro, A );
-    printf( "rank %d: fro norm %.6f\n", mpi_rank, A_norm );
+    real_type A_norm_one = slate::norm( slate::Norm::One, A );
+    real_type A_norm_inf = slate::norm( slate::Norm::Inf, A );
+    real_type A_norm_max = slate::norm( slate::Norm::Max, A );
+    real_type A_norm_fro = slate::norm( slate::Norm::Fro, A );
+    printf( "rank %d: norms: one %12.6f, inf %12.6f, max %12.6f, fro %12.6f\n",
+            mpi_rank, A_norm_one, A_norm_inf, A_norm_max, A_norm_fro );
 }
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
 void test_triangular_norm()
 {
+    using real_type = blas::real_type<scalar_type>;
+
     print_func( mpi_rank );
 
     int64_t n=1000, nb=256;
@@ -105,25 +92,20 @@ void test_triangular_norm()
     A.insertLocalTiles();
     random_matrix( A );
 
-    blas::real_type<scalar_type> A_norm;
-
-    A_norm = slate::norm( slate::Norm::One, A );
-    printf( "rank %d: one norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Inf, A );
-    printf( "rank %d: inf norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Max, A );
-    printf( "rank %d: max norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Fro, A );
-    printf( "rank %d: fro norm %.6f\n", mpi_rank, A_norm );
+    real_type A_norm_one = slate::norm( slate::Norm::One, A );
+    real_type A_norm_inf = slate::norm( slate::Norm::Inf, A );
+    real_type A_norm_max = slate::norm( slate::Norm::Max, A );
+    real_type A_norm_fro = slate::norm( slate::Norm::Fro, A );
+    printf( "rank %d: norms: one %12.6f, inf %12.6f, max %12.6f, fro %12.6f\n",
+            mpi_rank, A_norm_one, A_norm_inf, A_norm_max, A_norm_fro );
 }
 
 //------------------------------------------------------------------------------
 template <typename scalar_type>
 void test_trapezoid_norm()
 {
+    using real_type = blas::real_type<scalar_type>;
+
     print_func( mpi_rank );
 
     int64_t m=2000, n=1000, nb=256;
@@ -134,72 +116,87 @@ void test_trapezoid_norm()
     A.insertLocalTiles();
     random_matrix( A );
 
-    blas::real_type<scalar_type> A_norm;
-
-    A_norm = slate::norm( slate::Norm::One, A );
-    printf( "rank %d: one norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Inf, A );
-    printf( "rank %d: inf norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Max, A );
-    printf( "rank %d: max norm %.6f\n", mpi_rank, A_norm );
-
-    A_norm = slate::norm( slate::Norm::Fro, A );
-    printf( "rank %d: fro norm %.6f\n", mpi_rank, A_norm );
+    real_type A_norm_one = slate::norm( slate::Norm::One, A );
+    real_type A_norm_inf = slate::norm( slate::Norm::Inf, A );
+    real_type A_norm_max = slate::norm( slate::Norm::Max, A );
+    real_type A_norm_fro = slate::norm( slate::Norm::Fro, A );
+    printf( "rank %d: norms: one %12.6f, inf %12.6f, max %12.6f, fro %12.6f\n",
+            mpi_rank, A_norm_one, A_norm_inf, A_norm_max, A_norm_fro );
 }
 
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_general_norm   < float >();
+            test_symmetric_norm < float >();
+            test_hermitian_norm < float >();
+            test_triangular_norm< float >();
+            test_trapezoid_norm < float >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 1 ]) {
+            test_general_norm   < double >();
+            test_symmetric_norm < double >();
+            test_hermitian_norm < double >();
+            test_triangular_norm< double >();
+            test_trapezoid_norm < double >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 2 ]) {
+            test_general_norm   < std::complex<float> >();
+            test_symmetric_norm < std::complex<float> >();
+            test_hermitian_norm < std::complex<float> >();
+            test_triangular_norm< std::complex<float> >();
+            test_trapezoid_norm < std::complex<float> >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 3 ]) {
+            test_general_norm   < std::complex<double> >();
+            test_symmetric_norm < std::complex<double> >();
+            test_hermitian_norm < std::complex<double> >();
+            test_triangular_norm< std::complex<double> >();
+            test_trapezoid_norm < std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_general_norm< float >();
-    test_general_norm< double >();
-    test_general_norm< std::complex<float> >();
-    test_general_norm< std::complex<double> >();
-
-    test_symmetric_norm< float >();
-    test_symmetric_norm< double >();
-    test_symmetric_norm< std::complex<float> >();
-    test_symmetric_norm< std::complex<double> >();
-
-    test_hermitian_norm< float >();
-    test_hermitian_norm< double >();
-    test_hermitian_norm< std::complex<float> >();
-    test_hermitian_norm< std::complex<double> >();
-
-    test_triangular_norm< float >();
-    test_triangular_norm< double >();
-    test_triangular_norm< std::complex<float> >();
-    test_triangular_norm< std::complex<double> >();
-
-    test_trapezoid_norm< float >();
-    test_trapezoid_norm< double >();
-    test_trapezoid_norm< std::complex<float> >();
-    test_trapezoid_norm< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex06_linear_system_lu.cc
+++ b/examples/ex06_linear_system_lu.cc
@@ -112,47 +112,70 @@ void test_lu_inverse()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_lu< float >();
+            test_lu_factor< float >();
+            test_lu_inverse< float >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 1 ]) {
+            test_lu< double >();
+            test_lu_factor< double >();
+            test_lu_inverse< double >();
+            test_lu_mixed< double >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 2 ]) {
+            test_lu< std::complex<float> >();
+            test_lu_factor< std::complex<float> >();
+            test_lu_inverse< std::complex<float> >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 3 ]) {
+            test_lu< std::complex<double> >();
+            test_lu_factor< std::complex<double> >();
+            test_lu_inverse< std::complex<double> >();
+            test_lu_mixed< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_lu< float >();
-    test_lu< double >();
-    test_lu< std::complex<float> >();
-    test_lu< std::complex<double> >();
-
-    test_lu_mixed< double >();
-    test_lu_mixed< std::complex<double> >();
-
-    test_lu_factor< float >();
-    test_lu_factor< double >();
-    test_lu_factor< std::complex<float> >();
-    test_lu_factor< std::complex<double> >();
-
-    test_lu_inverse< float >();
-    test_lu_inverse< double >();
-    test_lu_inverse< std::complex<float> >();
-    test_lu_inverse< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex07_linear_system_cholesky.cc
+++ b/examples/ex07_linear_system_cholesky.cc
@@ -109,47 +109,70 @@ void test_cholesky_inverse()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_cholesky< float >();
+            test_cholesky_factor< float >();
+            test_cholesky_inverse< float >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 1 ]) {
+            test_cholesky< double >();
+            test_cholesky_factor< double >();
+            test_cholesky_inverse< double >();
+            test_cholesky_mixed< double >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 2 ]) {
+            test_cholesky< std::complex<float> >();
+            test_cholesky_factor< std::complex<float> >();
+            test_cholesky_inverse< std::complex<float> >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 3 ]) {
+            test_cholesky< std::complex<double> >();
+            test_cholesky_factor< std::complex<double> >();
+            test_cholesky_inverse< std::complex<double> >();
+            test_cholesky_mixed< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_cholesky< float >();
-    test_cholesky< double >();
-    test_cholesky< std::complex<float> >();
-    test_cholesky< std::complex<double> >();
-
-    test_cholesky_mixed< double >();
-    test_cholesky_mixed< std::complex<double> >();
-
-    test_cholesky_factor< float >();
-    test_cholesky_factor< double >();
-    test_cholesky_factor< std::complex<float> >();
-    test_cholesky_factor< std::complex<double> >();
-
-    test_cholesky_inverse< float >();
-    test_cholesky_inverse< double >();
-    test_cholesky_inverse< std::complex<float> >();
-    test_cholesky_inverse< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex08_linear_system_indefinite.cc
+++ b/examples/ex08_linear_system_indefinite.cc
@@ -10,16 +10,17 @@ int grid_p = 0;
 int grid_q = 0;
 
 //------------------------------------------------------------------------------
-// TODO: failing
+template <typename scalar_type>
 void test_hesv()
 {
     print_func( mpi_rank );
 
+    // note: currently requires n divisible by nb.
     int64_t n=1000, nrhs=100, nb=100;
 
-    slate::HermitianMatrix<double>
+    slate::HermitianMatrix<scalar_type>
         A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
-    slate::Matrix<double> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     random_matrix( A );
@@ -31,24 +32,25 @@ void test_hesv()
     // traditional API
     // workspaces
     // todo: drop H (internal workspace)
-    slate::Matrix<double>     H( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
-    slate::BandMatrix<double> T( n, n, nb, nb, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type>     H( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::BandMatrix<scalar_type> T( n, n, nb, nb, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::Pivots pivots, pivots2;
 
     slate::hesv( A, pivots, T, pivots2, H, B );
 }
 
 //------------------------------------------------------------------------------
-// TODO: failing
+template <typename scalar_type>
 void test_hetrf()
 {
     print_func( mpi_rank );
 
+    // note: currently requires n divisible by nb.
     int64_t n=1000, nrhs=100, nb=100;
 
-    slate::HermitianMatrix<double>
+    slate::HermitianMatrix<scalar_type>
         A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
-    slate::Matrix<double> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type> B( n, nrhs, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
     B.insertLocalTiles();
     random_matrix( A );
@@ -56,8 +58,8 @@ void test_hetrf()
 
     // workspaces
     // todo: drop H (internal workspace)
-    slate::Matrix<double>     H( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
-    slate::BandMatrix<double> T( n, n, nb, nb, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::Matrix<scalar_type>     H( n, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
+    slate::BandMatrix<scalar_type> T( n, n, nb, nb, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::Pivots pivots, pivots2;
 
     // simplified API
@@ -72,32 +74,64 @@ void test_hetrf()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_hesv < float >();
+            test_hetrf< float >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 1 ]) {
+            test_hesv < double >();
+            test_hetrf< double >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 2 ]) {
+            test_hesv < std::complex<float> >();
+            test_hetrf< std::complex<float> >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 3 ]) {
+            test_hesv < std::complex<double> >();
+            test_hetrf< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_hesv();
-    test_hetrf();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex09_least_squares.cc
+++ b/examples/ex09_least_squares.cc
@@ -15,8 +15,7 @@ void test_gels_overdetermined()
 {
     print_func( mpi_rank );
 
-    // TODO: failing if m, n not divisible by nb?
-    int64_t m=2000, n=1000, nrhs=100, nb=100;
+    int64_t m=2000, n=1000, nrhs=100, nb=256;
 
     int64_t max_mn = std::max( m, n );
     slate::Matrix<scalar_type> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
@@ -40,8 +39,7 @@ void test_gels_underdetermined()
 {
     print_func( mpi_rank );
 
-    // TODO: failing if not divisible by nb?
-    int64_t m=2000, n=1000, nrhs=100, nb=100;
+    int64_t m=2000, n=1000, nrhs=100, nb=256;
 
     int64_t max_mn = std::max( m, n );
     slate::Matrix<scalar_type> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
@@ -63,39 +61,64 @@ void test_gels_underdetermined()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_gels_overdetermined < float >();
+            test_gels_underdetermined< float >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 1 ]) {
+            test_gels_overdetermined < double >();
+            test_gels_underdetermined< double >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 2 ]) {
+            test_gels_overdetermined < std::complex<float> >();
+            test_gels_underdetermined< std::complex<float> >();
+        }
+        if (mpi_rank == 0)
+            printf( "\n" );
+
+        if (types[ 3 ]) {
+            test_gels_overdetermined < std::complex<double> >();
+            test_gels_underdetermined< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_gels_overdetermined< float >();
-    test_gels_overdetermined< double >();
-    test_gels_overdetermined< std::complex<float> >();
-    test_gels_overdetermined< std::complex<double> >();
-
-    test_gels_underdetermined< float >();
-    test_gels_underdetermined< double >();
-    test_gels_underdetermined< std::complex<float> >();
-    test_gels_underdetermined< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex10_svd.cc
+++ b/examples/ex10_svd.cc
@@ -17,8 +17,7 @@ void test_svd()
 
     print_func( mpi_rank );
 
-    // TODO: failing if m, n not divisible by nb?
-    int64_t m=2000, n=1000, nb=100;
+    int64_t m=2000, n=1000, nb=256;
 
     int64_t min_mn = std::min( m, n );
     slate::Matrix<T> A( m, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
@@ -68,31 +67,54 @@ void test_svd()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_svd< float >();
+        }
+
+        if (types[ 1 ]) {
+            test_svd< double >();
+        }
+
+        if (types[ 2 ]) {
+            test_svd< std::complex<float> >();
+        }
+
+        if (types[ 3 ]) {
+            test_svd< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_svd<double>();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex11_hermitian_eig.cc
+++ b/examples/ex11_hermitian_eig.cc
@@ -17,8 +17,7 @@ void test_hermitian_eig()
 
     print_func( mpi_rank );
 
-    // TODO: failing if n not divisible by nb?
-    int64_t n=1000, nb=100;
+    int64_t n=1000, nb=256;
 
     slate::HermitianMatrix<T> A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     A.insertLocalTiles();
@@ -50,35 +49,55 @@ void test_hermitian_eig()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    // Hermitian eig requires square MPI grid.
-    grid_size_square( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        // Hermitian eig requires square MPI grid.
+        grid_size_square( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_hermitian_eig< float >();
+        }
+
+        if (types[ 1 ]) {
+            test_hermitian_eig< double >();
+        }
+
+        if (types[ 2 ]) {
+            test_hermitian_eig< std::complex<float> >();
+        }
+
+        if (types[ 3 ]) {
+            test_hermitian_eig< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_hermitian_eig< float >();
-    test_hermitian_eig< double>();
-    test_hermitian_eig< std::complex<float> >();
-    test_hermitian_eig< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex12_generalized_hermitian_eig.cc
+++ b/examples/ex12_generalized_hermitian_eig.cc
@@ -21,8 +21,7 @@ void test_hermitian_eig()
 
     print_func( mpi_rank );
 
-    // TODO: failing if n not divisible by nb?
-    int64_t n=1000, nb=100;
+    int64_t n=1000, nb=256;
 
     slate::HermitianMatrix<T> A( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
     slate::HermitianMatrix<T> B( slate::Uplo::Lower, n, nb, grid_p, grid_q, MPI_COMM_WORLD );
@@ -71,35 +70,55 @@ void test_hermitian_eig()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    // Hermitian eig requires square MPI grid.
-    grid_size_square( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        // Hermitian eig requires square MPI grid.
+        grid_size_square( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_hermitian_eig< float >();
+        }
+
+        if (types[ 1 ]) {
+            test_hermitian_eig< double >();
+        }
+
+        if (types[ 2 ]) {
+            test_hermitian_eig< std::complex<float> >();
+        }
+
+        if (types[ 3 ]) {
+            test_hermitian_eig< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_hermitian_eig< float >();
-    test_hermitian_eig< double>();
-    test_hermitian_eig< std::complex<float> >();
-    test_hermitian_eig< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/ex13_non_uniform_block_size.cc
+++ b/examples/ex13_non_uniform_block_size.cc
@@ -68,34 +68,54 @@ void test_matrix_lambda()
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int provided = 0;
-    int err = MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided );
-    assert( err == 0 );
-    assert( provided == MPI_THREAD_MULTIPLE );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    slate_mpi_call(
-        MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
+        int provided = 0;
+        slate_mpi_call(
+            MPI_Init_thread( &argc, &argv, MPI_THREAD_MULTIPLE, &provided ) );
+        assert( provided == MPI_THREAD_MULTIPLE );
 
-    slate_mpi_call(
-        MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+        slate_mpi_call(
+            MPI_Comm_size( MPI_COMM_WORLD, &mpi_size ) );
 
-    // Determine p-by-q grid for this MPI size.
-    grid_size( mpi_size, &grid_p, &grid_q );
-    if (mpi_rank == 0) {
-        printf( "mpi_size %d, grid_p %d, grid_q %d\n",
-                mpi_size, grid_p, grid_q );
+        slate_mpi_call(
+            MPI_Comm_rank( MPI_COMM_WORLD, &mpi_rank ) );
+
+        // Determine p-by-q grid for this MPI size.
+        grid_size( mpi_size, &grid_p, &grid_q );
+        if (mpi_rank == 0) {
+            printf( "mpi_size %d, grid_p %d, grid_q %d\n",
+                    mpi_size, grid_p, grid_q );
+        }
+
+        // so random_matrix is different on different ranks.
+        srand( 100 * mpi_rank );
+
+        if (types[ 0 ]) {
+            test_matrix_lambda< float >();
+        }
+
+        if (types[ 1 ]) {
+            test_matrix_lambda< double >();
+        }
+
+        if (types[ 2 ]) {
+            test_matrix_lambda< std::complex<float> >();
+        }
+
+        if (types[ 3 ]) {
+            test_matrix_lambda< std::complex<double> >();
+        }
+
+        slate_mpi_call(
+            MPI_Finalize() );
     }
-
-    // so random_matrix is different on different ranks.
-    srand( 100 * mpi_rank );
-
-    test_matrix_lambda< float >();
-    test_matrix_lambda< double >();
-    test_matrix_lambda< std::complex<float> >();
-    test_matrix_lambda< std::complex<double> >();
-
-    slate_mpi_call(
-        MPI_Finalize() );
-
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -17,6 +17,9 @@ parser.add_argument( '--run', action='store', default='mpirun -np',
 parser.add_argument( '--np', action='store', default='4',
                      help='number of MPI processes; default=%(default)s' )
 
+parser.add_argument( '--type', action='store', default='s d c z',
+                     help='data types, space separated; default=%(default)s' )
+
 parser.add_argument( 'tests', nargs=argparse.REMAINDER )
 
 opts = parser.parse_args()
@@ -54,11 +57,11 @@ tests = [
     './ex05_blas',
     './ex06_linear_system_lu',
     './ex07_linear_system_cholesky',
-    #'./ex08_linear_system_indefinite',       # failing
+    './ex08_linear_system_indefinite',
     './ex09_least_squares',
     './ex10_svd',
-    #'./ex11_hermitian_eig',                  # failing
-    #'./ex12_generalized_hermitian_eig',      # failing
+    './ex11_hermitian_eig',
+    './ex12_generalized_hermitian_eig',
     './ex13_non_uniform_block_size',
     './ex14_scalapack_gemm',
 ]
@@ -72,8 +75,9 @@ print( 'runner', runner )
 
 failed_tests = []
 
+types = opts.type.split()
 for test in tests:
-    cmd = runner + test.split()
+    cmd = runner + test.split() + types
     err = run_test( cmd )
     if (err):
         failed_tests.append( test )

--- a/examples/util.hh
+++ b/examples/util.hh
@@ -9,7 +9,8 @@
 //------------------------------------------------------------------------------
 void print_func_( int rank, const char* func )
 {
-    printf( "rank %d: %s\n", rank, func );
+    if (rank == 0)
+        printf( "rank %d: %s\n", rank, func );
 }
 
 #ifdef __GNUC__
@@ -165,5 +166,40 @@ void grid_size_square( int mpi_size, int* p_out, int* q_out )
 //------------------------------------------------------------------------------
 // suppress compiler "unused" warning for variable x
 #define unused( x ) ((void) x)
+
+//------------------------------------------------------------------------------
+// Parse command line options:
+// s = single,         sets types[ 0 ]
+// d = double,         sets types[ 1 ]
+// c = complex,        sets types[ 2 ]
+// z = double-complex, sets types[ 3 ]
+// If no options, sets all types to true.
+// Throws error for unknown options.
+void parse_args( int argc, char** argv, bool types[ 4 ] )
+{
+    if (argc == 1) {
+        types[ 0 ] = types[ 1 ] = types[ 2 ] = types[ 3 ] = true;
+    }
+    else {
+        types[ 0 ] = types[ 1 ] = types[ 2 ] = types[ 3 ] = false;
+    }
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[ i ];
+        if (arg == "s")
+            types[ 0 ] = true;
+        else if (arg == "d")
+            types[ 1 ] = true;
+        else if (arg == "c")
+            types[ 2 ] = true;
+        else if (arg == "z")
+            types[ 3 ] = true;
+        else {
+            throw std::runtime_error(
+                "unknown option: \"" + arg + "\"\n"
+                + "Usage: " + argv[ 0 ] + " [s] [d] [c] [z]\n"
+                + "for single, double, complex, double-complex.\n" );
+        }
+    }
+}
 
 #endif // UTIL_H

--- a/src/gbmm.cc
+++ b/src/gbmm.cc
@@ -51,6 +51,8 @@ void gbmm(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
 
     int64_t kl = A.lowerBandwidth();
     int64_t ku = A.upperBandwidth();

--- a/src/gbtrf.cc
+++ b/src/gbtrf.cc
@@ -52,6 +52,7 @@ void gbtrf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
 
     int64_t kl = A.lowerBandwidth();
     int64_t ku = A.upperBandwidth();

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -135,6 +135,7 @@ void gelqf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > block_vector(A_mt);
     uint8_t* block = block_vector.data();
+    SLATE_UNUSED( block ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -58,6 +58,9 @@ void gemmA(
     std::vector<uint8_t> gemmA_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemmA = gemmA_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemmA ); // Used only by OpenMP
+
     const int priority_0 = 0;
     const int queue_0 = 0;
 

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -58,6 +58,9 @@ void gemmC(
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
     uint8_t* c     =     c_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
+    SLATE_UNUSED( c     ); // Used only by OpenMP
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -172,6 +172,7 @@ void geqrf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > block_vector(A_nt);
     uint8_t* block = block_vector.data();
+    SLATE_UNUSED( block ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -67,6 +67,7 @@ void getrf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
 
     // Communication of the jth tile column uses the MPI tag j
     // So, the data dependencies protect the corresponding MPI tags

--- a/src/getrf_nopiv.cc
+++ b/src/getrf_nopiv.cc
@@ -58,10 +58,13 @@ void getrf_nopiv(
     std::vector< uint8_t > diag_vector(A_nt);
     uint8_t* column = column_vector.data();
     uint8_t* diag = diag_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
+    SLATE_UNUSED( diag   ); // Used only by OpenMP
+
     // Running two listBcastMT's simultaneously can hang due to task ordering
     // This dependency avoids that
     uint8_t listBcastMT_token;
-    SLATE_UNUSED(listBcastMT_token); // Only used by OpenMP
+    SLATE_UNUSED( listBcastMT_token ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -126,6 +126,7 @@ void getrf_tntpiv(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
 
     // Running two listBcastMT's simultaneously can hang due to task ordering
     // This dependency avoids that

--- a/src/hbmm.cc
+++ b/src/hbmm.cc
@@ -73,6 +73,8 @@ void hbmm(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
 
     int64_t kd = A.bandwidth();
 

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -173,6 +173,8 @@ void he2hb(
     std::vector< uint8_t > block_vector( nt + 2 );
     uint8_t* block = block_vector.data();
     uint8_t* fetch_trailing  = &block_vector[ nt+1 ];
+    SLATE_UNUSED( block ); // Used only by OpenMP
+    SLATE_UNUSED( fetch_trailing ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -65,6 +65,8 @@ void hemmA(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
 
     if (target == Target::Devices) {
         if (A.num_devices() > 1)

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -81,6 +81,8 @@ void hemmC(
     std::vector<uint8_t>  gemm_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -58,6 +58,9 @@ void her2k(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
+
     const int priority_0 = 0;
     const int queue_0 = 0;
 

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -55,6 +55,9 @@ void herk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
+
     const int priority_0 = 0;
     const int queue_0 = 0;
 

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -56,11 +56,15 @@ void hetrf(
     std::vector< uint8_t > column_vectorT(A_mt);
     uint8_t* columnL = column_vectorL.data();
     uint8_t* columnT = column_vectorT.data();
+    SLATE_UNUSED( columnL ); // Used only by OpenMP
+    SLATE_UNUSED( columnT ); // Used only by OpenMP
 
     std::vector< uint8_t > column_vectorH1(A_mt);
     std::vector< uint8_t > column_vectorH2(A_mt);
     uint8_t* columnH1 = column_vectorH1.data();
     uint8_t* columnH2 = column_vectorH2.data();
+    SLATE_UNUSED( columnH1 ); // Used only by OpenMP
+    SLATE_UNUSED( columnH2 ); // Used only by OpenMP
 
     //std::vector< uint8_t > Ind1(1);
     //std::vector< uint8_t > Ind2(A_mt);
@@ -124,6 +128,8 @@ void hetrf(
         if (T.tileIsLocal(k, k)) {
             // Intel icpc doesn't like std::max in omp task depend clause.
             int64_t k_1 = std::max(izero, k-1);
+            SLATE_UNUSED( k_1 ); // Used only by OpenMP
+
             #pragma omp task depend(in:columnL[k_1]) \
                              depend(out:columnT[k])
             {

--- a/src/internal/internal_copy_col.hh
+++ b/src/internal/internal_copy_col.hh
@@ -122,7 +122,6 @@ void copy_col(
     assert( A.mt() == B.mt() );
 
     int64_t mt = A.mt();
-    int64_t ii = 0;
     for (int64_t i = 0; i < mt; ++i) {
         if (A.tileIsLocal( i, j )) {
             assert( B.tileIsLocal( i, j ) );
@@ -131,10 +130,8 @@ void copy_col(
             int64_t mb = Aij.mb();
             assert( mb == Bik.mb() );
             blas::copy( mb, &Aij.at( 0, jj ), 1, &Bik.at( 0, kk ), 1 );
-            ii += mb;
         }
     }
-    //assert( ii == mlocal );
 }
 
 } // namespace internal

--- a/src/internal/internal_he2hb_gemm.cc
+++ b/src/internal/internal_he2hb_gemm.cc
@@ -58,7 +58,7 @@ void he2hb_gemm(
     for (int64_t i = 0; i < A.mt(); ++i) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C ) \
-            firstprivate( alpha, beta, panel_rank, i ) \
+            firstprivate( alpha, beta, panel_rank, i, layoutc ) \
             priority( priority )
         {
             scalar_t beta_ = beta;
@@ -113,7 +113,8 @@ void he2hb_gemm(
     for (int device = 0; device < C.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, err ) \
-            firstprivate( alpha, beta, panel_rank, queue_index, device, layoutc ) \
+            firstprivate( alpha, beta, panel_rank, queue_index, device, \
+                          layout, layoutc ) \
             priority( priority )
         {
             Op opA = A.op();

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -59,7 +59,7 @@ void he2hb_hemm(
     for (int64_t i = 0; i < mt; ++i) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( one, i )
+            firstprivate( one, i, layoutc )
         {
             for (int64_t j : panel_rank_rows) {
                 if (i >= j) { // lower or diagonal
@@ -183,7 +183,7 @@ void he2hb_hemm(
     for (int device = 0; device < C.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( one, device, mt, num_queues ) \
+            firstprivate( one, device, mt, num_queues, layout ) \
             priority( priority )
         {
             trace::Block trace_block( "blas::batch::he2hb_hemm" );

--- a/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
+++ b/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
@@ -58,7 +58,7 @@ void he2hb_her2k_offdiag_ranks(
     for (int64_t j = 0; j < nt; ++j) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( alpha, beta, j )
+            firstprivate( alpha, beta, j, layoutc )
         {
             for (int64_t i : panel_rank_rows) {
                 // todo: if HermitianMatrix returned conjTrans
@@ -133,7 +133,7 @@ void he2hb_her2k_offdiag_ranks(
     for (int device = 0; device < C.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, err, panel_rank_rows ) \
-            firstprivate( alpha, beta, device, nt, layoutc, queue_index ) \
+            firstprivate( alpha, beta, device, nt, layout, layoutc, queue_index ) \
             priority( priority )
         {
             Op opA = A.op();

--- a/src/internal/internal_he2hb_trmm.cc
+++ b/src/internal/internal_he2hb_trmm.cc
@@ -64,7 +64,7 @@ void he2hb_trmm(
     for (int64_t i = 0; i < B.mt(); ++i) {
         #pragma omp task slate_omp_default_none \
             shared( A0, AH, B, panel_rank_rows ) \
-            firstprivate( one, i, mpi_rank ) \
+            firstprivate( one, i, mpi_rank, layoutc ) \
             priority( priority )
         {
             int rank_lower = -1;
@@ -130,7 +130,7 @@ void he2hb_trmm(
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, AH, B, panel_rank_rows ) \
-            firstprivate( device, queue_index, mpi_rank ) \
+            firstprivate( device, queue_index, mpi_rank, layout, layoutc ) \
             priority( priority )
         {
             std::set<ij_tuple> B_tiles_set, A0_tiles_set;

--- a/src/internal/internal_unmtr_hb2st.cc
+++ b/src/internal/internal_unmtr_hb2st.cc
@@ -114,6 +114,7 @@ void unmtr_hb2st( internal::TargetType<target>,
     // Add one phantom row at bottom to ease specifying dependencies.
     std::vector< uint8_t > row_vector(mt+1);
     uint8_t* row = row_vector.data();
+    SLATE_UNUSED( row ); // Used only by OpenMP
 
     // See SWAN13 for the definition of parallel tasks.
     //

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -47,6 +47,7 @@ void pbtrf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
 
     int64_t kd = A.bandwidth();
 

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -46,6 +46,7 @@ void potrf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );
@@ -177,6 +178,7 @@ void potrf(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > column_vector(A_nt);
     uint8_t* column = column_vector.data();
+    SLATE_UNUSED( column ); // Used only by OpenMP
 
     // Allocate batch arrays = number of kernels without lookahead + lookahead
     // number of kernels without lookahead = 3

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -81,6 +81,8 @@ void symm(
     std::vector<uint8_t>  gemm_vector( A.nt() );
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -62,6 +62,9 @@ void syr2k(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
+
     const int priority_0 = 0;
     const int queue_0 = 0;
 

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -61,6 +61,8 @@ void syrk(
     std::vector<uint8_t>  gemm_vector(A.nt());
     uint8_t* bcast = bcast_vector.data();
     uint8_t* gemm  =  gemm_vector.data();
+    SLATE_UNUSED( bcast ); // Used only by OpenMP
+    SLATE_UNUSED( gemm  ); // Used only by OpenMP
 
     if (target == Target::Devices) {
         C.allocateBatchArrays();

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -70,6 +70,7 @@ void tbsm(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> row_vector(A.nt());
     uint8_t* row = row_vector.data();
+    SLATE_UNUSED( row ); // Used only by OpenMP
 
     // todo: initially, assume fixed size, square tiles for simplicity
     int64_t kdt = ceildiv( A.bandwidth(), A.tileNb(0) );

--- a/src/trtri.cc
+++ b/src/trtri.cc
@@ -45,6 +45,8 @@ void trtri(
     std::vector< uint8_t > row_vector(A_nt);
     uint8_t* col = col_vector.data();
     uint8_t* row = row_vector.data();
+    SLATE_UNUSED( col ); // Used only by OpenMP
+    SLATE_UNUSED( row ); // Used only by OpenMP
 
     int tag = 0;
 

--- a/src/trtrm.cc
+++ b/src/trtrm.cc
@@ -43,6 +43,7 @@ void trtrm(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > row_vector(A_nt);
     uint8_t* row = row_vector.data();
+    SLATE_UNUSED( row ); // Used only by OpenMP
 
     if (target == Target::Devices) {
         A.allocateBatchArrays();

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -63,6 +63,7 @@ void unmlq(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > block_vector(A_mt);
     uint8_t* block = block_vector.data();
+    SLATE_UNUSED( block ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -67,6 +67,7 @@ void unmqr(
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector< uint8_t > block_vector(A_nt);
     uint8_t* block = block_vector.data();
+    SLATE_UNUSED( block ); // Used only by OpenMP
 
     // set min number for omp nested active parallel regions
     slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );


### PR DESCRIPTION
This prepares for CI for SYCL, but the actual CI changes are moved to another PR because this PR got too unwieldy.

- Update examples used for smoke tests to take precision, as in BLAS++. This is needed because our Intel GPU does only single precision.

- Mark OpenMP variables UNUSED because clang (icpx) doesn't think they are used, since only OpenMP pragmas use them.

- Add more variables / constants to OpenMP shared / firstprivate, because clang (icpx) is fussier about including all constants as well as variables.

The CI changes passed here: https://github.com/icl-utk-edu/slate/actions/runs/5769375007/job/15641344312?pr=74
But I removed those so they can be reviewed more closely, particularly the Makefile / CMake updates.