### PR TITLE
Potrf impl

### DIFF
--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -188,9 +188,8 @@ void potrf(
                 panel.releaseLocalWorkspace();
             }
         }
-        #pragma omp taskwait
-        A.tileUpdateAllOrigin();
     }
+    A.tileUpdateAllOrigin();
 
     if (hold_local_workspace == false) {
         A.releaseWorkspace();

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -17,130 +17,11 @@ namespace impl {
 //------------------------------------------------------------------------------
 /// Distributed parallel Cholesky factorization.
 /// Generic implementation for any target.
-/// Panel and lookahead computed on host using Host OpenMP task.
 /// @ingroup posv_impl
 ///
 template <Target target, typename scalar_t>
 void potrf(
     slate::internal::TargetType<target>,
-    HermitianMatrix<scalar_t> A,
-    Options const& opts )
-{
-    using real_t = blas::real_type<scalar_t>;
-    using BcastListTag = typename Matrix<scalar_t>::BcastListTag;
-
-    const scalar_t one = 1.0;
-
-    // Assumes column major
-    const Layout layout = Layout::ColMajor;
-
-    // Options
-    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
-
-    // if upper, change to lower
-    if (A.uplo() == Uplo::Upper) {
-        A = conj_transpose( A );
-    }
-    int64_t A_nt = A.nt();
-
-    // OpenMP needs pointer types, but vectors are exception safe
-    std::vector< uint8_t > column_vector(A_nt);
-    uint8_t* column = column_vector.data();
-    SLATE_UNUSED( column ); // Used only by OpenMP
-
-    // set min number for omp nested active parallel regions
-    slate::OmpSetMaxActiveLevels set_active_levels( MinOmpActiveLevels );
-
-    #pragma omp parallel
-    #pragma omp master
-    {
-        for (int64_t k = 0; k < A_nt; ++k) {
-            // panel, high priority
-            #pragma omp task depend(inout:column[k]) priority(1)
-            {
-                // factor A(k, k)
-                internal::potrf<Target::HostTask>(A.sub(k, k), 1);
-
-                // send A(k, k) down col A(k+1:nt-1, k)
-                if (k+1 <= A_nt-1)
-                    A.tileBcast(k, k, A.sub(k+1, A_nt-1, k, k), layout);
-
-                // A(k+1:nt-1, k) * A(k, k)^{-H}
-                if (k+1 <= A_nt-1) {
-                    auto Akk = A.sub(k, k);
-                    auto Tkk = TriangularMatrix< scalar_t >(Diag::NonUnit, Akk);
-                    internal::trsm<Target::HostTask>(
-                        Side::Right,
-                        one, conj_transpose( Tkk ),
-                        A.sub(k+1, A_nt-1, k, k), 1);
-                }
-
-                BcastListTag bcast_list_A;
-                for (int64_t i = k+1; i < A_nt; ++i) {
-                    // send A(i, k) across row A(i, k+1:i) and down
-                    // col A(i:nt-1, i) with msg tag i
-                    bcast_list_A.push_back({i, k, {A.sub(i, i, k+1, i),
-                                                   A.sub(i, A_nt-1, i, i)},
-                                            i});
-                }
-                A.template listBcastMT(bcast_list_A, layout);
-            }
-            // update lookahead column(s), high priority
-            for (int64_t j = k+1; j < k+1+lookahead && j < A_nt; ++j) {
-                #pragma omp task depend(in:column[k]) \
-                                 depend(inout:column[j]) priority(1)
-                {
-                    // A(j, j) -= A(j, k) * A(j, k)^H
-                    internal::herk<Target::HostTask>(
-                        real_t(-1.0), A.sub(j, j, k, k),
-                        real_t( 1.0), A.sub(j, j), 1);
-
-                    // A(j+1:nt-1, j) -= A(j+1:nt-1, k) * A(j, k)^H
-                    if (j+1 <= A_nt-1) {
-                        auto Ajk = A.sub(j, j, k, k);
-                        internal::gemm<Target::HostTask>(
-                            -one, A.sub(j+1, A_nt-1, k, k),
-                                  conj_transpose( Ajk ),
-                            one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, 1);
-                    }
-                }
-            }
-            // update trailing submatrix, normal priority
-            if (k+1+lookahead < A_nt) {
-                #pragma omp task depend(in:column[k]) \
-                                 depend(inout:column[k+1+lookahead]) \
-                                 depend(inout:column[A_nt-1])
-                {
-                    // A(kl+1:nt-1, kl+1:nt-1) -=
-                    //     A(kl+1:nt-1, k) * A(kl+1:nt-1, k)^H
-                    // where kl = k + lookahead
-                    internal::herk<target>(
-                        real_t(-1.0), A.sub(k+1+lookahead, A_nt-1, k, k),
-                        real_t( 1.0), A.sub(k+1+lookahead, A_nt-1));
-                }
-            }
-        }
-
-        // TODO: causes issues on summit Target::HostTask
-        // #pragma omp taskwait
-        // A.tileUpdateAllOrigin();
-    }
-
-    // Debug::checkTilesLives(A);
-    // Debug::printTilesLives(A);
-    A.tileUpdateAllOrigin();
-    A.releaseWorkspace();
-}
-
-//------------------------------------------------------------------------------
-/// Distributed parallel Cholesky factorization.
-/// GPU device batched cuBLAS implementation.
-/// @ingroup posv_impl
-///
-template <typename scalar_t>
-void potrf(
-    slate::internal::TargetType<Target::Devices>,
     HermitianMatrix<scalar_t> A,
     Options const& opts )
 {
@@ -190,15 +71,18 @@ void potrf(
     // for every execution for the internal::herk
     const int64_t batch_size_default = 0;
     int num_queues = 3 + lookahead;  // Number of kernels with lookahead
-    A.allocateBatchArrays( batch_size_default, num_queues );
-    A.reserveDeviceWorkspace();
-
-    // Allocate
     using lapack::device_info_int;
     std::vector< device_info_int* > device_info_array( A.num_devices(), nullptr );
-    for (int64_t dev = 0; dev < A.num_devices(); ++dev) {
-        blas::Queue* queue = A.comm_queue(dev);
-        device_info_array[dev] = blas::device_malloc<device_info_int>( 1, *queue );
+
+    if (target == Target::Devices) {
+        A.allocateBatchArrays( batch_size_default, num_queues );
+        A.reserveDeviceWorkspace();
+
+        // Allocate
+        for (int64_t dev = 0; dev < A.num_devices(); ++dev) {
+            blas::Queue* queue = A.comm_queue(dev);
+            device_info_array[dev] = blas::device_malloc<device_info_int>( 1, *queue );
+        }
     }
 
     // set min number for omp nested active parallel regions
@@ -212,7 +96,7 @@ void potrf(
             #pragma omp task depend(inout:column[k])
             {
                 // factor A(k, k)
-                internal::potrf<Target::Devices>(
+                internal::potrf<target>(
                     A.sub(k, k), priority_0, queue_2,
                     device_info_array[ A.tileDevice( k, k ) ] );
 
@@ -224,7 +108,7 @@ void potrf(
                 if (k+1 <= A_nt-1) {
                     auto Akk = A.sub(k, k);
                     auto Tkk = TriangularMatrix< scalar_t >(Diag::NonUnit, Akk);
-                    internal::trsm<Target::Devices>(
+                    internal::trsm<target>(
                         Side::Right,
                         one, conj_transpose( Tkk ),
                         A.sub(k+1, A_nt-1, k, k),
@@ -240,11 +124,12 @@ void potrf(
                                             i});
                 }
 
-                A.template listBcastMT<Target::Devices>(
+                A.template listBcastMT<target>(
                   bcast_list_A, layout);
             }
 
             // update trailing submatrix, normal priority
+            //if (target == Target::Devices && k+1+lookahead < A_nt) {
             if (k+1+lookahead < A_nt) {
                 #pragma omp task depend(in:column[k]) \
                                  depend(inout:column[k+1+lookahead]) \
@@ -253,7 +138,7 @@ void potrf(
                     // A(kl+1:nt-1, kl+1:nt-1) -=
                     //     A(kl+1:nt-1, k) * A(kl+1:nt-1, k)^H
                     // where kl = k + lookahead
-                    internal::herk<Target::Devices>(
+                    internal::herk<target>(
                         real_t(-1.0), A.sub(k+1+lookahead, A_nt-1, k, k),
                         real_t( 1.0), A.sub(k+1+lookahead, A_nt-1),
                         priority_0, queue_0, layout, opts2 );
@@ -271,7 +156,7 @@ void potrf(
                 {
                     // A(j, j) -= A(j, k) * A(j, k)^H
                     int queue_jk2 = j-k+2;
-                    internal::herk<Target::Devices>(
+                    internal::herk<target>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
                         priority_0, queue_jk2, layout, opts2 );
@@ -279,7 +164,7 @@ void potrf(
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
                         auto Ajk = A.sub(j, j, k, k);
-                        internal::gemm<Target::Devices>(
+                        internal::gemm<target>(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
@@ -306,12 +191,15 @@ void potrf(
         #pragma omp taskwait
         A.tileUpdateAllOrigin();
     }
+
     if (hold_local_workspace == false) {
         A.releaseWorkspace();
     }
-    for (int64_t dev = 0; dev < A.num_devices(); ++dev) {
-        blas::Queue* queue = A.comm_queue(dev);
-        blas::device_free( device_info_array[dev], *queue );
+    if (target == Target::Devices) {
+        for (int64_t dev = 0; dev < A.num_devices(); ++dev) {
+            blas::Queue* queue = A.comm_queue(dev);
+            blas::device_free( device_info_array[dev], *queue );
+        }
     }
 }
 
@@ -376,16 +264,10 @@ void potrf(
 
     switch (target) {
         case Target::Host:
+        case Target::HostNest:
+        case Target::HostBatch:
         case Target::HostTask:
             impl::potrf( TargetType<Target::HostTask>(), A, opts );
-            break;
-
-        case Target::HostNest:
-            impl::potrf( TargetType<Target::HostNest>(), A, opts );
-            break;
-
-        case Target::HostBatch:
-            impl::potrf( TargetType<Target::HostBatch>(), A, opts );
             break;
 
         case Target::Devices:


### PR DESCRIPTION
Merge the HostTask and Devices implementations of potrf.
The following compares the performance of the HostTask potrf:
```
type  origin  target  hemm  trsm  trs   dev-dist   A   B    uplo       n    nrhs    nb    p    q  la      error   time (s)       gflop/s  trs time (s)   trs gflop/s  ref time (s)   ref gflop/s  status
// HostTask potrf test using the standalone HostTask impl   
   d    host    task  auto  auto  all        col   1   2   lower  200000      10   192   12    8   1         NA    259.951     10258.406            NA            NA            NA            NA  no check
// HostTask potrf after merging the two implementations (commit 869df11)
   d    host    task  auto  auto  all        col   1   2   lower  200000      10   192   12    8   1   2.76e-20    268.913      9916.527         2.090       382.775            NA            NA  pass
// HostTask potrf after merging the two implementations and move A.tileUpdateAllOrigin() outside the omp-parallel (commit 80c30fc)
   d    host    task  auto  auto  all        col   1   2   lower  200000      10   192   12    8   1   2.75e-20    260.893     10221.378         2.039       392.364            NA            NA  pass
// HostTask potrf after merging the two implementations and move A.tileUpdateAllOrigin() outside the omp-parallel with task reorder and set priority to 1 (commit c372bc8)
   d    host    task  auto  auto  all        col   1   2   lower  200000      10   192   12    8   1   2.75e-20    261.439     10200.040         2.016       396.766            NA            NA  pass
```

The following compares the performance of the Devices potrf:
```
// potrf test using the standalone Devices impl
   d    host     dev  auto  auto  all        col   1   2   lower  256000      10   640    8    4   1         NA     78.424     71310.130            NA            NA            NA            NA  no check
   d    host     dev  auto  auto  all        col   1   2   lower  576000      10   640    8    4   1         NA    449.810    141618.028            NA            NA            NA            NA  no check
   d     dev     dev  auto  auto  all        col   1   2   lower  256000      10   640    8    4   1         NA     91.312     61245.069            NA            NA            NA            NA  no check
   d     dev     dev  auto  auto  all        col   1   2   lower  576000      10   640    8    4   1         NA    467.536    136248.617            NA            NA            NA            NA  no check
// potrf after merging the two implementations (commit 869df11)
   d    host     dev  auto  auto  all        col   1   2   lower  256000      10   640    8    4   1         NA    107.011     52260.307            NA            NA            NA            NA  no check
   d    host     dev  auto  auto  all        col   1   2   lower  576000      10   640    8    4   1         NA    397.780    160141.733            NA            NA            NA            NA  no check
   d     dev     dev  auto  auto  all        col   1   2   lower  256000      10   640    8    4   1         NA     88.540     63162.987            NA            NA            NA            NA  no check
   d     dev     dev  auto  auto  all        col   1   2   lower  576000      10   640    8    4   1         NA    450.341    141450.985            NA            NA            NA            NA  no check

// potrf after merging the two implementations and move A.tileUpdateAllOrigin() outside the omp-parallel (commit 80c30fc)
   d    host     dev  auto  auto  all        col   1   2   lower  256000      10   640    8    4   1   2.45e-20    129.853     43067.461        16.193        80.943            NA            NA  pass
   d    host     dev  auto  auto  all        col   1   2   lower  576000      10   640    8    4   1   1.64e-20    528.070    120630.045        78.173        84.882            NA            NA  pass
   d     dev     dev  auto  auto  all        col   1   2   lower  256000      10   640    8    4   1   2.45e-20     96.946     57686.226        21.523        60.898            NA            NA  pass
   d     dev     dev  auto  auto  all        col   1   2   lower  576000      10   640    8    4   1   1.63e-20    497.070    128153.332       104.191        63.686            NA            NA  pass
```