### PR TITLE
Unit test updates

### DIFF
--- a/unit_test/test_geadd.cc
+++ b/unit_test/test_geadd.cc
@@ -193,25 +193,24 @@ void test_geadd_dev()
         };
 
     // Each tuple contains (alpha, beta)
-    std::list<
-              std::tuple< std::complex<double>, std::complex<double> >
-             > values_list{
+    std::list< std::tuple< std::complex<double>, std::complex<double> > >
+        values_list{
             // All 0
             { {   0,   0 },
               {   0,   0 } },
-            // 1 and 1
+            // alpha == 1, beta == 1
             { {   1,   0 },
               {   1,   0 } },
-            // Offdiag 0, diag != 0
+            // alpha == 0, beta != 0
             { {   0,   0 },
               { 0.5, 0.5 } },
-            // Offdiag != 0, diag 0
+            // alpha != 0, beta == 0
             { { 0.3, 0.3 },
               {   0,   0 } },
-            // Real != 0, Imag 0
+            // Real == 0, Imag != 0
             { {   0, 0.3 },
               {   0, 0.5 } },
-            // Real = 0, Imag != 0
+            // Real != 0, Imag == 0
             { { 0.3,   0 },
               { 0.5,   0 } },
             // Standard case
@@ -494,22 +493,24 @@ void test_geadd_batch_dev()
         };
 
     // Each tuple contains (alpha, beta)
-    std::list<
-              std::tuple< std::complex<double>, std::complex<double> >
-             > values_list{
+    std::list< std::tuple< std::complex<double>, std::complex<double> > >
+        values_list{
             // All 0
             { {   0,   0 },
               {   0,   0 } },
-            // Offdiag 0, diag != 0
+            // alpha == 1, beta == 1
+            { {   1,   0 },
+              {   1,   0 } },
+            // alpha == 0, beta != 0
             { {   0,   0 },
               { 0.5, 0.5 } },
-            // Offdiag != 0, diag 0
+            // alpha != 0, beta == 0
             { { 0.3, 0.3 },
               {   0,   0 } },
-            // Real != 0, Imag 0
+            // Real == 0, Imag != 0
             { {   0, 0.3 },
               {   0, 0.5 } },
-            // Real = 0, Imag != 0
+            // Real != 0, Imag == 0
             { { 0.3,   0 },
               { 0.5,   0 } },
             // Standard case

--- a/unit_test/test_lq.cc
+++ b/unit_test/test_lq.cc
@@ -169,6 +169,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
         print( "Q^H C2", C2 );
     }
 
+    // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
         slate::tpmlqt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 );
         if (verbose > 1) {
@@ -179,8 +180,9 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
     else {
         // LAPACK xerbla may print error, e.g.,
         // "On entry to ZTPMLQT parameter number  2 had an illegal value"
-        test_assert_throw_std(
-            slate::tpmlqt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 ));
+        // By default, xerbla will exit, so disable this for routine testing.
+        //test_assert_throw_std(
+        //    slate::tpmlqt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 ));
     }
 
     //---------------------
@@ -217,6 +219,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
         print( "D2 Q^H", D2 );
     }
 
+    // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
         slate::tpmlqt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 );
         if (verbose > 1) {
@@ -227,8 +230,9 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
     else {
         // LAPACK xerbla may print error, e.g.,
         // "On entry to ZTPMLQT parameter number  2 had an illegal value"
-        test_assert_throw_std(
-            slate::tpmlqt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
+        // By default, xerbla will exit, so disable this for routine testing.
+        //test_assert_throw_std(
+        //    slate::tpmlqt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
     }
 }
 

--- a/unit_test/test_qr.cc
+++ b/unit_test/test_qr.cc
@@ -170,6 +170,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         print( "Q^H C2", C2 );
     }
 
+    // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
         slate::tpmqrt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 );
         if (verbose > 1) {
@@ -180,8 +181,9 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
     else {
         // LAPACK xerbla may print error, e.g.,
         // "On entry to ZTPMQRT parameter number  2 had an illegal value"
-        test_assert_throw_std(
-            slate::tpmqrt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 ));
+        // By default, xerbla will exit, so disable this for routine testing.
+        //test_assert_throw_std(
+        //    slate::tpmqrt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 ));
     }
 
     //---------------------
@@ -218,6 +220,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         print( "D2 Q^H", D2 );
     }
 
+    // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
         slate::tpmqrt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 );
         if (verbose > 1) {
@@ -228,8 +231,9 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
     else {
         // LAPACK xerbla may print error, e.g.,
         // "On entry to ZTPMQRT parameter number  2 had an illegal value"
-        test_assert_throw_std(
-            slate::tpmqrt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
+        // By default, xerbla will exit, so disable this for routine testing.
+        //test_assert_throw_std(
+        //    slate::tpmqrt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
     }
 }
 


### PR DESCRIPTION
Fixes comments in test_geadd.
- offdiag & diag => alpha & beta.
- In some cases, == 0 and != 0 were swapped.

Disables QR and LQ tests using Op::Trans. These invoke xerbla, which on some platforms (e.g, Frontier) will cause the tester to exit immediately with an error.