### PR TITLE
initial papi instrumentation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -165,6 +165,14 @@ ifneq ($(c_api),1)
 endif
 
 #-------------------------------------------------------------------------------
+ifeq (${papi},1)
+    CXXFLAGS  += -DBLAS_HAVE_PAPI -I ${PAPI_DIR}/include
+    LDFLAGS   += -L ${PAPI_DIR}/lib -Wl,-rpath,${abspath ${PAPI_DIR}/lib}
+    LIBS      += -lsde
+    TEST_LIBS += -lpapi
+endif
+
+#-------------------------------------------------------------------------------
 # if shared
 ifneq ($(static),1)
     CXXFLAGS   += -fPIC

--- a/test/test.hh
+++ b/test/test.hh
@@ -56,6 +56,7 @@ public:
     testsweeper::ParamChar   hold_local_workspace;
     testsweeper::ParamChar   trace;
     testsweeper::ParamDouble trace_scale;
+    testsweeper::ParamChar   papi;
     testsweeper::ParamDouble tol;
     testsweeper::ParamInt    repeat;
     testsweeper::ParamInt    verbose;


### PR DESCRIPTION
Still needs LAPACK routine support, issues with counter not resetting

```
calebhan ~/slate/test/> ./tester --repeat 3 --papi y --dim 500:500 --nb 200 --check n --ref n gemm
% SLATE version 2023.06.00, id 30873c6e
% input: ./tester --repeat 3 --papi y --dim 500:500 --nb 200 --check n --ref n gemm
% 2023-07-28 17:28:29, 1 MPI ranks, CPU-only MPI, 256 OpenMP threads, 8 GPU devices per MPI rank
                                                                                                                                                                                                         
type  origin  target  gemm   go   A   B   C   transA   transB       m       n       k      alpha       beta    nb    p    q  la      error   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
   d    host    task  auto  col   1   1   1  notrans  notrans     500     500     500   3.1+1.4i   2.7+1.7i   200    1    1   1         NA     0.0205        12.176            NA            NA  no check  
gemm( N, N, 200, 200, 100 ) count 4, flop count 3.20e+07
gemm( N, N, 200, 100, 200 ) count 4, flop count 3.20e+07
gemm( N, N, 100, 200, 100 ) count 2, flop count 8.00e+06
gemm( N, N, 200, 200, 200 ) count 8, flop count 1.28e+08
gemm( N, N, 100, 100, 200 ) count 2, flop count 8.00e+06
gemm( N, N, 100, 100, 100 ) count 1, flop count 2.00e+06
gemm( N, N, 100, 200, 200 ) count 4, flop count 3.20e+07
gemm( N, N, 200, 100, 100 ) count 2, flop count 8.00e+06
total BLAS flop count 2.50e+08

   d    host    task  auto  col   1   1   1  notrans  notrans     500     500     500   3.1+1.4i   2.7+1.7i   200    1    1   1         NA     0.0231        10.843            NA            NA  no check  
gemm( N, N, 200, 200, 100 ) count 8, flop count 6.40e+07
gemm( N, N, 200, 100, 200 ) count 8, flop count 6.40e+07
gemm( N, N, 100, 200, 100 ) count 4, flop count 1.60e+07
gemm( N, N, 200, 200, 200 ) count 16, flop count 2.56e+08
gemm( N, N, 100, 100, 200 ) count 4, flop count 1.60e+07
gemm( N, N, 100, 100, 100 ) count 2, flop count 4.00e+06
gemm( N, N, 100, 200, 200 ) count 8, flop count 6.40e+07
gemm( N, N, 200, 100, 100 ) count 4, flop count 1.60e+07
total BLAS flop count 5.00e+08

   d    host    task  auto  col   1   1   1  notrans  notrans     500     500     500   3.1+1.4i   2.7+1.7i   200    1    1   1         NA     0.0202        12.375            NA            NA  no check  
gemm( N, N, 200, 200, 100 ) count 12, flop count 9.60e+07
gemm( N, N, 200, 100, 200 ) count 12, flop count 9.60e+07
gemm( N, N, 100, 200, 100 ) count 6, flop count 2.40e+07
gemm( N, N, 200, 200, 200 ) count 24, flop count 3.84e+08
gemm( N, N, 100, 100, 200 ) count 6, flop count 2.40e+07
gemm( N, N, 100, 100, 100 ) count 3, flop count 6.00e+06
gemm( N, N, 100, 200, 200 ) count 12, flop count 9.60e+07
gemm( N, N, 200, 100, 100 ) count 6, flop count 2.40e+07
total BLAS flop count 7.50e+08



% Matrix kinds:
%  1: rand, cond unknown

% All tests passed: gemm
```