### PR TITLE
Changed CI compiler to gcc@10.4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,9 @@ jobs:
     strategy:
       matrix:
         maker: [make, cmake]
-        device: [cpu, gpu_amd]
+        device: [cpu, gpu_nvidia, gpu_amd, gpu_intel]
       fail-fast: false
-    runs-on: dopamine
-#${{ matrix.device }}
+    runs-on: ${{ matrix.device }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,10 @@ jobs:
     strategy:
       matrix:
         maker: [make, cmake]
-        device: [cpu, gpu_nvidia, gpu_amd, gpu_intel]
+        device: [cpu, gpu_amd]
       fail-fast: false
-    runs-on: ${{ matrix.device }}
+    runs-on: dopamine
+#${{ matrix.device }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -67,7 +67,7 @@ if [ "${device}" = "gpu_intel" ]; then
     quiet module load intel-oneapi-compilers
 else
     print "======================================== Load GNU compiler"
-    quiet module load gcc@8.5.0
+    quiet module load gcc@9.5.0
 fi
 print "---------------------------------------- Verify compiler"
 print "CXX = $CXX"

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -67,7 +67,7 @@ if [ "${device}" = "gpu_intel" ]; then
     quiet module load intel-oneapi-compilers
 else
     print "======================================== Load GNU compiler"
-    quiet module load gcc@9.5.0
+    quiet module load gcc@10.4.0
 fi
 print "---------------------------------------- Verify compiler"
 print "CXX = $CXX"


### PR DESCRIPTION
The next version of ROCM required minimum gcc version 9.  This upgrades the CI scripts to use this version so that we can later upgrade the ROCM on the CI image.