### PR TITLE
Add #ifdef to use listBcastMT

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,6 +36,7 @@ BLAS++, LAPACK++, and TestSweeper.
     CXX  = mpicxx    # MPI compiler wrappers recommended
     FC   = mpif90
     blas = openblas
+    CXXFLAGS = -DSLATE_HAVE_MT_BCAST
 
 Compile and install:
 
@@ -45,6 +46,7 @@ Compile and install:
 
     export CXX=g++      # or your preferred C++ compiler
     export FC=gfortran  # or your preferred Fortran compiler
+    export CXXFLAGS = -DSLATE_HAVE_MT_BCAST
     mkdir build && cd build
     cmake -Dblas=openblas ..
     make && make install
@@ -58,6 +60,13 @@ These include:
 
     CXX                 C++ compiler
     CXXFLAGS            C++ compiler flags
+        * SLATE_HAVE_MT_BCAST uses multiple OMP threads for MPI broadcast communication.
+        Using this flag to enable multithreading broadcast communication achieves
+        better performance but causes hangs on certain systems, particularly Frontier.
+        using make.inc file:
+            CXXFLAGS = -DSLATE_HAVE_MT_BCAST
+        using cmake:
+            export CXXFLAGS = -DSLATE_HAVE_MT_BCAST
     FC                  Fortran compiler
     FCFLAGS             Fortran compiler flags
     LDFLAGS             linker flags

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2098,9 +2098,11 @@ void BaseMatrix<scalar_t>::listBcastMT(
     using BcastTag =
         std::tuple< int64_t, int64_t, std::list<BaseMatrix<scalar_t> >, int64_t >;
 
-    #pragma omp taskloop slate_omp_default_none \
-        shared( bcast_list ) \
-        firstprivate(life_factor, layout, mpi_size, is_shared)
+    #if defined( SLATE_HAVE_listBcastMT )
+        #pragma omp taskloop slate_omp_default_none \
+            shared( bcast_list ) \
+            firstprivate(life_factor, layout, mpi_size, is_shared)
+    #endif
     for (size_t bcastnum = 0; bcastnum < bcast_list.size(); ++bcastnum) {
 
         BcastTag bcast = bcast_list[bcastnum];

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2098,7 +2098,7 @@ void BaseMatrix<scalar_t>::listBcastMT(
     using BcastTag =
         std::tuple< int64_t, int64_t, std::list<BaseMatrix<scalar_t> >, int64_t >;
 
-    #if defined( SLATE_HAVE_listBcastMT )
+    #if defined( SLATE_HAVE_MT_BCAST )
         #pragma omp taskloop slate_omp_default_none \
             shared( bcast_list ) \
             firstprivate(life_factor, layout, mpi_size, is_shared)


### PR DESCRIPTION
Use `#ifdef` to make  using`listBcastMT` optional.
Disabling `listBcastMT` and using `export SLATE_GPU_AWARE_MPI=1`, `gemm`, `potrf` and `getrf`, works fine using 4 and 16 nodes on Frontier. 

**Tests on 4 nodes:**

```
export OMP_NUM_THREADS=7
% SLATE version 2023.06.00, id 6718f4b7
% input: /ccs/home/sukkari/frontier-lib-dev/slate/test/tester --type d --nb 960 --dim 2000,28000:280000:28000 --transA n --transB n --check y --ref n --origin d --target d --lookahead 1 --repeat 1 gemm
% 2023-07-24 14:16:57, 32 MPI ranks, GPU-aware MPI, 7 OpenMP threads, 1 GPU devices per MPI rank

type  origin  target  gemm   go   A   B   C   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status
   d     dev     dev  auto  col   1   1   1  notrans  notrans    2000    2000    2000   3.1+1.4i   2.7+1.7i   960    4    8   1   6.43e-16    0.00479      3342.610            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans   28000   28000   28000   3.1+1.4i   2.7+1.7i   960    4    8   1   2.13e-16      0.290    151553.905            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans   56000   56000   56000   3.1+1.4i   2.7+1.7i   960    4    8   1   1.94e-16      1.116    314860.469            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans   84000   84000   84000   3.1+1.4i   2.7+1.7i   960    4    8   1   1.87e-16      2.544    465936.235            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  112000  112000  112000   3.1+1.4i   2.7+1.7i   960    4    8   1   2.18e-16      5.191    541316.729            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  140000  140000  140000   3.1+1.4i   2.7+1.7i   960    4    8   1   1.65e-16      9.888    555008.476            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  168000  168000  168000   3.1+1.4i   2.7+1.7i   960    4    8   1   2.21e-16     16.196    585521.270            NA            NA  pass
```

```
export OMP_NUM_THREADS=7
% SLATE version 2023.06.00, id 6718f4b7
% input: /ccs/home/sukkari/frontier-lib-dev/slate/test/tester --type d --nb 960 --dim 1000,28000:280000:28000 --check y --ref n --origin d --target d --lookahead 1 --repeat 1 --method-trsm trsmB potrf
% 2023-07-24 15:42:00, 32 MPI ranks, GPU-aware MPI, 7 OpenMP threads, 1 GPU devices per MPI rank

type  origin  target  hemm  trsm  trs   dev-dist   A   B    uplo       n    nrhs    nb    p    q  la      error   time (s)       gflop/s  trs time (s)   trs gflop/s  ref time (s)   ref gflop/s  status
   d     dev     dev  auto     B  all        col   1   2   lower    1000      10   960    4    8   1   3.62e-19      1.271         0.263         0.189         0.106            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower   28000      10   960    4    8   1   1.50e-20      3.025      2419.314         0.286        54.765            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower   56000      10   960    4    8   1   8.46e-21      2.533     23107.616         0.873        71.869            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower   84000      10   960    4    8   1   6.54e-21      4.775     41380.229         1.802        78.317            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  112000      10   960    4    8   1   5.15e-21      8.367     55972.095         2.851        87.998            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  140000      10   960    4    8   1   4.74e-21     13.065     70008.858         3.958        99.030            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  168000      10   960    4    8   1   4.07e-21     18.804     84052.417         5.864        96.269            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  196000      10   960    4    8   1   3.58e-21     24.501    102438.257         6.352       120.952            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  224000      10   960    4    8   1   3.21e-21     30.012    124833.919         8.227       121.981            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  252000      10   960    4    8   1   2.99e-21     38.624    138110.157        10.367       122.514            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  280000      10   960    4    8   1   3.05e-21     48.551    150716.435        12.761       122.870            NA            NA  pass
```

```
export OMP_NUM_THREADS=7
% SLATE version 2023.06.00, id 6718f4b7
% input: /ccs/home/sukkari/frontier-lib-dev/slate/test/tester --type d --nb 960 --dim 1000,28000:280000:28000 --check y --ref n --origin d --target d --lookahead 1 --repeat 1 getrf
% 2023-07-24 14:28:14, 32 MPI ranks, GPU-aware MPI, 7 OpenMP threads, 1 GPU devices per MPI rank

type  origin  target  gemm     lu  trsm   go   A   B       m       n    nrhs    nb  ib    p    q  la  pt  thresh      error   time (s)       gflop/s  trs time (s)   trs gflop/s  ref time (s)   ref gflop/s  status
   d     dev     dev  auto   PPLU  auto  col   1   1    1000    1000      10   960  32    4    8   1   3    1.00   2.62e-19      0.494         1.349         0.347        0.0576            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1   28000   28000      10   960  32    4    8   1   3    1.00   7.78e-20      3.631      4030.646        0.0982       159.716            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1   56000   56000      10   960  32    4    8   1   3    1.00   5.08e-20     11.152     10497.755         0.169       370.598            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1   84000   84000      10   960  32    4    8   1   3    1.00   3.89e-20     25.156     15707.012         0.252       559.734            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1  112000  112000      10   960  32    4    8   1   3    1.00   3.40e-20     45.068     20782.035         0.334       750.083            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1  140000  140000      10   960  32    4    8   1   3    1.00   2.98e-20     70.364     25997.949         0.421       930.480            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1  168000  168000      10   960  32    4    8   1   3    1.00   2.68e-20    100.844     31346.153         0.510      1107.272            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1  196000  196000      10   960  32    4    8   1   3    1.00   2.43e-20    138.394     36270.818         0.597      1287.812            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1  224000  224000      10   960  32    4    8   1   3    1.00   2.28e-20    242.389     30912.803         0.690      1454.037            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1  252000  252000      10   960  32    4    8   1   3    1.00   2.13e-20    227.910     46810.832         0.787      1614.590            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   0   0  280000  280000      10   960  32    4    8   1   3    1.00         NA         NA            NA            NA            NA            NA            NA  FAILED

^[[1m^[[31mError on rank 0: out of memory, in function device_malloc. (32 ranks had some error.)^[[0m
```

**Tests on 16 nodes:**
```
export OMP_NUM_THREADS=7
% SLATE version 2023.06.00, id 6718f4b7
% input: /ccs/home/sukkari/frontier-lib-dev/slate/test/tester --type d --nb 960 --dim 2000,56000:560000:56000 --transA n --transB n --check y --ref n --origin d --target d --lookahead 1 --repeat 1 gemm
% 2023-07-24 14:28:16, 128 MPI ranks, GPU-aware MPI, 7 OpenMP threads, 1 GPU devices per MPI rank

type  origin  target  gemm   go   A   B   C   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status
   d     dev     dev  auto  col   1   1   1  notrans  notrans    2000    2000    2000   3.1+1.4i   2.7+1.7i   960    8   16   1   6.39e-16    0.00425      3768.797            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans   56000   56000   56000   3.1+1.4i   2.7+1.7i   960    8   16   1   1.80e-16      0.789    445299.714            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  112000  112000  112000   3.1+1.4i   2.7+1.7i   960    8   16   1   1.80e-16      2.963    948209.488            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  168000  168000  168000   3.1+1.4i   2.7+1.7i   960    8   16   1   1.78e-16      6.542   1449557.540            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  224000  224000  224000   3.1+1.4i   2.7+1.7i   960    8   16   1   2.07e-16     11.727   1916911.816            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  280000  280000  280000   3.1+1.4i   2.7+1.7i   960    8   16   1   1.58e-16     20.426   2149454.277            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  336000  336000  336000   3.1+1.4i   2.7+1.7i   960    8   16   1   2.17e-16     41.564   1825299.102            NA            NA  pass
   d     dev     dev  auto  col   1   1   1  notrans  notrans  392000  392000  392000   3.1+1.4i   2.7+1.7i   960    8   16   1   1.76e-16     58.130   2072465.919            NA            NA  pass
```
```
export OMP_NUM_THREADS=7
% SLATE version 2023.06.00, id 6718f4b7
% input: /ccs/home/sukkari/frontier-lib-dev/slate/test/tester --type d --nb 960 --dim 1000,56000:560000:56000 --check y --ref n --origin d --target d --lookahead 1 --repeat 1 --method-trsm trsmB potrf
% 2023-07-24 14:28:13, 128 MPI ranks, GPU-aware MPI, 7 OpenMP threads, 1 GPU devices per MPI rank

type  origin  target  hemm  trsm  trs   dev-dist   A   B    uplo       n    nrhs    nb    p    q  la      error   time (s)       gflop/s  trs time (s)   trs gflop/s  ref time (s)   ref gflop/s  status
   d     dev     dev  auto     B  all        col   1   2   lower    1000      10   960    8   16   1   3.65e-19      1.405         0.238         0.203        0.0984            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower   56000      10   960    8   16   1   8.09e-21      5.920      9888.576         0.532       117.810            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  112000      10   960    8   16   1   4.83e-21      5.572     84040.607         1.392       180.285            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  168000      10   960    8   16   1   3.80e-21     11.639    135798.222         2.806       201.151            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  224000      10   960    8   16   1   2.96e-21     20.035    186999.797         4.739       211.758            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  280000      10   960    8   16   1   2.82e-21     40.949    178695.172        11.396       137.598            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  336000      10   960    8   16   1   2.45e-21     60.196    210054.596        16.301       138.515            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  392000      10   960    8   16   1   2.19e-21     76.461    262601.071        13.724       223.943            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  448000      10   960    8   16   1   1.98e-21     85.444    350777.909        28.229       142.197            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  504000      10   960    8   16   1   1.83e-21    138.190    308812.266        22.446       226.339            NA            NA  pass
   d     dev     dev  auto     B  all        col   1   2   lower  560000      10   960    8   16   1   1.91e-21    130.323    449180.901        27.425       228.696            NA            NA  pass
```

```
export OMP_NUM_THREADS=7
% SLATE version 2023.06.00, id 6718f4b7
% input: /ccs/home/sukkari/frontier-lib-dev/slate/test/tester --type d --nb 960 --dim 1000,56000:560000:56000 --check y --ref n --origin d --target d --lookahead 1 --repeat 1 getrf
% 2023-07-24 14:34:13, 128 MPI ranks, GPU-aware MPI, 7 OpenMP threads, 1 GPU devices per MPI rank

type  origin  target  gemm     lu  trsm   go   A   B       m       n    nrhs    nb  ib    p    q  la  pt  thresh      error   time (s)       gflop/s  trs time (s)   trs gflop/s  ref time (s)   ref gflop/s  status
   d     dev     dev  auto   PPLU  auto  col   1   1    1000    1000      10   960  32    8   16   1   3    1.00   3.31e-19      0.465         1.432         0.597        0.0335            NA            NA  pass
   d     dev     dev  auto   PPLU  auto  col   1   1   56000   56000      10   960  32    8   16   1   3    1.00   5.05e-20      7.877     14862.622         0.222       282.886            NA            NA  pass
```