### PR TITLE
Changing CI to gcc 11.3

### DIFF
--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -67,7 +67,7 @@ if [ "${device}" = "gpu_intel" ]; then
     quiet module load intel-oneapi-compilers
 else
     print "======================================== Load GNU compiler"
-    quiet module load gcc@11.3.1
+    quiet module load gcc@11.3
 fi
 print "---------------------------------------- Verify compiler"
 print "CXX = $CXX"

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -67,7 +67,7 @@ if [ "${device}" = "gpu_intel" ]; then
     quiet module load intel-oneapi-compilers
 else
     print "======================================== Load GNU compiler"
-    quiet module load gcc@10.4.0
+    quiet module load gcc@11.3.1
 fi
 print "---------------------------------------- Verify compiler"
 print "CXX = $CXX"


### PR DESCRIPTION
ROCM 5.5 requires GCC 11.  This will upgrade the CI scripts to use gcc@11.3 so that the gpu_amd CI checks will be able to build against ROCM 5.5.