### PR TITLE
Fix bug in CALU.

### DIFF
--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -497,8 +497,7 @@ void getrf_nopiv(Matrix<scalar_t>&& A,
 template <Target target=Target::HostTask, typename scalar_t>
 void getrf_tntpiv_panel(
     Matrix<scalar_t>&& A, Matrix<scalar_t>&& Awork,
-    std::vector< scalar_t* > dwork_array,
-    size_t work_size,
+    std::vector< char* > dwork_array, size_t dwork_bytes,
     int64_t diag_len, int64_t ib,
     std::vector<Pivot>& pivot,
     int max_panel_threads, int priority=0);


### PR DESCRIPTION
When device_pivot_int was 64-bit but scalar_t was 32-bit (float), dipiv and dwork overlapped.
Here are the offending lines in `internal_getrf_tntpiv.cc`:
```
    scalar_t* work = dwork_array[ device ];
    ...
    device_pivot_int* dipiv = (device_pivot_int*) &work[ size_A ];
    void*             dwork = &work[ size_A + diag_len ];
```
In that case, dwork left only diag_len * 4 bytes for dipiv, instead of required diag_len * 8 bytes.

Change to managing workspaces in bytes for clarity.