### PR TITLE
[Fix] trsmA: remove the use of transpose for the scaling and setting of tiles.

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -30,8 +30,7 @@ if [ "$device" = "cpu" ]; then
     origin="s"
     tests=""
 else
-    # trsmA currently fails device tests. Enable when it is fixed.
-    tests="-x trsmA"
+    tests=""
 fi
 
 if [ "$maker" = "cmake" ]; then

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -326,15 +326,18 @@ void gemmA(internal::TargetType<Target::Devices>,
                         i, 0, device, LayoutConvert( layout ) );
 
                     auto T = C( i, 0, device );
-                    if (T.op() == Op::Trans || T.op() == Op::ConjTrans)
-                        T = transpose( T );
+                    int64_t T_mb = T.mb();
+                    int64_t T_nb = T.nb();
+                    if (T.op() != Op::NoTrans) {
+                        swap( T_mb, T_nb );
+                    }
 
                     if (beta == zero) {
-                        device::geset( T.mb(), T.nb(), beta, beta,
+                        device::geset( T_mb, T_nb, beta, beta,
                             T.data(), T.stride(), *queue );
                     }
                     else{
-                        device::gescale( T.mb(), T.nb(), beta, one,
+                        device::gescale( T_mb, T_nb, beta, one,
                             T.data(), T.stride(), *queue );
                     }
                 }
@@ -373,10 +376,13 @@ void gemmA(internal::TargetType<Target::Devices>,
                                 C.tileInsertWorkspace( i, 0, device );
                                 C.tileModified( i, 0, device );
                                 auto T = C( i, 0, device );
-                                if (T.op() == Op::Trans || T.op() == Op::ConjTrans)
-                                    T = transpose( T );
+                                int64_t T_mb = T.mb();
+                                int64_t T_nb = T.nb();
+                                if (T.op() != Op::NoTrans) {
+                                    swap( T_mb, T_nb );
+                                }
 
-                                device::geset( T.mb(), T.nb(), zero, zero,
+                                device::geset( T_mb, T_nb, zero, zero,
                                     T.data(), T.stride(), *queue );
                             }
                         }


### PR DESCRIPTION
## Issue

See issue [66](https://github.com/icl-utk-edu/slate/issues/66)

## Solution
When scaling the RHS, we do not transpose it to avoid the weird case of transposing a conjugate-transpose state.

## Checking
```bash
OMP_NUM_THREADS=5 mpirun -n 4 ./gpu_bind.sh 4 ./test/tester --dim 1000 --nb 63 --grid 1x4,2x2,4x1 --verbose 0 --origin h,s,d --target t,d --seed 0 --alpha 1.0,-2.123 --seedB 0 --uplo lower,upper --side left,right --transA n,t,c --diag n,u --type s,d,c,z --lookahead 0,1,2 --repeat 1 trsmA
```