### PR TITLE
Improve support for variable blocksizes

### DIFF
--- a/examples/ex13_non_uniform_block_size.cc
+++ b/examples/ex13_non_uniform_block_size.cc
@@ -28,8 +28,8 @@ void test_matrix_lambda()
         return (j % 2 != 0 ? nb_/2 : nb_);
     };
 
-    auto tileRank = slate::func::process_2d_grid( slate::Layout::ColMajor, p_, q_ );
-    auto tileDevice = slate::func::device_1d_grid( slate::Layout::ColMajor,
+    auto tileRank = slate::func::process_2d_grid( slate::GridOrder::Col, p_, q_ );
+    auto tileDevice = slate::func::device_1d_grid( slate::GridOrder::Col,
                                                    p_, num_devices_ );
 
     slate::Matrix<scalar_type> A( n, n, tileNb, tileNb, tileRank, tileDevice, MPI_COMM_WORLD );

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -1295,7 +1295,7 @@ void BaseMatrix<scalar_t>::gridinfo(
         // When matrix is empty, storage_ may be null
         if (mt_ != 0 && nt_ != 0) {
             int64_t nprow_i64, npcol_i64;
-            func::is_grid_2d_cyclic(mt(), nt(), tileRankFunc(), order_, nprow_i64, npcol_i64);
+            func::is_2d_cyclic_grid(mt(), nt(), tileRankFunc(), order_, nprow_i64, npcol_i64);
             nprow_ = nprow_i64;
             npcol_ = npcol_i64;
 

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -842,8 +842,6 @@ BaseMatrix<scalar_t>::BaseMatrix(
       op_(Op::NoTrans),
       layout_(Layout::ColMajor),
       origin_(Target::Host),
-      storage_(std::make_shared< MatrixStorage< scalar_t > >(
-          inTileMb, inTileNb, inTileRank, inTileDevice, mpi_comm)),
       mpi_comm_(mpi_comm)
 {
     // Count number of block rows.
@@ -865,6 +863,10 @@ BaseMatrix<scalar_t>::BaseMatrix(
         jj += last_nb_;
         ++nt_;
     }
+
+    storage_ = std::make_shared< MatrixStorage< scalar_t > >(
+                                           mt_, nt_, inTileMb, inTileNb,
+                                           inTileRank, inTileDevice, mpi_comm );
 
     slate_mpi_call(
         MPI_Comm_rank(mpi_comm_, &mpi_rank_));

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -753,8 +753,8 @@ private:
     int64_t joffset_;   ///< block col offset with respect to original matrix
     int64_t mt_;        ///< number of local block rows in this view
     int64_t nt_;        ///< number of local block cols in this view
-    int64_t nprow_;     ///< number of process rows if 2D block cyclic
-    int64_t npcol_;     ///< number of process cols if 2D block cyclic
+    int nprow_;         ///< number of process rows if 2D block cyclic
+    int npcol_;         ///< number of process cols if 2D block cyclic
     GridOrder order_;   ///< order to map MPI processes to tile grid
 
 protected:
@@ -1294,10 +1294,7 @@ void BaseMatrix<scalar_t>::gridinfo(
         slate_mpi_call(MPI_Comm_size(mpiComm(), &mpi_size));
         // When matrix is empty, storage_ may be null
         if (mt_ != 0 && nt_ != 0) {
-            int64_t nprow_i64, npcol_i64;
-            func::is_2d_cyclic_grid(mt(), nt(), tileRankFunc(), order_, nprow_i64, npcol_i64);
-            nprow_ = nprow_i64;
-            npcol_ = npcol_i64;
+            func::is_2d_cyclic_grid(mt(), nt(), tileRankFunc(), &order_, &nprow_, &npcol_);
 
             // Detected grid doesn't match process distribution
             // Label it as unknown since some processes won't have a row/column

--- a/include/slate/func.hh
+++ b/include/slate/func.hh
@@ -252,7 +252,8 @@ inline bool is_same_map(int64_t mt, int64_t nt, std::function<int(ij_tuple)> fun
 
 
 //------------------------------------------------------------------------------
-/// Checks whether the given tile map is a 2d cyclic grid.
+/// Checks whether the given tile map is a 2d cyclic grid (i.e., equivalent
+/// to 'process_2d_grid(layout, p, q)' for some 'layout', 'p', and 'q').
 ///
 /// @param[in] mt
 ///     The number of tile rows to consider
@@ -261,22 +262,22 @@ inline bool is_same_map(int64_t mt, int64_t nt, std::function<int(ij_tuple)> fun
 ///     The number of tile columns to consider
 ///
 /// @param[in] func
-///     The tile map to inspect
+///     The tile distribution to inspect
 ///
 /// @param[out] order
 ///     The GridOrder detected.
 ///
 /// @param[out] p
-///     The number of rows in the grid
+///     The number of rows in the grid, or -1 of the GridOrder is unknown.
 ///
 /// @param[out] q
-///     The number of columns in the grid
+///     The number of columns in the grid, or -1 of the GridOrder is unknown.
 ///
-/// @retval Whether the map is a 2d cyclic grid
+/// @return Whether the map is a 2d cyclic grid
 ///
 /// @ingroup func
 ///
-inline bool is_grid_2d_cyclic(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func,
+inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func,
                               GridOrder& order, int64_t& p, int64_t& q)
 {
     if (mt == 0 || nt == 0 || (mt == 1 && nt == 1)) {
@@ -328,7 +329,7 @@ inline bool is_grid_2d_cyclic(int64_t mt, int64_t nt, std::function<int(ij_tuple
         }
     }
 
-    auto ref = grid_2d_cyclic( Layout(pred_order), pred_p, pred_q );
+    auto ref = process_2d_grid( Layout(pred_order), pred_p, pred_q );
     auto is_same = is_same_map( mt, nt, ref, func );
     if (is_same) {
         order = pred_order;
@@ -339,7 +340,8 @@ inline bool is_grid_2d_cyclic(int64_t mt, int64_t nt, std::function<int(ij_tuple
 }
 
 //------------------------------------------------------------------------------
-/// Checks whether the given tile map is a 2d cyclic grid.
+/// Checks whether the given tile map is a 2d cyclic grid (i.e., equivalent
+/// to 'process_2d_grid(layout, p, q)' for some 'layout', 'p', and 'q').
 ///
 /// @param[in] mt
 ///     The number of tile rows to consider
@@ -354,11 +356,11 @@ inline bool is_grid_2d_cyclic(int64_t mt, int64_t nt, std::function<int(ij_tuple
 ///
 /// @ingroup func
 ///
-inline bool is_grid_2d_cyclic(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func)
+inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func)
 {
     GridOrder order;
     int64_t p, q;
-    return is_grid_2d_cyclic(mt, nt, func, order, p, q);
+    return is_2d_cyclic_grid(mt, nt, func, order, p, q);
 }
 
 } // namespace func

--- a/include/slate/func.hh
+++ b/include/slate/func.hh
@@ -263,19 +263,19 @@ transpose_grid(std::function<int(ij_tuple)> old_func)
 /// @ingroup func
 ///
 inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func,
-                              GridOrder& order, int64_t& p, int64_t& q)
+                              GridOrder* order, int* p, int* q)
 {
     // Hard code trivial corner cases
     if (mt == 0 || nt == 0 || (mt == 1 && nt == 1)) {
-        order = GridOrder::Col;
-        p = 1;
-        q = 1;
+        *order = GridOrder::Col;
+        *p = 1;
+        *q = 1;
         return true;
     }
 
-    order = GridOrder::Unknown;
-    p = -1;
-    q = -1;
+    *order = GridOrder::Unknown;
+    *p = -1;
+    *q = -1;
 
     // Determine possible grid order by checking f(0, 1) and f(1, 0)
     GridOrder pred_order = GridOrder::Unknown;
@@ -327,9 +327,9 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
         }
     }
     // Grid is 2d cyclic
-    order = pred_order;
-    p = pred_p;
-    q = pred_q;
+    *order = pred_order;
+    *p = pred_p;
+    *q = pred_q;
     return true;
 }
 

--- a/include/slate/func.hh
+++ b/include/slate/func.hh
@@ -329,30 +329,6 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
     return true;
 }
 
-//------------------------------------------------------------------------------
-/// Checks whether the given tile map is a 2d cyclic grid (i.e., equivalent
-/// to 'process_2d_grid(layout, p, q)' for some 'layout', 'p', and 'q').
-///
-/// @param[in] mt
-///     The number of tile rows to consider
-///
-/// @param[in] nt
-///     The number of tile columns to consider
-///
-/// @param[in] func
-///     The tile map to inspect
-///
-/// @return Whether the map is a 2d cyclic grid
-///
-/// @ingroup func
-///
-inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func)
-{
-    GridOrder order;
-    int64_t p, q;
-    return is_2d_cyclic_grid(mt, nt, func, order, p, q);
-}
-
 } // namespace func
 } // namespace slate
 

--- a/include/slate/func.hh
+++ b/include/slate/func.hh
@@ -233,25 +233,6 @@ transpose_grid(std::function<int(ij_tuple)> old_func)
 }
 
 //------------------------------------------------------------------------------
-/// Checks whether two tile maps are identical
-///
-/// @ingroup func
-///
-inline bool is_same_map(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func1,
-                                                std::function<int(ij_tuple)> func2)
-{
-    for (int64_t i = 0; i < mt; ++i) {
-        for (int64_t j = 0; j < nt; ++j) {
-            if (func1( {i, j} ) != func2( {i, j} )) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-
-//------------------------------------------------------------------------------
 /// Checks whether the given tile map is a 2d cyclic grid (i.e., equivalent
 /// to 'process_2d_grid(layout, p, q)' for some 'layout', 'p', and 'q').
 ///
@@ -330,13 +311,18 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
     }
 
     auto ref = process_2d_grid( Layout(pred_order), pred_p, pred_q );
-    auto is_same = is_same_map( mt, nt, ref, func );
-    if (is_same) {
-        order = pred_order;
-        p = pred_p;
-        q = pred_q;
+    for (int64_t i = 0; i < mt; ++i) {
+        for (int64_t j = 0; j < nt; ++j) {
+            if (func( {i, j} ) != ref( {i, j} )) {
+                return false;
+            }
+        }
     }
-    return is_same;
+    // Grid is 2d cyclic
+    order = pred_order;
+    p = pred_p;
+    q = pred_q;
+    return true;
 }
 
 //------------------------------------------------------------------------------

--- a/include/slate/func.hh
+++ b/include/slate/func.hh
@@ -41,6 +41,29 @@ inline std::function<int64_t(int64_t)> uniform_blocksize(int64_t n, int64_t nb)
     return [n, nb](int64_t j) { return (j + 1)*nb > n ? n%nb : nb; };
 }
 
+//------------------------------------------------------------------------------
+/// Computes the largest block given a blocksize function
+///
+/// @param[in] nt
+///     Number of tiles
+///
+/// @param[in] size
+///     Block size function
+///
+/// @retval The maximum blocksize
+///
+/// @ingroup func
+///
+inline int64_t max_blocksize(int64_t nt, std::function<int64_t(int64_t)> size)
+{
+    int64_t max = 0;
+    for (int64_t i = 0; i < nt; ++i) {
+        int64_t size_i = size(i);
+        max = max < size_i ? size_i : max;
+    }
+    return max;
+}
+
 
 //------------------------------------------------------------------------------
 // Process & device distribution functions

--- a/include/slate/func.hh
+++ b/include/slate/func.hh
@@ -24,7 +24,7 @@ using ij_tuple = std::tuple<int64_t, int64_t>;
 // Block size functions
 
 //------------------------------------------------------------------------------
-/// Creates a uniform blocksize
+/// Creates a uniform blocksize.
 ///
 /// @param[in] n
 ///     Global matrix size.  Needed to correctly handle the last block size
@@ -42,7 +42,7 @@ inline std::function<int64_t(int64_t)> uniform_blocksize(int64_t n, int64_t nb)
 }
 
 //------------------------------------------------------------------------------
-/// Computes the largest block given a blocksize function
+/// Computes the largest block given a blocksize function.
 ///
 /// @param[in] nt
 ///     Number of tiles
@@ -50,7 +50,7 @@ inline std::function<int64_t(int64_t)> uniform_blocksize(int64_t n, int64_t nb)
 /// @param[in] size
 ///     Block size function
 ///
-/// @retval The maximum blocksize
+/// @return The maximum blocksize
 ///
 /// @ingroup func
 ///
@@ -249,10 +249,10 @@ transpose_grid(std::function<int(ij_tuple)> old_func)
 ///     The GridOrder detected.
 ///
 /// @param[out] p
-///     The number of rows in the grid, or -1 of the GridOrder is unknown.
+///     The number of rows in the grid, or -1 if the GridOrder is unknown.
 ///
 /// @param[out] q
-///     The number of columns in the grid, or -1 of the GridOrder is unknown.
+///     The number of columns in the grid, or -1 if the GridOrder is unknown.
 ///
 /// @return Whether the map is a 2d cyclic grid
 ///
@@ -261,6 +261,7 @@ transpose_grid(std::function<int(ij_tuple)> old_func)
 inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple)> func,
                               GridOrder& order, int64_t& p, int64_t& q)
 {
+    // Hard code trivial corner cases
     if (mt == 0 || nt == 0 || (mt == 1 && nt == 1)) {
         order = GridOrder::Col;
         p = 1;
@@ -272,6 +273,7 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
     p = -1;
     q = -1;
 
+    // Determine possible grid order by checking f(0, 1) and f(1, 0)
     GridOrder pred_order = GridOrder::Unknown;
     if (mt == 1 || nt == 1) {
         // 1d distribution
@@ -291,6 +293,7 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
         return false;
     }
 
+    // Scan first row and column to determine p and q
     int64_t pred_p = 0;
     int64_t pred_q = 0;
     if (pred_order == GridOrder::Col) {
@@ -310,6 +313,7 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
         }
     }
 
+    // Verify the detected grid across the entire matrix
     auto ref = process_2d_grid( Layout(pred_order), pred_p, pred_q );
     for (int64_t i = 0; i < mt; ++i) {
         for (int64_t j = 0; j < nt; ++j) {
@@ -338,7 +342,7 @@ inline bool is_2d_cyclic_grid(int64_t mt, int64_t nt, std::function<int(ij_tuple
 /// @param[in] func
 ///     The tile map to inspect
 ///
-/// @retval Whether the map is a 2d cyclic grid
+/// @return Whether the map is a 2d cyclic grid
 ///
 /// @ingroup func
 ///

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -218,7 +218,7 @@ public:
     void clearWorkspace();
     void releaseWorkspace();
 
-    scalar_t* allocWorkspaceBuffer(int device);
+    scalar_t* allocWorkspaceBuffer(int device, int size);
     void      releaseWorkspaceBuffer(scalar_t* data, int device);
 
 private:
@@ -1020,15 +1020,15 @@ void MatrixStorage<scalar_t>::clear()
 /// @param[in] device
 ///     Device ID (GPU or Host) where the memory block is needed.
 ///
+/// @param[in] size
+///     Number of scalars needed in the memory block
+///
 template <typename scalar_t>
-scalar_t* MatrixStorage<scalar_t>::allocWorkspaceBuffer(int device)
+scalar_t* MatrixStorage<scalar_t>::allocWorkspaceBuffer(int device, int size)
 {
-    int64_t mb = tileMb(0);
-    int64_t nb = tileNb(0);
     // if device==HostNum (-1) use nullptr as queue (not comm_queues_[-1])
     blas::Queue* queue = ( device == HostNum ? nullptr : comm_queues_[device]);
-    scalar_t* data = (scalar_t*) memory_.alloc(device, sizeof(scalar_t) * mb * nb, queue);
-    return data;
+    return (scalar_t*) memory_.alloc(device, sizeof(scalar_t) * size, queue);
 }
 
 //------------------------------------------------------------------------------

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -490,23 +490,22 @@ MatrixStorage<scalar_t>::MatrixStorage(
     num_devices_ = memory_.num_devices_;
 
     // functions for computing the tile's size
-    tileMb = slate::func::uniform_blocksize(m, mb);
-    tileNb = slate::func::uniform_blocksize(n, nb);
+    tileMb = func::uniform_blocksize(m, mb);
+    tileNb = func::uniform_blocksize(n, nb);
 
     // function for computing the tile's rank, assuming 2D block cyclic
     if (order == GridOrder::Col) {
-        tileRank = slate::func::process_2d_grid( slate::Layout::ColMajor, p, q );
+        tileRank = func::process_2d_grid( GridOrder::Col, p, q );
     }
     else if (order == GridOrder::Row) {
-        tileRank = slate::func::process_2d_grid( slate::Layout::RowMajor, p, q );
+        tileRank = func::process_2d_grid( GridOrder::Row, p, q );
     }
     else {
         slate_error( "invalid GridOrder, must be Col or Row" );
     }
     // function for computing the tile's device, assuming 1d block cyclic
     if (num_devices_ > 0) {
-        tileDevice = slate::func::device_1d_grid( slate::Layout::RowMajor,
-                                                  q, num_devices_ );
+        tileDevice = func::device_1d_grid( GridOrder::Row, q, num_devices_ );
     }
     else {
         tileDevice = []( ij_tuple ij ) {

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -128,6 +128,7 @@ void* Memory::alloc(int device, size_t size, blas::Queue* queue)
         block = new char[size];
     }
     else {
+        slate_assert( size <= block_size_ );
         // this block for device only
         #pragma omp critical(slate_memory)
         {

--- a/src/gecondest.cc
+++ b/src/gecondest.cc
@@ -90,11 +90,7 @@ void gecondest(
     scalar_t alpha = 1.;
     real_t Ainvnorm = 0.0;
 
-    std::vector<int64_t> isave(4);
-    isave[0] = 0;
-    isave[1] = 0;
-    isave[2] = 0;
-    isave[3] = 0;
+    std::vector<int64_t> isave = {0, 0, 0, 0};
 
     auto tileMb = A.tileMbFunc();
     auto tileNb = func::uniform_blocksize(1, 1);

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -83,9 +83,9 @@ void he2hb(
     assert( grid_order == GridOrder::Col );  // todo: update for Row
 
     auto tileNb = slate::func::uniform_blocksize( n, nb_A );
-    auto tileRank = slate::func::process_2d_grid( Layout::ColMajor, nprow, npcol );
+    auto tileRank = slate::func::process_2d_grid( GridOrder::Col, nprow, npcol );
     int num_devices = blas::get_device_count();
-    auto tileDevice = slate::func::device_1d_grid( Layout::ColMajor,
+    auto tileDevice = slate::func::device_1d_grid( GridOrder::Col,
                                                            nprow, num_devices );
 
     // W is like A, but within node the GPU distribution is row-cyclic.

--- a/src/trcondest.cc
+++ b/src/trcondest.cc
@@ -81,11 +81,7 @@ void trcondest(
     scalar_t alpha = 1.;
     real_t Ainvnorm = 0.0;
 
-    std::vector<int64_t> isave(4);
-    isave[0] = 0;
-    isave[1] = 0;
-    isave[2] = 0;
-    isave[3] = 0;
+    std::vector<int64_t> isave = {0, 0, 0, 0};
 
     auto tileMb = A.tileMbFunc();
     auto tileNb = func::uniform_blocksize(1, 1);

--- a/src/trcondest.cc
+++ b/src/trcondest.cc
@@ -15,8 +15,6 @@ namespace slate {
 /// of a triangular matrix A, in either the 1-norm or the infinity-norm.
 /// Generic implementation for any target.
 ///
-/// ColMajor layout is assumed
-///
 /// The reciprocal of the condition number computed as:
 /// \[
 ///     rcond = \frac{1}{\|\|A\|\| \times \|\|A^{-1}\|\|}
@@ -72,47 +70,41 @@ void trcondest(
     }
 
     int64_t m = A.m();
-    int64_t nb = A.tileNb(0);
-    int p, q;
-    int myrow, mycol, mpi_size;
-    int izero = 0;
 
     // Quick return
     *rcond = 0.;
-    if (m == 0) {
+    if (m <= 0) {
         *rcond = 1.;
+        return;
     }
 
     scalar_t alpha = 1.;
     real_t Ainvnorm = 0.0;
 
-    GridOrder grid_order;
-    A.gridinfo(&grid_order, &p, &q, &myrow, &mycol);
-    slate_mpi_call(
-            MPI_Comm_size(A.mpiComm(), &mpi_size));
-    //myrow = A.mpiRank();
-    int64_t mloc  = numberLocalRowOrCol(m, nb, myrow, izero, p);
-    int64_t lldA  = blas::max(1, mloc);
-
-    std::vector<scalar_t> X_data(lldA);
-    std::vector<scalar_t> V_data(lldA);
-    std::vector<int64_t> isgn_data(lldA);
-    std::vector<int64_t> isave(3);
+    std::vector<int64_t> isave(4);
     isave[0] = 0;
     isave[1] = 0;
     isave[2] = 0;
+    isave[3] = 0;
 
-    auto X = slate::Matrix<scalar_t>::fromScaLAPACK(
-            m, 1, &X_data[0], lldA, nb, 1, p, q, A.mpiComm() );
-    auto V = slate::Matrix<scalar_t>::fromScaLAPACK(
-            m, 1, &V_data[0], lldA, nb, 1, p, q, A.mpiComm() );
-    auto isgn = slate::Matrix<int64_t>::fromScaLAPACK(
-            m, 1, &isgn_data[0], lldA, nb, 1, p, q, A.mpiComm() );
+    auto tileMb = A.tileMbFunc();
+    auto tileNb = func::uniform_blocksize(1, 1);
+    auto tileRank = A.tileRankFunc();
+    auto tileDevice = A.tileDeviceFunc();
+    slate::Matrix<scalar_t> X (m, 1, tileMb, tileNb,
+                               tileRank, tileDevice, A.mpiComm());
+    X.insertLocalTiles(Target::Host);
+    slate::Matrix<scalar_t> V (m, 1, tileMb, tileNb,
+                               tileRank, tileDevice, A.mpiComm());
+    V.insertLocalTiles(Target::Host);
+    slate::Matrix<int64_t> isgn (m, 1, tileMb, tileNb,
+                                 tileRank, tileDevice, A.mpiComm());
+    isgn.insertLocalTiles(Target::Host);
 
     // initial and final value of kase is 0
     kase = 0;
     internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
-    MPI_Bcast( &isave[0], 3, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
+    MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
     MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
 
     while (kase != 0) {
@@ -127,7 +119,7 @@ void trcondest(
         }
 
         internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
-        MPI_Bcast( &isave[0], 3, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
+        MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
         MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
     } // while (kase != 0)
 

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -168,10 +168,10 @@ void test_gesv_work(Params& params, bool run)
     };
 
     // rank and device functions for using the lambda constructor
-    auto tileRank = slate::func::process_2d_grid( slate::Layout::ColMajor, p, q );
+    auto tileRank = slate::func::process_2d_grid( slate::GridOrder::Col, p, q );
     int num_devices_ = blas::get_device_count();
-    auto tileDevice = slate::func::device_1d_grid( slate::Layout::ColMajor,
-                                                    p, num_devices_ );
+    auto tileDevice = slate::func::device_1d_grid( slate::GridOrder::Col,
+                                                   p, num_devices_ );
 
     std::vector<scalar_t> A_data, B_data, X_data;
     slate::Matrix<scalar_t> A, B, X;

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -146,11 +146,11 @@ void test_posv_work(Params& params, bool run)
             // slate_assert(lookahead < 3);
 
             auto tileNb = slate::func::uniform_blocksize( n, nb );
-            auto tileRank = slate::func::process_2d_grid( slate::Layout::ColMajor,
-                                                         p, q );
+            auto tileRank = slate::func::process_2d_grid( slate::GridOrder::Col,
+                                                          p, q );
             int num_devices = blas::get_device_count();
-            auto tileDevice = slate::func::device_1d_grid(
-                                    slate::Layout::ColMajor, p, num_devices );
+            auto tileDevice = slate::func::device_1d_grid( slate::GridOrder::Col,
+                                                           p, num_devices );
 
             A = slate::HermitianMatrix<scalar_t>(
                     uplo, n, tileNb, tileRank, tileDevice, MPI_COMM_WORLD);

--- a/unit_test/test_HermitianMatrix.cc
+++ b/unit_test/test_HermitianMatrix.cc
@@ -46,11 +46,11 @@ void test_HermitianMatrix_default()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Col );
-    test_assert( myp == 1 );
-    test_assert( myq == 1 );
-    test_assert( myrow == 0 );
-    test_assert( mycol == 0 );
+    test_assert( order == GridOrder::Unknown );
+    test_assert( myp == -1 );
+    test_assert( myq == -1 );
+    test_assert( myrow == -1 );
+    test_assert( mycol == -1 );
 }
 
 //------------------------------------------------------------------------------

--- a/unit_test/test_HermitianMatrix.cc
+++ b/unit_test/test_HermitianMatrix.cc
@@ -116,10 +116,9 @@ void test_HermitianMatrix_lambda()
     {
         return (j % 2 == 0 ? 2*nb_ : nb_);
     };
-    auto tileRank = slate::func::process_1d_grid( slate::Layout::ColMajor, p );
+    auto tileRank = slate::func::process_1d_grid( slate::GridOrder::Col, p );
     // NB. this is process_1d_grid because we want a true cyclic device distribution
-    auto tileDevice = slate::func::process_1d_grid( slate::Layout::RowMajor,
-                                                    num_devices );
+    auto tileDevice = slate::func::process_1d_grid( slate::GridOrder::Row, num_devices );
 
     // ----------
     // lower

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -156,7 +156,12 @@ void test_Matrix_empty()
     test_assert( D.uplo() == slate::Uplo::General );
 
     D.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Row );
+    if (p == 1 || q == 1) {
+        test_assert( order != GridOrder::Unknown );
+    }
+    else {
+        test_assert( order == GridOrder::Row );
+    }
     test_assert( myp == p );
     test_assert( myq == q );
     test_assert( myrow == mpi_rank / q );  // row major
@@ -222,24 +227,15 @@ void test_Matrix_lambda()
     test_assert(A.op() == blas::Op::NoTrans);
     test_assert(A.uplo() == slate::Uplo::General);
 
-    // SLATE doesn't know distribution.
+    // SLATE detects the distribution.
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    if (mpi_size == 1) {
-        test_assert( order == GridOrder::Col );
-        test_assert( myp == 1 );
-        test_assert( myq == 1 );
-        test_assert( myrow == 0 );
-        test_assert( mycol == 0 );
-    }
-    else {
-        test_assert( order == GridOrder::Unknown );
-        test_assert( myp == -1 );
-        test_assert( myq == -1 );
-        test_assert( myrow == -1 );
-        test_assert( mycol == -1 );
-    }
+    test_assert( order == GridOrder::Col );
+    test_assert( myp == p );
+    test_assert( myq == 1 );
+    test_assert( myrow == (mpi_rank < p ? mpi_rank : -1) );
+    test_assert( mycol == (mpi_rank < p ? 0 : -1) );
 
     auto tileMb_     = A.tileMbFunc();
     auto tileNb_     = A.tileNbFunc();

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -45,11 +45,11 @@ void test_Matrix_default()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Col );
-    test_assert( myp == 1 );
-    test_assert( myq == 1 );
-    test_assert( myrow == 0 );
-    test_assert( mycol == 0 );
+    test_assert( order == GridOrder::Unknown );
+    test_assert( myp == -1 );
+    test_assert( myq == -1 );
+    test_assert( myrow == -1 );
+    test_assert( mycol == -1 );
 
     // todo: What is reasonable in this case? It segfaults right now.
     // auto tileMb_     = A.tileMbFunc();
@@ -156,12 +156,7 @@ void test_Matrix_empty()
     test_assert( D.uplo() == slate::Uplo::General );
 
     D.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    if (p == 1 || q == 1) {
-        test_assert( order != GridOrder::Unknown );
-    }
-    else {
-        test_assert( order == GridOrder::Row );
-    }
+    test_assert( order == GridOrder::Row );
     test_assert( myp == p );
     test_assert( myq == q );
     test_assert( myrow == mpi_rank / q );  // row major
@@ -231,7 +226,7 @@ void test_Matrix_lambda()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Col );
+    test_assert( order != GridOrder::Unknown );
     test_assert( myp == p );
     test_assert( myq == 1 );
     test_assert( myrow == (mpi_rank < p ? mpi_rank : -1) );

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -191,10 +191,9 @@ void test_Matrix_lambda()
     {
         return (j % 2 == 0 ? 2*nb_ : nb_);
     };
-    auto tileRank = slate::func::process_1d_grid( slate::Layout::ColMajor, p );
+    auto tileRank = slate::func::process_1d_grid( slate::GridOrder::Col, p );
     // NB. this is process_1d_grid because we want a true cyclic device distribution
-    auto tileDevice = slate::func::process_1d_grid( slate::Layout::RowMajor,
-                                                    num_devices );
+    auto tileDevice = slate::func::process_1d_grid( slate::GridOrder::Row, num_devices );
 
     // ----------
     slate::Matrix<double> A(m, n, tileMb, tileNb, tileRank, tileDevice, mpi_comm);

--- a/unit_test/test_SymmetricMatrix.cc
+++ b/unit_test/test_SymmetricMatrix.cc
@@ -46,11 +46,11 @@ void test_SymmetricMatrix_default()
     GridOrder order;
     int myp, myq, myrow, mycol;
     A.gridinfo( &order, &myp, &myq, &myrow, &mycol );
-    test_assert( order == GridOrder::Col );
-    test_assert( myp == 1 );
-    test_assert( myq == 1 );
-    test_assert( myrow == 0 );
-    test_assert( mycol == 0 );
+    test_assert( order == GridOrder::Unknown );
+    test_assert( myp == -1 );
+    test_assert( myq == -1 );
+    test_assert( myrow == -1 );
+    test_assert( mycol == -1 );
 }
 
 //------------------------------------------------------------------------------

--- a/unit_test/test_SymmetricMatrix.cc
+++ b/unit_test/test_SymmetricMatrix.cc
@@ -116,10 +116,9 @@ void test_SymmetricMatrix_lambda()
     {
         return (j % 2 == 0 ? 2*nb_ : nb_);
     };
-    auto tileRank = slate::func::process_1d_grid( slate::Layout::ColMajor, p );
+    auto tileRank = slate::func::process_1d_grid( slate::GridOrder::Col, p );
     // NB. this is process_1d_grid because we want a true cyclic device distribution
-    auto tileDevice = slate::func::process_1d_grid( slate::Layout::RowMajor,
-                                                    num_devices );
+    auto tileDevice = slate::func::process_1d_grid( slate::GridOrder::Row, num_devices );
 
     // ----------
     // lower

--- a/unit_test/test_TrapezoidMatrix.cc
+++ b/unit_test/test_TrapezoidMatrix.cc
@@ -112,10 +112,9 @@ void test_TrapezoidMatrix_lambda()
     {
         return (j % 2 == 0 ? 2*nb_ : nb_);
     };
-    auto tileRank = slate::func::process_1d_grid( slate::Layout::ColMajor, p );
+    auto tileRank = slate::func::process_1d_grid( slate::GridOrder::Col, p );
     // NB. this is process_1d_grid because we want a true cyclic device distribution
-    auto tileDevice = slate::func::process_1d_grid( slate::Layout::RowMajor,
-                                                    num_devices );
+    auto tileDevice = slate::func::process_1d_grid( slate::GridOrder::Row, num_devices );
 
     // ----------
     // lower

--- a/unit_test/test_TriangularBandMatrix.cc
+++ b/unit_test/test_TriangularBandMatrix.cc
@@ -135,10 +135,9 @@ void test_TriangularBandMatrix_lambda()
     {
         return (j % 2 == 0 ? 2*nb_ : nb_);
     };
-    auto tileRank = slate::func::process_1d_grid( slate::Layout::ColMajor, p );
+    auto tileRank = slate::func::process_1d_grid( slate::GridOrder::Col, p );
     // NB. this is process_1d_grid because we want a true cyclic device distribution
-    auto tileDevice = slate::func::process_1d_grid( slate::Layout::RowMajor,
-                                                    num_devices );
+    auto tileDevice = slate::func::process_1d_grid( slate::GridOrder::Row, num_devices );
 
     // ----------
     // lower

--- a/unit_test/test_TriangularMatrix.cc
+++ b/unit_test/test_TriangularMatrix.cc
@@ -112,10 +112,9 @@ void test_TriangularMatrix_lambda()
     {
         return (j % 2 == 0 ? 2*nb_ : nb_);
     };
-    auto tileRank = slate::func::process_1d_grid( slate::Layout::ColMajor, p );
+    auto tileRank = slate::func::process_1d_grid( slate::GridOrder::Col, p );
     // NB. this is process_1d_grid because we want a true cyclic device distribution
-    auto tileDevice = slate::func::process_1d_grid( slate::Layout::RowMajor,
-                                                    num_devices );
+    auto tileDevice = slate::func::process_1d_grid( slate::GridOrder::Row, num_devices );
 
     // ----------
     // lower

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -32,7 +32,35 @@ void test_uniform_blocksize()
 }
 
 //------------------------------------------------------------------------------
+<<<<<<< HEAD
 void test_process_2d_grid()
+=======
+void test_max_blocksize()
+{
+    auto error = []( int64_t i ) {
+        test_assert( false );
+        return -1;
+    };
+    test_assert( slate::func::max_blocksize( 0, error ) == 0 );
+
+    auto uni_100_16 = slate::func::uniform_blocksize( 100, 16 );
+    test_assert( slate::func::max_blocksize( 7, uni_100_16 ) == 16 );
+    test_assert( slate::func::max_blocksize( 1, uni_100_16 ) == 16 );
+
+    auto uni_75_25 = slate::func::uniform_blocksize( 75, 25 );
+    test_assert( slate::func::max_blocksize( 3, uni_75_25 ) == 25 );
+
+    auto growing = []( int64_t i ) {
+        return i+1;
+    };
+    for (int64_t i = 1; i < 100; ++i) {
+        test_assert( slate::func::max_blocksize( i, growing ) == i );
+    }
+}
+
+//------------------------------------------------------------------------------
+void test_grid_2d_block_cyclic()
+>>>>>>> efcf1925 (Improve Memory allocations when tile size is nonuniform)
 {
     auto grid_col = slate::func::process_2d_grid(slate::Layout::ColMajor, 4, 5);
 
@@ -432,14 +460,14 @@ void test_is_grid_2d_cyclic()
 /// Runs all tests. Called by unit test main().
 void run_tests()
 {
-    run_test(test_uniform_blocksize, "test_uniform_blocksize");
-    run_test(test_process_2d_grid,   "test_process_2d_grid");
-    run_test(test_process_1d_grid,   "test_process_1d_grid");
-    run_test(test_device_2d_grid,    "test_device_2d_grid");
-    run_test(test_device_1d_grid,    "test_device_1d_grid");
-    run_test(test_grid_transpose,    "test_transpose_grid");
-    run_test(test_is_same_map,       "test_is_same_map");
-    run_test(test_is_grid_2d_cyclic, "test_is_grid_2d_cyclic");
+    run_test( test_uniform_blocksize, "test_uniform_blocksize" );
+    run_test( test_process_2d_grid,   "test_process_2d_grid" );
+    run_test( test_process_1d_grid,   "test_process_1d_grid" );
+    run_test( test_device_2d_grid,    "test_device_2d_grid" );
+    run_test( test_device_1d_grid,    "test_device_1d_grid" );
+    run_test( test_grid_transpose,    "test_transpose_grid" );
+    run_test( test_is_same_map,       "test_is_same_map" );
+    run_test( test_is_grid_2d_cyclic, "test_is_grid_2d_cyclic" );
 }
 
 }  // namespace test

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -32,9 +32,6 @@ void test_uniform_blocksize()
 }
 
 //------------------------------------------------------------------------------
-<<<<<<< HEAD
-void test_process_2d_grid()
-=======
 void test_max_blocksize()
 {
     auto error = []( int64_t i ) {
@@ -59,8 +56,7 @@ void test_max_blocksize()
 }
 
 //------------------------------------------------------------------------------
-void test_grid_2d_block_cyclic()
->>>>>>> efcf1925 (Improve Memory allocations when tile size is nonuniform)
+void test_process_2d_grid()
 {
     auto grid_col = slate::func::process_2d_grid(slate::Layout::ColMajor, 4, 5);
 
@@ -261,13 +257,13 @@ void test_is_same_map()
     test_assert( slate::func::is_same_map(0, 1000, error, error) );
 
 
-    auto col_2d = slate::func::grid_2d_block_cyclic(
+    auto col_2d = slate::func::device_2d_grid(
                             slate::Layout::ColMajor, 2, 3, 4, 5 );
-    auto row_2d = slate::func::grid_2d_block_cyclic(
+    auto row_2d = slate::func::device_2d_grid(
                             slate::Layout::RowMajor, 2, 3, 4, 5 );
-    auto col_1d = slate::func::grid_2d_block_cyclic(
+    auto col_1d = slate::func::device_2d_grid(
                             slate::Layout::ColMajor, 2, 1, 4, 1 );
-    auto row_1d = slate::func::grid_2d_block_cyclic(
+    auto row_1d = slate::func::device_2d_grid(
                             slate::Layout::ColMajor, 1, 3, 1, 5 );
     // equality
     test_assert( slate::func::is_same_map(100, 100, col_2d, col_2d) );
@@ -286,7 +282,7 @@ void test_is_same_map()
 }
 
 //------------------------------------------------------------------------------
-void test_is_grid_2d_cyclic()
+void test_is_2d_cyclic_grid()
 {
     slate::GridOrder out_o;
     int64_t out_p, out_q;
@@ -310,20 +306,20 @@ void test_is_grid_2d_cyclic()
             } \
         } while(0)
 
-    // Check that is_grid_2d_cyclic doesn't access an empty map
+    // Check that is_2d_cyclic_grid doesn't access an empty map
     std::function<int( std::tuple<int64_t, int64_t> )>
     error = []( std::tuple<int64_t, int64_t> ij ) {
         test_assert( false );
         return -1;
     };
-    test_assert( slate::func::is_grid_2d_cyclic(0, 0, error) );
-    test_assert( slate::func::is_grid_2d_cyclic(0, 0, error, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(0, 0, error) );
+    test_assert( slate::func::is_2d_cyclic_grid(0, 0, error, out_o, out_p, out_q) );
     test_pq( 1, 1 );
-    test_assert( slate::func::is_grid_2d_cyclic(1000, 0, error) );
-    test_assert( slate::func::is_grid_2d_cyclic(1000, 0, error, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error) );
+    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, out_o, out_p, out_q) );
     test_pq( 1, 1 );
-    test_assert( slate::func::is_grid_2d_cyclic(0, 1000, error) );
-    test_assert( slate::func::is_grid_2d_cyclic(1000, 0, error, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(0, 1000, error) );
+    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, out_o, out_p, out_q) );
     test_pq( 1, 1 );
 
     // Loop over arguments to grid_2d_block_cyclic
@@ -352,7 +348,7 @@ void test_is_grid_2d_cyclic()
             {slate::Layout::RowMajor, 1, 1, 1, 1},
     };
     for (auto config : configs) {
-        auto func = std::apply(slate::func::grid_2d_block_cyclic, config );
+        auto func = std::apply(slate::func::device_2d_grid, config );
 
         bool is_col_layout = std::get<0>(config) == slate::Layout::ColMajor;
         bool is_row_layout = ! is_col_layout;
@@ -371,13 +367,13 @@ void test_is_grid_2d_cyclic()
         //          << is_2d_cyclic << std::endl;
 
 
-        test_assert( slate::func::is_grid_2d_cyclic( 1,  1, func) );
-        test_assert( slate::func::is_grid_2d_cyclic( 1,  1, func, out_o, out_p, out_q) );
+        test_assert( slate::func::is_2d_cyclic_grid( 1,  1, func) );
+        test_assert( slate::func::is_2d_cyclic_grid( 1,  1, func, out_o, out_p, out_q) );
         test_pq( 1, 1 );
 
-        test_assert( slate::func::is_grid_2d_cyclic( 40,  1, func )
+        test_assert( slate::func::is_2d_cyclic_grid( 40,  1, func )
                      == is_col_cyclic );
-        test_assert( slate::func::is_grid_2d_cyclic( 40,  1, func, out_o, out_p, out_q )
+        test_assert( slate::func::is_2d_cyclic_grid( 40,  1, func, out_o, out_p, out_q )
                      == is_col_cyclic );
         if (is_col_cyclic) {
             test_pq( p, 1 );
@@ -386,9 +382,9 @@ void test_is_grid_2d_cyclic()
             test_opq( slate::GridOrder::Unknown, -1, -1 );
         }
 
-        test_assert( slate::func::is_grid_2d_cyclic(  1, 40, func )
+        test_assert( slate::func::is_2d_cyclic_grid(  1, 40, func )
                      == is_row_cyclic );
-        test_assert( slate::func::is_grid_2d_cyclic(  1, 40, func, out_o, out_p, out_q )
+        test_assert( slate::func::is_2d_cyclic_grid(  1, 40, func, out_o, out_p, out_q )
                      == is_row_cyclic );
         if (is_row_cyclic) {
             test_pq( 1, q );
@@ -397,13 +393,13 @@ void test_is_grid_2d_cyclic()
             test_opq( slate::GridOrder::Unknown, -1, -1 );
         }
 
-        test_assert( slate::func::is_grid_2d_cyclic( 40, 40, func )
+        test_assert( slate::func::is_2d_cyclic_grid( 40, 40, func )
                      == is_2d_cyclic );
-        test_assert( slate::func::is_grid_2d_cyclic( 40, 40, func, out_o, out_p, out_q )
+        test_assert( slate::func::is_2d_cyclic_grid( 40, 40, func, out_o, out_p, out_q )
                      == is_2d_cyclic );
         if (is_2d_cyclic) {
             if (p != 1 && q != 1) {
-                // GridOrder only garunteed for non-1d grids
+                // GridOrder only guaranteed for non-1d grids
                 test_opq( is_col_layout ? slate::GridOrder::Col : slate::GridOrder::Row,
                           p, q );
             }
@@ -417,7 +413,7 @@ void test_is_grid_2d_cyclic()
     }
 
     // Test a map that's almost cyclic
-    auto cyclic = slate::func::grid_2d_cyclic( slate::Layout::ColMajor, 4, 5 );
+    auto cyclic = slate::func::process_2d_grid( slate::Layout::ColMajor, 4, 5 );
     std::function<int( std::tuple<int64_t, int64_t> )>
     tricky_func = [cyclic]( std::tuple<int64_t, int64_t> ij ) {
         int64_t i = std::get<0>( ij );
@@ -429,27 +425,27 @@ void test_is_grid_2d_cyclic()
             return cyclic( ij );
         }
     };
-    test_assert( ! slate::func::is_grid_2d_cyclic(99, 99, tricky_func) );
-    test_assert( ! slate::func::is_grid_2d_cyclic(99, 99, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(99, 99, tricky_func) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(99, 99, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_grid_2d_cyclic(50, 99, tricky_func) );
-    test_assert( ! slate::func::is_grid_2d_cyclic(50, 99, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(50, 99, tricky_func) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(50, 99, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_grid_2d_cyclic(99, 50, tricky_func) );
-    test_assert( ! slate::func::is_grid_2d_cyclic(99, 50, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(99, 50, tricky_func) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(99, 50, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_grid_2d_cyclic(50, 50, tricky_func) );
-    test_assert( ! slate::func::is_grid_2d_cyclic(50, 50, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(50, 50, tricky_func) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(50, 50, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
 
-    test_assert( slate::func::is_grid_2d_cyclic(50, 49, tricky_func) );
-    test_assert( slate::func::is_grid_2d_cyclic(50, 49, tricky_func, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(50, 49, tricky_func) );
+    test_assert( slate::func::is_2d_cyclic_grid(50, 49, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
-    test_assert( slate::func::is_grid_2d_cyclic(49, 50, tricky_func) );
-    test_assert( slate::func::is_grid_2d_cyclic(49, 50, tricky_func, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(49, 50, tricky_func) );
+    test_assert( slate::func::is_2d_cyclic_grid(49, 50, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
-    test_assert( slate::func::is_grid_2d_cyclic(49, 49, tricky_func) );
-    test_assert( slate::func::is_grid_2d_cyclic(49, 49, tricky_func, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(49, 49, tricky_func) );
+    test_assert( slate::func::is_2d_cyclic_grid(49, 49, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
 
     #undef test_opq
@@ -467,7 +463,7 @@ void run_tests()
     run_test( test_device_1d_grid,    "test_device_1d_grid" );
     run_test( test_grid_transpose,    "test_transpose_grid" );
     run_test( test_is_same_map,       "test_is_same_map" );
-    run_test( test_is_grid_2d_cyclic, "test_is_grid_2d_cyclic" );
+    run_test( test_is_2d_cyclic_grid, "test_is_2d_cyclic_grid" );
 }
 
 }  // namespace test

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -58,7 +58,7 @@ void test_max_blocksize()
 //------------------------------------------------------------------------------
 void test_process_2d_grid()
 {
-    auto grid_col = slate::func::process_2d_grid(slate::Layout::ColMajor, 4, 5);
+    auto grid_col = slate::func::process_2d_grid(slate::GridOrder::Col, 4, 5);
 
     for (int i = 0; i < 20; ++i) {
         for (int j = 0; j < 20; ++j) {
@@ -78,7 +78,7 @@ void test_process_2d_grid()
         }
     }
 
-    auto grid_row = slate::func::process_2d_grid(slate::Layout::RowMajor, 4, 5);
+    auto grid_row = slate::func::process_2d_grid(slate::GridOrder::Row, 4, 5);
 
     for (int i = 0; i < 20; ++i) {
         for (int j = 0; j < 20; ++j) {
@@ -102,7 +102,7 @@ void test_process_2d_grid()
 //------------------------------------------------------------------------------
 void test_process_1d_grid()
 {
-    auto grid_col = slate::func::process_1d_grid(slate::Layout::ColMajor, 4);
+    auto grid_col = slate::func::process_1d_grid(slate::GridOrder::Col, 4);
 
     for (int i = 0; i < 20; ++i) {
         int ref_proc = 0;
@@ -118,7 +118,7 @@ void test_process_1d_grid()
         } // ii loop
     }
 
-    auto grid_row = slate::func::process_1d_grid(slate::Layout::RowMajor, 5);
+    auto grid_row = slate::func::process_1d_grid(slate::GridOrder::Row, 5);
 
     for (int j = 0; j < 20; ++j) {
         int ref_proc = 0;
@@ -136,7 +136,7 @@ void test_process_1d_grid()
 //------------------------------------------------------------------------------
 void test_device_2d_grid()
 {
-    auto grid_col = slate::func::device_2d_grid(slate::Layout::ColMajor, 2, 3, 4, 5);
+    auto grid_col = slate::func::device_2d_grid(slate::GridOrder::Col, 2, 3, 4, 5);
 
     for (int i = 0; i < 10; ++i) {
         for (int j = 0; j < 10; ++j) {
@@ -161,7 +161,7 @@ void test_device_2d_grid()
         }
     }
 
-    auto grid_row = slate::func::device_2d_grid(slate::Layout::RowMajor, 2, 3, 4, 5);
+    auto grid_row = slate::func::device_2d_grid(slate::GridOrder::Row, 2, 3, 4, 5);
 
     for (int i = 0; i < 10; ++i) {
         for (int j = 0; j < 10; ++j) {
@@ -190,7 +190,7 @@ void test_device_2d_grid()
 //------------------------------------------------------------------------------
 void test_device_1d_grid()
 {
-    auto grid_col = slate::func::device_1d_grid(slate::Layout::ColMajor, 2, 4);
+    auto grid_col = slate::func::device_1d_grid(slate::GridOrder::Col, 2, 4);
 
     for (int i = 0; i < 10; ++i) {
         int ref_proc = 0;
@@ -208,7 +208,7 @@ void test_device_1d_grid()
         } // ii loop
     }
 
-    auto grid_row = slate::func::device_1d_grid(slate::Layout::RowMajor, 3, 5);
+    auto grid_row = slate::func::device_1d_grid(slate::GridOrder::Row, 3, 5);
 
     for (int j = 0; j < 10; ++j) {
         int ref_proc = 0;
@@ -286,34 +286,34 @@ void test_is_2d_cyclic_grid()
     test_pq( 1, 1 );
 
     // Loop over arguments to grid_2d_block_cyclic
-    std::vector<std::tuple<slate::Layout, int64_t, int64_t, int64_t, int64_t>>
+    std::vector<std::tuple<slate::GridOrder, int64_t, int64_t, int64_t, int64_t>>
         configs = {
-            {slate::Layout::ColMajor, 2, 3, 4, 5},
-            {slate::Layout::RowMajor, 2, 3, 4, 5},
-            {slate::Layout::ColMajor, 2, 1, 4, 5},
-            {slate::Layout::RowMajor, 2, 1, 4, 5},
-            {slate::Layout::ColMajor, 1, 3, 4, 5},
-            {slate::Layout::RowMajor, 1, 3, 4, 5},
-            {slate::Layout::ColMajor, 2, 3, 4, 1},
-            {slate::Layout::RowMajor, 2, 3, 4, 1},
-            {slate::Layout::ColMajor, 2, 3, 1, 5},
-            {slate::Layout::RowMajor, 2, 3, 1, 5},
-            {slate::Layout::ColMajor, 2, 3, 1, 1},
-            {slate::Layout::RowMajor, 2, 3, 1, 1},
+            {slate::GridOrder::Col, 2, 3, 4, 5},
+            {slate::GridOrder::Row, 2, 3, 4, 5},
+            {slate::GridOrder::Col, 2, 1, 4, 5},
+            {slate::GridOrder::Row, 2, 1, 4, 5},
+            {slate::GridOrder::Col, 1, 3, 4, 5},
+            {slate::GridOrder::Row, 1, 3, 4, 5},
+            {slate::GridOrder::Col, 2, 3, 4, 1},
+            {slate::GridOrder::Row, 2, 3, 4, 1},
+            {slate::GridOrder::Col, 2, 3, 1, 5},
+            {slate::GridOrder::Row, 2, 3, 1, 5},
+            {slate::GridOrder::Col, 2, 3, 1, 1},
+            {slate::GridOrder::Row, 2, 3, 1, 1},
 
-            {slate::Layout::ColMajor, 1, 1, 4, 5},
-            {slate::Layout::RowMajor, 1, 1, 4, 5},
-            {slate::Layout::ColMajor, 1, 1, 1, 3},
-            {slate::Layout::RowMajor, 1, 1, 1, 3},
-            {slate::Layout::ColMajor, 1, 1, 10, 1},
-            {slate::Layout::RowMajor, 1, 1, 10, 1},
-            {slate::Layout::ColMajor, 1, 1, 1, 1},
-            {slate::Layout::RowMajor, 1, 1, 1, 1},
+            {slate::GridOrder::Col, 1, 1, 4, 5},
+            {slate::GridOrder::Row, 1, 1, 4, 5},
+            {slate::GridOrder::Col, 1, 1, 1, 3},
+            {slate::GridOrder::Row, 1, 1, 1, 3},
+            {slate::GridOrder::Col, 1, 1, 10, 1},
+            {slate::GridOrder::Row, 1, 1, 10, 1},
+            {slate::GridOrder::Col, 1, 1, 1, 1},
+            {slate::GridOrder::Row, 1, 1, 1, 1},
     };
     for (auto config : configs) {
         auto func = std::apply(slate::func::device_2d_grid, config );
 
-        bool is_col_layout = std::get<0>(config) == slate::Layout::ColMajor;
+        bool is_col_layout = std::get<0>(config) == slate::GridOrder::Col;
         bool is_row_layout = ! is_col_layout;
         int64_t m = std::get<1>(config);
         int64_t n = std::get<2>(config);
@@ -369,7 +369,7 @@ void test_is_2d_cyclic_grid()
     }
 
     // Test a map that's almost cyclic
-    auto cyclic = slate::func::process_2d_grid( slate::Layout::ColMajor, 4, 5 );
+    auto cyclic = slate::func::process_2d_grid( slate::GridOrder::Col, 4, 5 );
     std::function<int( std::tuple<int64_t, int64_t> )>
     tricky_func = [cyclic]( std::tuple<int64_t, int64_t> ij ) {
         int64_t i = std::get<0>( ij );

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -250,6 +250,8 @@ void test_is_2d_cyclic_grid()
     int64_t out_p, out_q;
 
     // Private helpers to check order, p, and q
+    // Verifies that the output order (out_o), out_p, out_q matches
+    // the expected order (exp_o), exp_p, exp_q.
     #define test_opq( exp_o, exp_p, exp_q ) \
         do { \
             if ((exp_o) != out_o || (exp_p) != out_p || (exp_q) != out_q) { \
@@ -258,6 +260,8 @@ void test_is_2d_cyclic_grid()
                 exit(1); \
             } \
         } while(0)
+    // Verifies that the out_p, out_q matches exp_p, exp_q and that
+    // the output order (out_o) is not unknown.
     #define test_pq( exp_p, exp_q ) \
         do { \
             if (slate::GridOrder::Unknown == out_o \

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -244,44 +244,6 @@ void test_grid_transpose()
 }
 
 //------------------------------------------------------------------------------
-void test_is_same_map()
-{
-    // Check that is_same_map doesn't access an empty map
-    std::function<int( std::tuple<int64_t, int64_t> )>
-    error = []( std::tuple<int64_t, int64_t> ij ) {
-        test_assert( false );
-        return -1;
-    };
-    test_assert( slate::func::is_same_map(0, 0, error, error) );
-    test_assert( slate::func::is_same_map(1000, 0, error, error) );
-    test_assert( slate::func::is_same_map(0, 1000, error, error) );
-
-
-    auto col_2d = slate::func::device_2d_grid(
-                            slate::Layout::ColMajor, 2, 3, 4, 5 );
-    auto row_2d = slate::func::device_2d_grid(
-                            slate::Layout::RowMajor, 2, 3, 4, 5 );
-    auto col_1d = slate::func::device_2d_grid(
-                            slate::Layout::ColMajor, 2, 1, 4, 1 );
-    auto row_1d = slate::func::device_2d_grid(
-                            slate::Layout::ColMajor, 1, 3, 1, 5 );
-    // equality
-    test_assert( slate::func::is_same_map(100, 100, col_2d, col_2d) );
-    test_assert( slate::func::is_same_map(100, 150, row_2d, row_2d) );
-    test_assert( slate::func::is_same_map(100, 1, col_2d, col_1d) );
-    test_assert( slate::func::is_same_map(100, 2, col_2d, col_1d) );
-    test_assert( slate::func::is_same_map(100, 3, col_2d, col_1d) );
-    test_assert( slate::func::is_same_map(1, 100, row_2d, row_1d) );
-    test_assert( slate::func::is_same_map(2, 100, row_2d, row_1d) );
-
-    //inequality
-    test_assert( ! slate::func::is_same_map(150, 100, row_2d, col_2d) );
-    test_assert( ! slate::func::is_same_map(34, 33, col_2d, row_2d) );
-    test_assert( ! slate::func::is_same_map(100, 4, col_2d, col_1d) );
-    test_assert( ! slate::func::is_same_map(3, 100, row_2d, row_1d) );
-}
-
-//------------------------------------------------------------------------------
 void test_is_2d_cyclic_grid()
 {
     slate::GridOrder out_o;
@@ -462,7 +424,6 @@ void run_tests()
     run_test( test_device_2d_grid,    "test_device_2d_grid" );
     run_test( test_device_1d_grid,    "test_device_1d_grid" );
     run_test( test_grid_transpose,    "test_transpose_grid" );
-    run_test( test_is_same_map,       "test_is_same_map" );
     run_test( test_is_2d_cyclic_grid, "test_is_2d_cyclic_grid" );
 }
 

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -278,13 +278,10 @@ void test_is_2d_cyclic_grid()
         test_assert( false );
         return -1;
     };
-    test_assert( slate::func::is_2d_cyclic_grid(0, 0, error) );
     test_assert( slate::func::is_2d_cyclic_grid(0, 0, error, out_o, out_p, out_q) );
     test_pq( 1, 1 );
-    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error) );
     test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, out_o, out_p, out_q) );
     test_pq( 1, 1 );
-    test_assert( slate::func::is_2d_cyclic_grid(0, 1000, error) );
     test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, out_o, out_p, out_q) );
     test_pq( 1, 1 );
 
@@ -333,12 +330,9 @@ void test_is_2d_cyclic_grid()
         //          << is_2d_cyclic << std::endl;
 
 
-        test_assert( slate::func::is_2d_cyclic_grid( 1,  1, func) );
         test_assert( slate::func::is_2d_cyclic_grid( 1,  1, func, out_o, out_p, out_q) );
         test_pq( 1, 1 );
 
-        test_assert( slate::func::is_2d_cyclic_grid( 40,  1, func )
-                     == is_col_cyclic );
         test_assert( slate::func::is_2d_cyclic_grid( 40,  1, func, out_o, out_p, out_q )
                      == is_col_cyclic );
         if (is_col_cyclic) {
@@ -348,8 +342,6 @@ void test_is_2d_cyclic_grid()
             test_opq( slate::GridOrder::Unknown, -1, -1 );
         }
 
-        test_assert( slate::func::is_2d_cyclic_grid(  1, 40, func )
-                     == is_row_cyclic );
         test_assert( slate::func::is_2d_cyclic_grid(  1, 40, func, out_o, out_p, out_q )
                      == is_row_cyclic );
         if (is_row_cyclic) {
@@ -359,8 +351,6 @@ void test_is_2d_cyclic_grid()
             test_opq( slate::GridOrder::Unknown, -1, -1 );
         }
 
-        test_assert( slate::func::is_2d_cyclic_grid( 40, 40, func )
-                     == is_2d_cyclic );
         test_assert( slate::func::is_2d_cyclic_grid( 40, 40, func, out_o, out_p, out_q )
                      == is_2d_cyclic );
         if (is_2d_cyclic) {
@@ -391,26 +381,19 @@ void test_is_2d_cyclic_grid()
             return cyclic( ij );
         }
     };
-    test_assert( ! slate::func::is_2d_cyclic_grid(99, 99, tricky_func) );
     test_assert( ! slate::func::is_2d_cyclic_grid(99, 99, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_2d_cyclic_grid(50, 99, tricky_func) );
     test_assert( ! slate::func::is_2d_cyclic_grid(50, 99, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_2d_cyclic_grid(99, 50, tricky_func) );
     test_assert( ! slate::func::is_2d_cyclic_grid(99, 50, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_2d_cyclic_grid(50, 50, tricky_func) );
     test_assert( ! slate::func::is_2d_cyclic_grid(50, 50, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
 
-    test_assert( slate::func::is_2d_cyclic_grid(50, 49, tricky_func) );
     test_assert( slate::func::is_2d_cyclic_grid(50, 49, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
-    test_assert( slate::func::is_2d_cyclic_grid(49, 50, tricky_func) );
     test_assert( slate::func::is_2d_cyclic_grid(49, 50, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
-    test_assert( slate::func::is_2d_cyclic_grid(49, 49, tricky_func) );
     test_assert( slate::func::is_2d_cyclic_grid(49, 49, tricky_func, out_o, out_p, out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
 

--- a/unit_test/test_func.cc
+++ b/unit_test/test_func.cc
@@ -247,7 +247,7 @@ void test_grid_transpose()
 void test_is_2d_cyclic_grid()
 {
     slate::GridOrder out_o;
-    int64_t out_p, out_q;
+    int out_p, out_q;
 
     // Private helpers to check order, p, and q
     // Verifies that the output order (out_o), out_p, out_q matches
@@ -278,11 +278,11 @@ void test_is_2d_cyclic_grid()
         test_assert( false );
         return -1;
     };
-    test_assert( slate::func::is_2d_cyclic_grid(0, 0, error, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(0, 0, error, &out_o, &out_p, &out_q) );
     test_pq( 1, 1 );
-    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, &out_o, &out_p, &out_q) );
     test_pq( 1, 1 );
-    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(1000, 0, error, &out_o, &out_p, &out_q) );
     test_pq( 1, 1 );
 
     // Loop over arguments to grid_2d_block_cyclic
@@ -330,10 +330,10 @@ void test_is_2d_cyclic_grid()
         //          << is_2d_cyclic << std::endl;
 
 
-        test_assert( slate::func::is_2d_cyclic_grid( 1,  1, func, out_o, out_p, out_q) );
+        test_assert( slate::func::is_2d_cyclic_grid( 1,  1, func, &out_o, &out_p, &out_q) );
         test_pq( 1, 1 );
 
-        test_assert( slate::func::is_2d_cyclic_grid( 40,  1, func, out_o, out_p, out_q )
+        test_assert( slate::func::is_2d_cyclic_grid( 40,  1, func, &out_o, &out_p, &out_q )
                      == is_col_cyclic );
         if (is_col_cyclic) {
             test_pq( p, 1 );
@@ -342,7 +342,7 @@ void test_is_2d_cyclic_grid()
             test_opq( slate::GridOrder::Unknown, -1, -1 );
         }
 
-        test_assert( slate::func::is_2d_cyclic_grid(  1, 40, func, out_o, out_p, out_q )
+        test_assert( slate::func::is_2d_cyclic_grid(  1, 40, func, &out_o, &out_p, &out_q )
                      == is_row_cyclic );
         if (is_row_cyclic) {
             test_pq( 1, q );
@@ -351,7 +351,7 @@ void test_is_2d_cyclic_grid()
             test_opq( slate::GridOrder::Unknown, -1, -1 );
         }
 
-        test_assert( slate::func::is_2d_cyclic_grid( 40, 40, func, out_o, out_p, out_q )
+        test_assert( slate::func::is_2d_cyclic_grid( 40, 40, func, &out_o, &out_p, &out_q )
                      == is_2d_cyclic );
         if (is_2d_cyclic) {
             if (p != 1 && q != 1) {
@@ -381,20 +381,20 @@ void test_is_2d_cyclic_grid()
             return cyclic( ij );
         }
     };
-    test_assert( ! slate::func::is_2d_cyclic_grid(99, 99, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(99, 99, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_2d_cyclic_grid(50, 99, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(50, 99, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_2d_cyclic_grid(99, 50, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(99, 50, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
-    test_assert( ! slate::func::is_2d_cyclic_grid(50, 50, tricky_func, out_o, out_p, out_q) );
+    test_assert( ! slate::func::is_2d_cyclic_grid(50, 50, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Unknown, -1, -1 );
 
-    test_assert( slate::func::is_2d_cyclic_grid(50, 49, tricky_func, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(50, 49, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
-    test_assert( slate::func::is_2d_cyclic_grid(49, 50, tricky_func, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(49, 50, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
-    test_assert( slate::func::is_2d_cyclic_grid(49, 49, tricky_func, out_o, out_p, out_q) );
+    test_assert( slate::func::is_2d_cyclic_grid(49, 49, tricky_func, &out_o, &out_p, &out_q) );
     test_opq( slate::GridOrder::Col, 4, 5 );
 
     #undef test_opq


### PR DESCRIPTION
This is a few different changes to improve SLATE's support for variable block sizes.
1. `BaseMatrix::gridinfo` now tries to detect the grid layout when unknown.  Fixes #102 
2. `condest` was rewritten to not depend on a 2d block-cyclic layout.
3. Device memory is allocated for the largest tile, not the (0,0) tile.  Fixes #101
4. `MatrixStorage::allocWorkspaceBuffer` now takes a buffer size instead of assuming a size of `tileMb(0) x tileNb(0)`

Detecting the layout of a 2000x2000 tile grid (i.e., `n=1e6` and `nb=500` or `n=32000` and `nb=16`) takes about 0.3s on Haswell.  And the result is cached with a 2d block cyclic layout is detected, so we pay that cost at most once per matrix.