### PR TITLE
LU info

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -489,6 +489,7 @@ ifneq ($(only_unit),1)
         src/internal/internal_hettmqr.cc \
         src/internal/internal_norm1est.cc \
         src/internal/internal_potrf.cc \
+        src/internal/internal_reduce_info.cc \
         src/internal/internal_swap.cc \
         src/internal/internal_symm.cc \
         src/internal/internal_synorm.cc \

--- a/include/slate/simplified_api.hh
+++ b/include/slate/simplified_api.hh
@@ -238,13 +238,13 @@ void lu_solve(
 
 // gesv
 template <typename scalar_t>
-void lu_solve(
+int64_t lu_solve(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,
     Options const& opts = Options())
 {
     Pivots pivots;
-    gesv(A, pivots, B, opts);
+    return gesv( A, pivots, B, opts );
 }
 
 //-----------------------------------------
@@ -286,11 +286,11 @@ void lu_factor(
 
 // getrf
 template <typename scalar_t>
-void lu_factor(
+int64_t lu_factor(
     Matrix<scalar_t>& A, Pivots& pivots,
     Options const& opts = Options())
 {
-    getrf(A, pivots, opts);
+    return getrf( A, pivots, opts );
 }
 
 //-----------------------------------------
@@ -515,7 +515,7 @@ void chol_inverse_using_factor(
 
 // hesv
 template <typename scalar_t>
-void indefinite_solve(
+int64_t indefinite_solve(
     HermitianMatrix<scalar_t>& A,
              Matrix<scalar_t>& B,
     Options const& opts = Options())
@@ -528,13 +528,13 @@ void indefinite_solve(
     auto T = slate::BandMatrix<scalar_t>::emptyLike(A, kl, ku);
 
     Pivots pivots, pivots2;
-    hesv(A, pivots, T, pivots2, H, B, opts);
+    return hesv( A, pivots, T, pivots2, H, B, opts );
 }
 
 // forward real-symmetric matrices to hesv;
 // disabled for complex
 template <typename scalar_t>
-void indefinite_solve(
+int64_t indefinite_solve(
     SymmetricMatrix<scalar_t>& A,
              Matrix<scalar_t>& B,
     Options const& opts = Options(),
@@ -548,7 +548,7 @@ void indefinite_solve(
     auto T = slate::BandMatrix<scalar_t>::emptyLike(A, kl, ku);
 
     Pivots pivots, pivots2;
-    sysv(A, pivots, T, pivots2, H, B, opts);
+    return sysv( A, pivots, T, pivots2, H, B, opts );
 }
 
 //-----------------------------------------
@@ -556,26 +556,26 @@ void indefinite_solve(
 
 // hetrf
 template <typename scalar_t>
-void indefinite_factor(
+int64_t indefinite_factor(
     HermitianMatrix<scalar_t>& A, Pivots& pivots,
          BandMatrix<scalar_t>& T, Pivots& pivots2,
              Matrix<scalar_t>& H,
     Options const& opts = Options())
 {
-    hetrf(A, pivots, T, pivots2, H, opts);
+    return hetrf( A, pivots, T, pivots2, H, opts );
 }
 
 // forward real-symmetric matrices to hetrf;
 // disabled for complex
 template <typename scalar_t>
-void indefinite_factor(
+int64_t indefinite_factor(
     SymmetricMatrix<scalar_t>& A, Pivots& pivots,
          BandMatrix<scalar_t>& T, Pivots& pivots2,
              Matrix<scalar_t>& H,
     Options const& opts = Options(),
     enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
-    sytrf(A, pivots, T, pivots2, H, opts);
+    return sytrf( A, pivots, T, pivots2, H, opts );
 }
 
 //-----------------------------------------

--- a/include/slate/simplified_api.hh
+++ b/include/slate/simplified_api.hh
@@ -250,26 +250,15 @@ int64_t lu_solve(
 //-----------------------------------------
 // lu_solve_nopiv()
 
-// todo
-// gbsv_nopiv
-// template <typename scalar_t>
-// void lu_solve_nopiv(
-//     BandMatrix<scalar_t>& A,
-//         Matrix<scalar_t>& B,
-//     Options const& opts = Options())
-// {
-//     gbsv_nopiv(A, B, opts);
-// }
-
 // gesv_nopiv
-// todo: deprecate, use lu_solve( ..., { MethodLU: NoPiv } )
 template <typename scalar_t>
-void lu_solve_nopiv(
+[[deprecated( "Use lu_solve( A, { Option::MethodLU, MethodLU::NoPiv } ) instead. Will be removed 2024-09." )]]
+int64_t lu_solve_nopiv(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,
     Options const& opts = Options())
 {
-    gesv_nopiv(A, B, opts);
+    return gesv_nopiv( A, B, opts );
 }
 
 //-----------------------------------------
@@ -296,24 +285,14 @@ int64_t lu_factor(
 //-----------------------------------------
 // lu_factor_nopiv()
 
-// todo
-// gbtrf_nopiv
-// template <typename scalar_t>
-// void lu_factor_nopiv(
-//     BandMatrix<scalar_t>& A,
-//     Options const& opts = Options())
-// {
-//     gbtrf_nopiv(A, opts);
-// }
-
 // getrf_nopiv
-// todo: deprecate, use lu_factor_nopiv( ..., { MethodLU: NoPiv } )
 template <typename scalar_t>
-void lu_factor_nopiv(
+[[deprecated( "Use lu_factor( A, { Option::MethodLU, MethodLU::NoPiv } ) instead. Will be removed 2024-09." )]]
+int64_t lu_factor_nopiv(
     Matrix<scalar_t>& A,
     Options const& opts = Options())
 {
-    getrf_nopiv(A, opts);
+    return getrf_nopiv( A, opts );
 }
 
 //-----------------------------------------
@@ -342,20 +321,9 @@ void lu_solve_using_factor(
 //-----------------------------------------
 // lu_solve_using_factor_nopiv()
 
-// todo
-// gbtrs_nopiv
-// template <typename scalar_t>
-// void lu_solve_using_factor_nopiv(
-//     BandMatrix<scalar_t>& A,
-//         Matrix<scalar_t>& B,
-//     Options const& opts = Options())
-// {
-//     gbtrs_nopiv(A, B, opts);
-// }
-
 // getrs_nopiv
-// todo: deprecate, use lu_solve_using_factor( ..., { MethodLU: NoPiv } )
 template <typename scalar_t>
+[[deprecated( "Use lu_solve_using_factor( A, { Option::MethodLU, MethodLU::NoPiv } ) instead. Will be removed 2024-09." )]]
 void lu_solve_using_factor_nopiv(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -473,7 +473,7 @@ void colNorms(
 //-----------------------------------------
 // gbsv()
 template <typename scalar_t>
-void gbsv(
+int64_t gbsv(
     BandMatrix<scalar_t>& A, Pivots& pivots,
         Matrix<scalar_t>& B,
     Options const& opts = Options());
@@ -481,7 +481,7 @@ void gbsv(
 //-----------------------------------------
 // gesv()
 template <typename scalar_t>
-void gesv(
+int64_t gesv(
     Matrix<scalar_t>& A, Pivots& pivots,
     Matrix<scalar_t>& B,
     Options const& opts = Options());
@@ -490,7 +490,7 @@ void gesv(
 // gesv_nopiv()
 // todo: deprecate, use gesv( ..., { MethodLU: NoPiv } )
 template <typename scalar_t>
-void gesv_nopiv(
+int64_t gesv_nopiv(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,
     Options const& opts = Options());
@@ -498,7 +498,7 @@ void gesv_nopiv(
 //-----------------------------------------
 // gesv_mixed()
 template <typename scalar_t>
-void gesv_mixed(
+int64_t gesv_mixed(
     Matrix<scalar_t>& A, Pivots& pivots,
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& X,
@@ -506,7 +506,7 @@ void gesv_mixed(
     Options const& opts = Options());
 
 template <typename scalar_hi, typename scalar_lo>
-void gesv_mixed(
+int64_t gesv_mixed(
     Matrix<scalar_hi>& A, Pivots& pivots,
     Matrix<scalar_hi>& B,
     Matrix<scalar_hi>& X,
@@ -515,32 +515,32 @@ void gesv_mixed(
 
 template <typename scalar_t>
 [[deprecated( "Use gesv_mixed instead. Will be removed 2024-02." )]]
-void gesvMixed(
+int64_t gesvMixed(
     Matrix<scalar_t>& A, Pivots& pivots,
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& X,
     int& iter,
     Options const& opts = Options())
 {
-    gesv_mixed( A, pivots, B, X, iter, opts );
+    return gesv_mixed( A, pivots, B, X, iter, opts );
 }
 
 template <typename scalar_hi, typename scalar_lo>
 [[deprecated( "Use gesv_mixed instead. Will be removed 2024-02." )]]
-void gesvMixed(
+int64_t gesvMixed(
     Matrix<scalar_hi>& A, Pivots& pivots,
     Matrix<scalar_hi>& B,
     Matrix<scalar_hi>& X,
     int& iter,
     Options const& opts = Options())
 {
-    gesv_mixed( A, pivots, B, X, iter, opts );
+    return gesv_mixed( A, pivots, B, X, iter, opts );
 }
 
 //-----------------------------------------
 // gesv_mixed_gmres()
 template <typename scalar_t>
-void gesv_mixed_gmres(
+int64_t gesv_mixed_gmres(
     Matrix<scalar_t>& A, Pivots& pivots,
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& X,
@@ -548,7 +548,7 @@ void gesv_mixed_gmres(
     Options const& opts = Options());
 
 template <typename scalar_hi, typename scalar_lo>
-void gesv_mixed_gmres(
+int64_t gesv_mixed_gmres(
     Matrix<scalar_hi>& A, Pivots& pivots,
     Matrix<scalar_hi>& B,
     Matrix<scalar_hi>& X,
@@ -558,14 +558,14 @@ void gesv_mixed_gmres(
 //-----------------------------------------
 // gbtrf()
 template <typename scalar_t>
-void gbtrf(
+int64_t gbtrf(
     BandMatrix<scalar_t>& A, Pivots& pivots,
     Options const& opts = Options());
 
 //-----------------------------------------
 // getrf()
 template <typename scalar_t>
-void getrf(
+int64_t getrf(
     Matrix<scalar_t>& A, Pivots& pivots,
     Options const& opts = Options());
 
@@ -791,7 +791,7 @@ void potri(
 //-----------------------------------------
 // hesv()
 template <typename scalar_t>
-void hesv(
+int64_t hesv(
     HermitianMatrix<scalar_t>& A, Pivots& pivots,
          BandMatrix<scalar_t>& T, Pivots& pivots2,
              Matrix<scalar_t>& H,
@@ -803,7 +803,7 @@ void hesv(
 // forward real-symmetric matrices to hesv;
 // disabled for complex
 template <typename scalar_t>
-void sysv(
+int64_t sysv(
     SymmetricMatrix<scalar_t>& A, Pivots& pivots,
          BandMatrix<scalar_t>& T, Pivots& pivots2,
              Matrix<scalar_t>& H,
@@ -811,14 +811,14 @@ void sysv(
     Options const& opts = Options(),
     enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
-    HermitianMatrix<scalar_t> AH(A);
-    hesv(AH, pivots, T, pivots2, H, B, opts);
+    HermitianMatrix<scalar_t> AH( A );
+    return hesv( AH, pivots, T, pivots2, H, B, opts );
 }
 
 //-----------------------------------------
 // hetrf()
 template <typename scalar_t>
-void hetrf(
+int64_t hetrf(
     HermitianMatrix<scalar_t>& A, Pivots& pivots,
          BandMatrix<scalar_t>& T, Pivots& pivots2,
              Matrix<scalar_t>& H,
@@ -829,15 +829,15 @@ void hetrf(
 // forward real-symmetric matrices to hetrf;
 // disabled for complex
 template <typename scalar_t>
-void sytrf(
+int64_t sytrf(
     SymmetricMatrix<scalar_t>& A, Pivots& pivots,
          BandMatrix<scalar_t>& T, Pivots& pivots2,
              Matrix<scalar_t>& H,
     Options const& opts = Options(),
     enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
-    HermitianMatrix<scalar_t> AH(A);
-    hetrf(AH, pivots, T, pivots2, H, opts);
+    HermitianMatrix<scalar_t> AH( A );
+    return hetrf( AH, pivots, T, pivots2, H, opts );
 }
 
 //-----------------------------------------

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -579,7 +579,7 @@ int64_t getrf_nopiv(
 //-----------------------------------------
 // getrf_tntpiv()
 template <typename scalar_t>
-void getrf_tntpiv(
+int64_t getrf_tntpiv(
     Matrix<scalar_t>& A, Pivots& pivots,
     Options const& opts = Options());
 

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -572,7 +572,7 @@ int64_t getrf(
 //-----------------------------------------
 // getrf_nopiv()
 template <typename scalar_t>
-void getrf_nopiv(
+int64_t getrf_nopiv(
     Matrix<scalar_t>& A,
     Options const& opts = Options());
 

--- a/include/slate/types.hh
+++ b/include/slate/types.hh
@@ -99,9 +99,21 @@ using Pivots = std::vector< std::vector<Pivot> >;
 
 //------------------------------------------------------------------------------
 /// Gives mpi_type based on actual scalar_t.
-//  Constants are initialized in slate_types.cc
+//  Constants are initialized in src/core/types.cc
 template <typename scalar_t>
 class mpi_type {};
+
+template<>
+class mpi_type<int> {
+public:
+    static MPI_Datatype value; // = MPI_INT
+};
+
+template<>
+class mpi_type<int64_t> {
+public:
+    static MPI_Datatype value; // = MPI_INT64_T
+};
 
 template<>
 class mpi_type<float> {

--- a/src/core/types.cc
+++ b/src/core/types.cc
@@ -8,6 +8,9 @@
 namespace slate {
 
 //------------------------------------------------------------------------------
+MPI_Datatype mpi_type<int    >::value = MPI_INT;
+MPI_Datatype mpi_type<int64_t>::value = MPI_INT64_T;
+
 MPI_Datatype mpi_type<float >::value = MPI_FLOAT;
 MPI_Datatype mpi_type<double>::value = MPI_DOUBLE;
 MPI_Datatype mpi_type< std::complex<float>  >::value = MPI_C_COMPLEX;

--- a/src/gbsv.cc
+++ b/src/gbsv.cc
@@ -66,10 +66,9 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// TODO: return value
-/// @retval 0 successful exit
-/// @retval >0 for return value = $i$, the computed $U(i,i)$ is exactly zero.
-///         The factorization has been completed, but the factor U is exactly
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
+///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, so the solution could not be computed.
 ///
 /// @ingroup gbsv

--- a/src/gbsv.cc
+++ b/src/gbsv.cc
@@ -75,44 +75,47 @@ namespace slate {
 /// @ingroup gbsv
 ///
 template <typename scalar_t>
-void gbsv(BandMatrix<scalar_t>& A, Pivots& pivots,
-          Matrix<scalar_t>& B,
-          Options const& opts)
+int64_t gbsv(
+    BandMatrix<scalar_t>& A, Pivots& pivots,
+    Matrix<scalar_t>& B,
+    Options const& opts)
 {
-    slate_assert(A.mt() == A.nt());  // square
-    slate_assert(B.mt() == A.mt());
+    slate_assert( A.mt() == A.nt() );  // square
+    slate_assert( B.mt() == A.mt() );
 
     // factorization
-    gbtrf(A, pivots, opts);
+    int64_t info = gbtrf( A, pivots, opts );
 
     // solve
-    gbtrs(A, pivots, B, opts);
+    if (info == 0) {
+        gbtrs( A, pivots, B, opts );
+    }
 
-    // todo: return value for errors?
+    return info;
 }
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template
-void gbsv<float>(
+int64_t gbsv<float>(
     BandMatrix<float>& A, Pivots& pivots,
     Matrix<float>& B,
     Options const& opts);
 
 template
-void gbsv<double>(
+int64_t gbsv<double>(
     BandMatrix<double>& A, Pivots& pivots,
     Matrix<double>& B,
     Options const& opts);
 
 template
-void gbsv< std::complex<float> >(
+int64_t gbsv< std::complex<float> >(
     BandMatrix< std::complex<float> >& A, Pivots& pivots,
     Matrix< std::complex<float> >& B,
     Options const& opts);
 
 template
-void gbsv< std::complex<double> >(
+int64_t gbsv< std::complex<double> >(
     BandMatrix< std::complex<double> >& A, Pivots& pivots,
     Matrix< std::complex<double> >& B,
     Options const& opts);

--- a/src/gbtrf.cc
+++ b/src/gbtrf.cc
@@ -271,8 +271,8 @@ int64_t gbtrf(
 ///      Strictness of the pivot selection.  Between 0 and 1 with 1 giving
 ///      partial pivoting and 0 giving no pivoting.  Default 1.
 ///
-/// @retval 0 successful exit
-/// @retval i > 0, $U(i,i)$ is exactly zero, where i is a 1-based index.
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
 ///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, and division by zero will occur if it is used
 ///         to solve a system of equations.
@@ -285,27 +285,22 @@ int64_t gbtrf(
     Options const& opts )
 {
     Target target = get_option( opts, Option::Target, Target::HostTask );
-    int64_t info = 0;
 
     switch (target) {
         case Target::Host:
         case Target::HostTask:
-            info = impl::gbtrf<Target::HostTask>( A, pivots, opts );
-            break;
+            return impl::gbtrf<Target::HostTask>( A, pivots, opts );
 
         case Target::HostNest:
-            info = impl::gbtrf<Target::HostNest>( A, pivots, opts );
-            break;
+            return impl::gbtrf<Target::HostNest>( A, pivots, opts );
 
         case Target::HostBatch:
-            info = impl::gbtrf<Target::HostBatch>( A, pivots, opts );
-            break;
+            return impl::gbtrf<Target::HostBatch>( A, pivots, opts );
 
         case Target::Devices:
-            info = impl::gbtrf<Target::Devices>( A, pivots, opts );
-            break;
+            return impl::gbtrf<Target::Devices>( A, pivots, opts );
     }
-    return info;
+    return -3;  // shouldn't happen
 }
 
 //------------------------------------------------------------------------------

--- a/src/gesv.cc
+++ b/src/gesv.cc
@@ -75,9 +75,9 @@ namespace slate {
 ///       - NoPiv: no pivoting.
 ///         Note pivots vector is currently ignored for NoPiv.
 ///
-/// @retval 0 successful exit
-/// @retval i > 0, $U(i,i)$ is exactly zero, where i is a 1-based index.
-///         The factorization has been completed, but the factor U is exactly
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
+///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, so the solution could not be computed.
 ///
 /// @ingroup gesv

--- a/src/gesv.cc
+++ b/src/gesv.cc
@@ -75,18 +75,18 @@ namespace slate {
 ///       - NoPiv: no pivoting.
 ///         Note pivots vector is currently ignored for NoPiv.
 ///
-/// TODO: return value
 /// @retval 0 successful exit
-/// @retval >0 for return value = $i$, the computed $U(i,i)$ is exactly zero.
+/// @retval i > 0, $U(i,i)$ is exactly zero, where i is a 1-based index.
 ///         The factorization has been completed, but the factor U is exactly
 ///         singular, so the solution could not be computed.
 ///
 /// @ingroup gesv
 ///
 template <typename scalar_t>
-void gesv(Matrix<scalar_t>& A, Pivots& pivots,
-          Matrix<scalar_t>& B,
-          Options const& opts)
+int64_t gesv(
+    Matrix<scalar_t>& A, Pivots& pivots,
+    Matrix<scalar_t>& B,
+    Options const& opts)
 {
     Timer t_gesv;
 
@@ -95,41 +95,42 @@ void gesv(Matrix<scalar_t>& A, Pivots& pivots,
 
     // factorization
     Timer t_getrf;
-    getrf(A, pivots, opts);
+    int64_t info = getrf(A, pivots, opts);
     timers[ "gesv::getrf" ] = t_getrf.stop();
 
     // solve
     Timer t_getrs;
-    getrs(A, pivots, B, opts);
+    if (info == 0) {
+        getrs( A, pivots, B, opts );
+    }
     timers[ "gesv::getrs" ] = t_getrs.stop();
 
-    // todo: return value for errors?
-
     timers[ "gesv" ] = t_gesv.stop();
+    return info;
 }
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template
-void gesv<float>(
+int64_t gesv<float>(
     Matrix<float>& A, Pivots& pivots,
     Matrix<float>& B,
     Options const& opts);
 
 template
-void gesv<double>(
+int64_t gesv<double>(
     Matrix<double>& A, Pivots& pivots,
     Matrix<double>& B,
     Options const& opts);
 
 template
-void gesv< std::complex<float> >(
+int64_t gesv< std::complex<float> >(
     Matrix< std::complex<float> >& A, Pivots& pivots,
     Matrix< std::complex<float> >& B,
     Options const& opts);
 
 template
-void gesv< std::complex<double> >(
+int64_t gesv< std::complex<double> >(
     Matrix< std::complex<double> >& A, Pivots& pivots,
     Matrix< std::complex<double> >& B,
     Options const& opts);

--- a/src/gesv_mixed.cc
+++ b/src/gesv_mixed.cc
@@ -72,9 +72,13 @@ namespace slate {
 ///     On exit, if return value = 0, the n-by-nrhs solution matrix $X$.
 ///
 /// @param[out] iter
-///     The number of the iterations in the iterative refinement
-///     process, needed for the convergence. If failed, it is set
-///     to be -(1+itermax), where itermax = 30.
+///     > 0: The number of the iterations the iterative refinement
+///          process needed for convergence.
+///     < 0: Iterative refinement failed; it falls back to a double
+///          precision factorization and solve.
+///          -3: single precision matrix was exactly singular in getrf.
+///          -(itermax+1): iterative refinement failed to converge in
+///          itermax iterations.
 ///
 /// @param[in] opts
 ///     Additional options, as map of name = value pairs. Possible options:
@@ -88,10 +92,9 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// TODO: return value
-/// @retval 0 successful exit
-/// @retval >0 for return value = $i$, the computed $U(i,i)$ is exactly zero.
-///         The factorization has been completed, but the factor U is exactly
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
+///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, so the solution could not be computed.
 ///
 /// @ingroup gesv

--- a/src/gesv_mixed_gmres.cc
+++ b/src/gesv_mixed_gmres.cc
@@ -72,9 +72,14 @@ namespace slate {
 ///     On exit, if return value = 0, the n-by-nrhs solution matrix $X$.
 ///
 /// @param[out] iter
-///     The number of the iterations in the iterative refinement
-///     process, needed for the convergence. If failed, it is set
-///     to be -(1+itermax), where itermax is controlled by the opts argument.
+/// @param[out] iter
+///     > 0: The number of the iterations the iterative refinement
+///          process needed for convergence.
+///     < 0: Iterative refinement failed; it falls back to a double
+///          precision factorization and solve.
+///          -3: single precision matrix was exactly singular in getrf.
+///          -(itermax+1): iterative refinement failed to converge in
+///          itermax iterations.
 ///
 /// @param[in] opts
 ///     Additional options, as map of name = value pairs. Possible options:
@@ -92,10 +97,9 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// TODO: return value
-/// @retval 0 successful exit
-/// @retval >0 for return value = $i$, the computed $U(i,i)$ is exactly zero.
-///         The factorization has been completed, but the factor U is exactly
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
+///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, so the solution could not be computed.
 ///
 /// @ingroup gesv

--- a/src/gesv_nopiv.cc
+++ b/src/gesv_nopiv.cc
@@ -58,9 +58,9 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// @retval 0 successful exit
-/// @retval i > 0: U(i,i) is exactly zero (1-based index). The factorization
-///         will have NaN due to division by zero.
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
+///         The factorization will have NaN due to division by zero.
 ///
 /// @ingroup gesv
 ///

--- a/src/gesv_nopiv.cc
+++ b/src/gesv_nopiv.cc
@@ -58,16 +58,14 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// TODO: return value
 /// @retval 0 successful exit
-/// @retval >0 for return value = $i$, the computed $U(i,i)$ is exactly zero.
-///         The factorization has been completed, but the factor U is exactly
-///         singular, so the solution could not be computed.
+/// @retval i > 0: U(i,i) is exactly zero (1-based index). The factorization
+///         will have NaN due to division by zero.
 ///
 /// @ingroup gesv
 ///
 template <typename scalar_t>
-void gesv_nopiv(
+int64_t gesv_nopiv(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,
     Options const& opts)
@@ -76,36 +74,37 @@ void gesv_nopiv(
     slate_assert(B.mt() == A.mt());
 
     // factorization
-    getrf_nopiv(A, opts);
+    int64_t info = getrf_nopiv( A, opts );
 
     // solve
-    getrs_nopiv(A, B, opts);
-
-    // todo: return value for errors?
+    if (info == 0) {
+        getrs_nopiv( A, B, opts );
+    }
+    return info;
 }
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template
-void gesv_nopiv<float>(
+int64_t gesv_nopiv<float>(
     Matrix<float>& A,
     Matrix<float>& B,
     Options const& opts);
 
 template
-void gesv_nopiv<double>(
+int64_t gesv_nopiv<double>(
     Matrix<double>& A,
     Matrix<double>& B,
     Options const& opts);
 
 template
-void gesv_nopiv< std::complex<float> >(
+int64_t gesv_nopiv< std::complex<float> >(
     Matrix< std::complex<float> >& A,
     Matrix< std::complex<float> >& B,
     Options const& opts);
 
 template
-void gesv_nopiv< std::complex<double> >(
+int64_t gesv_nopiv< std::complex<double> >(
     Matrix< std::complex<double> >& A,
     Matrix< std::complex<double> >& B,
     Options const& opts);

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -336,7 +336,7 @@ int64_t getrf(
     }
     else if (method == MethodLU::NoPiv) {
         // todo: fill in pivots vector?
-        getrf_nopiv( A, opts );
+        info = getrf_nopiv( A, opts );
     }
     else if (method == MethodLU::PartialPiv) {
         Target target = get_option( opts, Option::Target, Target::HostTask );

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -315,7 +315,7 @@ int64_t getrf(
 ///         Note pivots vector is currently ignored for NoPiv.
 ///
 /// @retval 0 successful exit
-/// @retval i > 0, $U(i,i)$ is exactly zero, where i is a 1-based index.
+/// @retval i > 0: $U(i,i)$ is exactly zero, where i is a 1-based index.
 ///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, and division by zero will occur if it is used
 ///         to solve a system of equations.
@@ -328,15 +328,14 @@ int64_t getrf(
     Options const& opts )
 {
     Method method = get_option( opts, Option::MethodLU, MethodLU::PartialPiv );
-    int64_t info = 0;
 
     // todo: info for tntpiv, nopiv
     if (method == MethodLU::CALU) {
-        getrf_tntpiv( A, pivots, opts );
+        return getrf_tntpiv( A, pivots, opts );
     }
     else if (method == MethodLU::NoPiv) {
         // todo: fill in pivots vector?
-        info = getrf_nopiv( A, opts );
+        return getrf_nopiv( A, opts );
     }
     else if (method == MethodLU::PartialPiv) {
         Target target = get_option( opts, Option::Target, Target::HostTask );
@@ -344,26 +343,26 @@ int64_t getrf(
         switch (target) {
             case Target::Host:
             case Target::HostTask:
-                info = impl::getrf<Target::HostTask>( A, pivots, opts );
+                return impl::getrf<Target::HostTask>( A, pivots, opts );
                 break;
 
             case Target::HostNest:
-                info = impl::getrf<Target::HostNest>( A, pivots, opts );
+                return impl::getrf<Target::HostNest>( A, pivots, opts );
                 break;
 
             case Target::HostBatch:
-                info = impl::getrf<Target::HostBatch>( A, pivots, opts );
+                return impl::getrf<Target::HostBatch>( A, pivots, opts );
                 break;
 
             case Target::Devices:
-                info = impl::getrf<Target::Devices>( A, pivots, opts );
+                return impl::getrf<Target::Devices>( A, pivots, opts );
                 break;
         }
     }
     else {
         throw Exception( "unknown value for MethodLU" );
     }
-    return info;
+    return -2;  // shouldn't happen
 }
 
 //------------------------------------------------------------------------------

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -314,8 +314,8 @@ int64_t getrf(
 ///       - MethodLU::NoPiv: no pivoting.
 ///         Note pivots vector is currently ignored for NoPiv.
 ///
-/// @retval 0 successful exit
-/// @retval i > 0: $U(i,i)$ is exactly zero, where i is a 1-based index.
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
 ///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, and division by zero will occur if it is used
 ///         to solve a system of equations.
@@ -344,25 +344,21 @@ int64_t getrf(
             case Target::Host:
             case Target::HostTask:
                 return impl::getrf<Target::HostTask>( A, pivots, opts );
-                break;
 
             case Target::HostNest:
                 return impl::getrf<Target::HostNest>( A, pivots, opts );
-                break;
 
             case Target::HostBatch:
                 return impl::getrf<Target::HostBatch>( A, pivots, opts );
-                break;
 
             case Target::Devices:
                 return impl::getrf<Target::Devices>( A, pivots, opts );
-                break;
         }
     }
     else {
         throw Exception( "unknown value for MethodLU" );
     }
-    return -2;  // shouldn't happen
+    return -3;  // shouldn't happen
 }
 
 //------------------------------------------------------------------------------

--- a/src/getrf_nopiv.cc
+++ b/src/getrf_nopiv.cc
@@ -285,10 +285,9 @@ int64_t getrf_nopiv(
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// @retval 0 successful exit
-/// @retval i < 0: the i-th argument had an illegal value.
-/// @retval i > 0: U(i,i) is exactly zero (1-based index). The factorization
-///         will have NaN due to division by zero.
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
+///         The factorization will have NaN due to division by zero.
 ///
 /// @ingroup gesv_computational
 ///
@@ -303,19 +302,15 @@ int64_t getrf_nopiv(
         case Target::Host:
         case Target::HostTask:
             return impl::getrf_nopiv<Target::HostTask>( A, opts );
-            break;
 
         case Target::HostNest:
             return impl::getrf_nopiv<Target::HostNest>( A, opts );
-            break;
 
         case Target::HostBatch:
             return impl::getrf_nopiv<Target::HostBatch>( A, opts );
-            break;
 
         case Target::Devices:
             return impl::getrf_nopiv<Target::Devices>( A, opts );
-            break;
     }
     return -2;  // shouldn't happen
 }

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -411,10 +411,8 @@ int64_t getrf_tntpiv(
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// TODO: return value
-/// @retval 0 successful exit
-/// @retval i < 0: the i-th argument had an illegal value.
-/// @retval i > 0: $U(i,i)$ is exactly zero, where i is a 1-based index.
+/// @return 0: successful exit
+/// @return i > 0: $U(i,i)$ is exactly zero, where $i$ is a 1-based index.
 ///         The factorization has been completed, but the factor $U$ is exactly
 ///         singular, and division by zero will occur if it is used
 ///         to solve a system of equations.
@@ -432,19 +430,15 @@ int64_t getrf_tntpiv(
         case Target::Host:
         case Target::HostTask:
             return impl::getrf_tntpiv<Target::HostTask>( A, pivots, opts );
-            break;
 
         case Target::HostNest:
             return impl::getrf_tntpiv<Target::HostNest>( A, pivots, opts );
-            break;
 
         case Target::HostBatch:
             return impl::getrf_tntpiv<Target::HostBatch>( A, pivots, opts );
-            break;
 
         case Target::Devices:
             return impl::getrf_tntpiv<Target::Devices>( A, pivots, opts );
-            break;
     }
     return -2;  // shouldn't happen
 }

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -86,9 +86,8 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// @retval 0 successful exit
-/// @retval >0 for return value = $i$, the band LU factorization failed on the
-///         $i$-th column.
+/// @return 0: successful exit
+/// @return i > 0: the band LU factorization failed on the $i$-th column.
 ///
 /// @ingroup hesv
 ///

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -86,7 +86,6 @@ namespace slate {
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
-/// TODO: return value
 /// @retval 0 successful exit
 /// @retval >0 for return value = $i$, the band LU factorization failed on the
 ///         $i$-th column.
@@ -94,11 +93,12 @@ namespace slate {
 /// @ingroup hesv
 ///
 template <typename scalar_t>
-void hesv(HermitianMatrix<scalar_t>& A, Pivots& pivots,
-               BandMatrix<scalar_t>& T, Pivots& pivots2,
-                   Matrix<scalar_t>& H,
-          Matrix<scalar_t>& B,
-          Options const& opts)
+int64_t hesv(
+    HermitianMatrix<scalar_t>& A, Pivots& pivots,
+         BandMatrix<scalar_t>& T, Pivots& pivots2,
+             Matrix<scalar_t>& H,
+             Matrix<scalar_t>& B,
+    Options const& opts )
 {
     assert(B.mt() == A.mt());
 
@@ -109,16 +109,19 @@ void hesv(HermitianMatrix<scalar_t>& A, Pivots& pivots,
         A_ = conj_transpose( A_ );
 
     // factorization
-    hetrf(A_, pivots, T, pivots2, H, opts);
+    int64_t info = hetrf( A_, pivots, T, pivots2, H, opts );
 
     // solve
-    hetrs(A_, pivots, T, pivots2, B, opts);
+    if (info == 0) {
+        hetrs( A_, pivots, T, pivots2, B, opts );
+    }
+    return info;
 }
 
 //------------------------------------------------------------------------------
 // Explicit instantiations.
 template
-void hesv<float>(
+int64_t hesv<float>(
     HermitianMatrix<float>& A, Pivots& pivots,
          BandMatrix<float>& T, Pivots& pivots2,
              Matrix<float>& H,
@@ -126,7 +129,7 @@ void hesv<float>(
     Options const& opts);
 
 template
-void hesv<double>(
+int64_t hesv<double>(
     HermitianMatrix<double>& A, Pivots& pivots,
          BandMatrix<double>& T, Pivots& pivots2,
              Matrix<double>& H,
@@ -134,7 +137,7 @@ void hesv<double>(
     Options const& opts);
 
 template
-void hesv< std::complex<float> >(
+int64_t hesv< std::complex<float> >(
     HermitianMatrix< std::complex<float> >& A, Pivots& pivots,
          BandMatrix< std::complex<float> >& T, Pivots& pivots2,
              Matrix< std::complex<float> >& H,
@@ -142,7 +145,7 @@ void hesv< std::complex<float> >(
     Options const& opts);
 
 template
-void hesv< std::complex<double> >(
+int64_t hesv< std::complex<double> >(
     HermitianMatrix< std::complex<double> >& A, Pivots& pivots,
          BandMatrix< std::complex<double> >& T, Pivots& pivots2,
              Matrix< std::complex<double> >& H,

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -566,6 +566,9 @@ int64_t hetrf(
 ///       - HostBatch: batched BLAS on CPU host.
 ///       - Devices:   batched BLAS on GPU device.
 ///
+/// @return 0: successful exit
+/// @return i > 0: the band LU factorization failed on the $i$-th column.
+///
 /// @ingroup hesv_computational
 ///
 template <typename scalar_t>
@@ -576,27 +579,23 @@ int64_t hetrf(
     Options const& opts)
 {
     Target target = get_option( opts, Option::Target, Target::HostTask );
-    int64_t info = 0;
 
     switch (target) {
         case Target::Host:
         case Target::HostTask:
-            info = impl::hetrf<Target::HostTask>( A, pivots, T, pivots2, H, opts );
-            break;
+            return impl::hetrf<Target::HostTask>( A, pivots, T, pivots2, H, opts );
 
         case Target::HostNest:
-            info = impl::hetrf<Target::HostNest>( A, pivots, T, pivots2, H, opts );
-            break;
+            return impl::hetrf<Target::HostNest>( A, pivots, T, pivots2, H, opts );
 
         case Target::HostBatch:
-            info = impl::hetrf<Target::HostBatch>( A, pivots, T, pivots2, H, opts );
-            break;
+            return impl::hetrf<Target::HostBatch>( A, pivots, T, pivots2, H, opts );
 
         case Target::Devices:
             slate_not_implemented( "hetrf not yet implemented for GPU devices" );
             break;
     }
-    return info;
+    return -6;  // shouldn't happen
 }
 
 //------------------------------------------------------------------------------

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -50,7 +50,9 @@ int64_t hetrf(
         = get_option<double>( opts, Option::PivotThreshold, 1.0 );
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
     int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
-    int64_t max_panel_threads = std::max( omp_get_max_threads()/2, 1 );
+
+    // Using > 1 thread leads to hang, reason unclear.
+    int64_t max_panel_threads = 1;  //std::max( omp_get_max_threads()/2, 1 );
     max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads,
                                              max_panel_threads );
 

--- a/src/internal/Tile_getrf_tntpiv.hh
+++ b/src/internal/Tile_getrf_tntpiv.hh
@@ -91,7 +91,8 @@ void getrf_tntpiv_local(
     std::vector< scalar_t >& max_value,
     std::vector< int64_t  >& max_index,
     std::vector< int64_t  >& max_offset,
-    std::vector< scalar_t >& top_block)
+    std::vector< scalar_t >& top_block,
+    int64_t* info )
 {
     trace::Block trace_block( "lapack::getrf_tntpiv" );
 
@@ -235,11 +236,10 @@ void getrf_tntpiv_local(
                             tile.at( i, j ) /= aux_pivot[ 0 ][ j ].value();
                     }
                 }
-                else {
-                    // aux_pivot[ 0 ][ j ].value() == 0:
-                    // The factorization has been completed
-                    // but the factor U is exactly singular
-                    // todo: how to handle a zero pivot
+                else if (*info == 0 && idx == 0) {
+                    // U(j,j) = 0; save info on thread with diagonal tile,
+                    // using 1-based index.
+                    *info = j + 1;
                 }
 
                 // trailing update

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -486,7 +486,7 @@ void getrf_panel(
     Matrix<scalar_t>&& A, int64_t diag_len, int64_t ib,
     std::vector<Pivot>& pivot,
     blas::real_type<scalar_t> remote_pivot_threshold,
-    int max_panel_threads, int priority=0, int tag=0);
+    int max_panel_threads, int priority, int tag, int64_t* info );
 
 //-----------------------------------------
 // getrf_nopiv()
@@ -668,6 +668,10 @@ void norm1est(
     int* kase,
     std::vector<int64_t>& isave,
     Options const& opts = Options());
+
+//------------------------------------------------------------------------------
+// MPI reduce info, used in getrf, hetrf, etc.
+void reduce_info( int64_t* info, MPI_Comm mpi_comm );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -491,8 +491,9 @@ void getrf_panel(
 //-----------------------------------------
 // getrf_nopiv()
 template <Target target=Target::HostTask, typename scalar_t>
-void getrf_nopiv(Matrix<scalar_t>&& A,
-                 int64_t ib, int priority=0);
+void getrf_nopiv(
+    Matrix<scalar_t>&& A,
+    int64_t ib, int priority, int64_t* info );
 
 //-----------------------------------------
 // getrf_tntpiv()

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -503,7 +503,7 @@ void getrf_tntpiv_panel(
     std::vector< char* > dwork_array, size_t dwork_bytes,
     int64_t diag_len, int64_t ib,
     std::vector<Pivot>& pivot,
-    int max_panel_threads, int priority=0);
+    int max_panel_threads, int priority, int64_t* info );
 
 //-----------------------------------------
 // geqrf()

--- a/src/internal/internal_getrf_nopiv.cc
+++ b/src/internal/internal_getrf_nopiv.cc
@@ -17,26 +17,38 @@ namespace internal {
 /// @ingroup gesv_internal
 ///
 template <Target target, typename scalar_t>
-void getrf_nopiv(Matrix< scalar_t >&& A, int64_t ib, int priority)
+void getrf_nopiv(
+    Matrix< scalar_t >&& A,
+    int64_t ib, int priority, int64_t* info )
 {
-    getrf_nopiv(internal::TargetType<target>(), A, ib, priority);
+    getrf_nopiv( internal::TargetType<target>(), A, ib, priority, info );
 }
 
 //------------------------------------------------------------------------------
 /// LU factorization of single tile without pivoting, host implementation.
+///
+/// @param[in,out] info
+///     Exit status.
+///     * 0: successful exit
+///     * i > 0: U(i,i) is exactly zero (1-based index). The factorization
+///       will have NaN due to division by zero.
+///
 /// @ingroup gesv_internal
 ///
 template <typename scalar_t>
-void getrf_nopiv(internal::TargetType<Target::HostTask>,
-                 Matrix<scalar_t>& A,
-                 int64_t ib, int priority)
+void getrf_nopiv(
+    internal::TargetType<Target::HostTask>,
+    Matrix<scalar_t>& A,
+    int64_t ib, int priority, int64_t* info )
 {
     assert(A.mt() == 1);
     assert(A.nt() == 1);
 
+    *info = 0;
+
     if (A.tileIsLocal(0, 0)) {
         A.tileGetForWriting(0, 0, LayoutConvert::ColMajor);
-        getrf_nopiv(A(0, 0), ib);
+        tile::getrf_nopiv( A( 0, 0 ), ib, info );
     }
 }
 
@@ -47,28 +59,32 @@ template
 void getrf_nopiv<Target::HostTask, float>(
     Matrix<float>&& A,
     int64_t ib,
-    int priority);
+    int priority,
+    int64_t* info );
 
 // ----------------------------------------
 template
 void getrf_nopiv<Target::HostTask, double>(
     Matrix<double>&& A,
     int64_t ib,
-    int priority);
+    int priority,
+    int64_t* info );
 
 // ----------------------------------------
 template
 void getrf_nopiv< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
     int64_t ib,
-    int priority);
+    int priority,
+    int64_t* info );
 
 // ----------------------------------------
 template
 void getrf_nopiv< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
     int64_t ib,
-    int priority);
+    int priority,
+    int64_t* info );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_getrf_tntpiv.cc
+++ b/src/internal/internal_getrf_tntpiv.cc
@@ -6,7 +6,6 @@
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
 #include "slate/types.hh"
-//#include "internal/Tile_getrf.hh"
 #include "internal/Tile_getrf_tntpiv.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
@@ -329,6 +328,9 @@ void getrf_tntpiv_local(
     blas::device_memcpy<device_pivot_int>( &hipiv[0], dipiv, diag_len,
                                    blas::MemcpyKind::Default, *queue);
 
+    // todo: could merge with above memcpy if host_info and dinfo are
+    // made the last entry of hipiv and dipiv; slightly complicated if
+    // device_pivot_int != device_info_int.
     device_info_int host_info;
     blas::device_memcpy<device_info_int>( &host_info, dinfo, 1, *queue );
     *info = host_info;

--- a/src/internal/internal_reduce_info.cc
+++ b/src/internal/internal_reduce_info.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "slate/types.hh"
+#include "internal/internal.hh"
+
+namespace slate {
+namespace internal {
+
+//------------------------------------------------------------------------------
+/// MPI reduce info, used in getrf, hetrf, etc.
+///
+/// @param[in,out] info
+///     On input, status on each rank; 0 means no error.
+///     On output, smallest non-zero info among all MPI ranks,
+///     or zero if info is zero on all MPI ranks.
+///
+/// @param[in] mpi_comm
+///     MPI communicator.
+///
+void reduce_info( int64_t* info, MPI_Comm mpi_comm )
+{
+    // Use int64_max as a sentinel to indicate no error.
+    int64_t send_info = *info;
+    if (send_info == 0)
+        send_info = std::numeric_limits<int64_t>::max();
+
+    slate_mpi_call(
+        MPI_Allreduce( &send_info, info, 1, mpi_type<int64_t>::value, MPI_MIN,
+                       mpi_comm ) );
+
+    if (*info == std::numeric_limits<int64_t>::max())
+        *info = 0;
+}
+
+} // namespace internal
+} // namespace slate


### PR DESCRIPTION
[Depends on #115]

Adds info error handling to LU and Aasen symmetric indefinite factorization and solves. Abbreviated output [outdated]:
```
slate/test> mpirun -np 4 ./tester --matrix rand,identity,one,zero,rand_zerocol0,rand_zerocol1.0,rand_zerocol1,rand_zerocol13,rand_zerocol0.5 --dim 137 --nb 32 --ib 8 getrf
% SLATE version 2023.08.25, id 61d7ba6c
% input: ./tester --matrix rand,identity,one,zero,rand_zerocol0,rand_zerocol1.0,rand_zerocol1,rand_zerocol13,rand_zerocol0.5 --dim 137 --nb 32 --ib 8 getrf
% 2023-09-16 22:00:32, 4 MPI ranks, CPU-only MPI, 4 OpenMP threads per MPI rank
                                                                                                                                                                                                                      
A    m    n  nb  ib  p  q  la  pt     error  status  
1  137  137  32   8  2  2   1   2  5.10e-19  pass    
2  137  137  32   8  2  2   1   2  0.00e+00  pass    
3  137  137  32   8  2  2   1   2  7.25e-03  FAILED  info = 2  
4  137  137  32   8  2  2   1   2       inf  FAILED  info = 1  
5  137  137  32   8  2  2   1   2  6.14e-03  FAILED  info = 1  
6  137  137  32   8  2  2   1   2  6.16e-03  FAILED  info = 137  
7  137  137  32   8  2  2   1   2  6.24e-03  FAILED  info = 2  
8  137  137  32   8  2  2   1   2  6.48e-03  FAILED  info = 14  
9  137  137  32   8  2  2   1   2  6.38e-03  FAILED  info = 69  

% Matrix kinds:
%  1: rand, cond unknown
%  2: identity, cond = 1
%  3: one, cond = inf
%  4: zero, cond = inf
%  5: rand_zerocol0, cond = inf
%  6: rand_zerocol1.0, cond = inf
%  7: rand_zerocol1, cond = inf
%  8: rand_zerocol13, cond = inf
%  9: rand_zerocol0.5, cond = inf

% 7 tests FAILED: getrf
```
Currently, one inconsistency is `zerocolN` takes 0-based index N in [ 0, n-1 ], while returned info is 1-based index in [ 1, n ]. info = 0 is generally considered to mean "no error". For instance, above, rand_zerocol13 has info = 14.

I guess if info != 0, then it should be marked as "pass", since the routine is correctly catching the singularity. Also, the tester should inspect U and verify that U( i, i ) == 0. [Updated]