### PR TITLE
Fix an issue in gridinfo when mpi_size == 1 and the matrix has manual…

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -1252,7 +1252,14 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::gridinfo(
     GridOrder* order, int* nprow, int* npcol, int* myrow, int* mycol ) const
 {
-    if (nprow_ > 0) {
+    int mpi_size;
+    MPI_Comm_size(mpiComm(), &mpi_size);
+    if (mpi_size == 1) {
+        *order = GridOrder::Col;
+        *nprow = *npcol = 1;
+        *myrow = *mycol = 0;
+    }
+    else if (nprow_ > 0) {
         *order = order_;
         *nprow = nprow_;
         *npcol = npcol_;

--- a/unit_test/test_HermitianMatrix.cc
+++ b/unit_test/test_HermitianMatrix.cc
@@ -46,11 +46,11 @@ void test_HermitianMatrix_default()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Unknown );
-    test_assert( myp == -1 );
-    test_assert( myq == -1 );
-    test_assert( myrow == -1 );
-    test_assert( mycol == -1 );
+    test_assert( order == GridOrder::Col );
+    test_assert( myp == 1 );
+    test_assert( myq == 1 );
+    test_assert( myrow == 0 );
+    test_assert( mycol == 0 );
 }
 
 //------------------------------------------------------------------------------

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -241,11 +241,11 @@ void test_Matrix_lambda()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Unknown );
-    test_assert( myp == -1 );
-    test_assert( myq == -1 );
-    test_assert( myrow == -1 );
-    test_assert( mycol == -1 );
+    test_assert( order == GridOrder::Col );
+    test_assert( myp == 1 );
+    test_assert( myq == 1 );
+    test_assert( myrow == 0 );
+    test_assert( mycol == 0 );
 
     auto tileMb_     = A.tileMbFunc();
     auto tileNb_     = A.tileNbFunc();
@@ -1752,6 +1752,8 @@ void test_Matrix_MOSI()
 
     A.reserveDeviceWorkspace();
 
+    // Copy tiles to GPU for reading with the same layout.
+    // assert on tileState to be Shared on CPU and GPU.
     A.tileGetAllForReadingOnDevices(slate::LayoutConvert::None);
 
     for (int j = 0; j < A.nt(); ++j) {
@@ -1763,6 +1765,8 @@ void test_Matrix_MOSI()
         }
     }
 
+    // Copy tiles to GPU for writing with the same layout.
+    // assert on tileState to be Invalid on CPU and Modified GPU.
     A.tileGetAllForWritingOnDevices(slate::LayoutConvert::None);
 
     for (int j = 0; j < A.nt(); ++j) {
@@ -1774,6 +1778,8 @@ void test_Matrix_MOSI()
         }
     }
 
+    // Update tiles on CPU.
+    // assert on tileState to be Shared on CPU and GPU.
     A.tileUpdateAllOrigin();
 
     for (int j = 0; j < A.nt(); ++j) {
@@ -1789,6 +1795,8 @@ void test_Matrix_MOSI()
 
     A.releaseWorkspace();
 
+    // Copy tiles to CPU for reading with the RowMajor layout.
+    // assert on RowMajor layout.
     A.tileGetAllForReading( HostNum, slate::LayoutConvert::RowMajor );
 
     for (int j = 0; j < A.nt(); ++j) {
@@ -1801,6 +1809,8 @@ void test_Matrix_MOSI()
         }
     }
 
+    // Copy tiles to GPU for writing with the RowMajor layout.
+    // assert on RowMajor layout.
     A.tileGetAllForWritingOnDevices(slate::LayoutConvert::None);
 
     for (int j = 0; j < A.nt(); ++j) {
@@ -1812,6 +1822,8 @@ void test_Matrix_MOSI()
         }
     }
 
+    // Copy tiles to CPU for writing with the ColMajor layout.
+    // assert on ColMajor layout.
     A.tileGetAllForWriting( HostNum, slate::LayoutConvert::ColMajor );
 
     for (int j = 0; j < A.nt(); ++j) {

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -45,11 +45,11 @@ void test_Matrix_default()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Unknown );
-    test_assert( myp == -1 );
-    test_assert( myq == -1 );
-    test_assert( myrow == -1 );
-    test_assert( mycol == -1 );
+    test_assert( order == GridOrder::Col );
+    test_assert( myp == 1 );
+    test_assert( myq == 1 );
+    test_assert( myrow == 0 );
+    test_assert( mycol == 0 );
 
     // todo: What is reasonable in this case? It segfaults right now.
     // auto tileMb_     = A.tileMbFunc();

--- a/unit_test/test_SymmetricMatrix.cc
+++ b/unit_test/test_SymmetricMatrix.cc
@@ -46,11 +46,11 @@ void test_SymmetricMatrix_default()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Unknown );
-    test_assert( myp == -1 );
-    test_assert( myq == -1 );
-    test_assert( myrow == -1 );
-    test_assert( mycol == -1 );
+    test_assert( order == GridOrder::Col );
+    test_assert( myp == 1 );
+    test_assert( myq == 1 );
+    test_assert( myrow == 0 );
+    test_assert( mycol == 0 );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
If A is created using a manual tiles distribution by using Lambda function for the tileRank instead of a p-by-q 2D block-cyclic distribution:
```
    auto A = slate::HermitianMatrix<scalar_t>(                                                                        
        uplo, n, tileNb, tileRank, tileDevice, MPI_COMM_WORLD);
```
then testing routines that check on grid order (restriced to col-major) may fails using 1 mpi rank (ex: test_he2hb).
However, for 1 mpi rank (1-by-1 grid), col-major or row-major is irrelevant. This PR sets gridorder to col-major in case of using 1 mpi rank.
