### PR TITLE
MOSI cleanup

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -1779,7 +1779,7 @@ void BaseMatrix<scalar_t>::tileRecv(
     int64_t i, int64_t j, int src_rank, Layout layout, int tag)
 {
     if (src_rank != mpiRank()) {
-        storage_->tilePrepareToRecieve( globalIndex( i, j ), 1, layout );
+        storage_->tilePrepareToReceive( globalIndex( i, j ), 1, layout );
         tileAcquire(i, j, layout);
 
         // Receive data.
@@ -1915,7 +1915,7 @@ void BaseMatrix<scalar_t>::listBcast(
         if (bcast_set.find(mpi_rank_) != bcast_set.end()) {
 
             // If receiving the tile.
-            storage_->tilePrepareToRecieve( globalIndex( i, j ), life, layout_ );
+            storage_->tilePrepareToReceive( globalIndex( i, j ), life, layout_ );
 
             // Send across MPI ranks.
             // Previous used MPI bcast: tileBcastToSet(i, j, bcast_set);
@@ -2067,7 +2067,7 @@ void BaseMatrix<scalar_t>::listBcastMT(
             // If this rank is in the set.
             if (bcast_set.find(mpi_rank_) != bcast_set.end()) {
                 // If receiving the tile.
-                storage_->tilePrepareToRecieve( globalIndex( i, j ), life, layout_ );
+                storage_->tilePrepareToReceive( globalIndex( i, j ), life, layout_ );
 
                 // Send across MPI ranks.
                 // Previous used MPI bcast: tileBcastToSet(i, j, bcast_set);

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -296,7 +296,7 @@ public:
 
     //--------------------------------------------------------------------------
     /// Returns tile(i, j)'s state on device (defaults to host).
-    /// Asserts if tile does not exist.
+    /// Asserts that the tile exists.
     ///
     /// @param[in] i
     ///     Tile's block row index. 0 <= i < mt.
@@ -314,7 +314,7 @@ public:
 
     //------------------------------------------------------------------------------
     /// Returns whether tile(i, j) is OnHold on device (defaults to host).
-    /// Asserts if tile does not exist.
+    /// Asserts that the tile exists.
     ///
     /// @param[in] i
     ///     Tile's block row index. 0 <= i < mt.
@@ -1621,7 +1621,7 @@ void BaseMatrix<scalar_t>::tileErase(int64_t i, int64_t j, int device)
 
 //------------------------------------------------------------------------------
 /// Erase the tile {i, j}'s instance on device if it is a workspace tile with
-/// no hold is set on it.
+/// no hold set on it.
 /// If tile's memory was allocated by SLATE,
 /// via tileInsert(i, j, dev) or tileInsertWorkspace(i, j, dev),
 /// then the memory is released to the allocator pool.
@@ -2724,7 +2724,7 @@ void BaseMatrix<scalar_t>::tileGet(std::set<ij_tuple>& tile_set, int device,
     if (device != HostNum) {
         LockGuard guard(storage_->getTilesMapLock());
 
-        // find number of aready existing tiles on the device
+        // find number of already existing tiles on the device
         int64_t existing_tiles = 0;
         for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
             int64_t i = std::get<0>(*iter);

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -568,10 +568,12 @@ public:
         storage_->clear();
     }
 
-    /// Clear all workspace tiles that are not on hold or modified.
+    /// Clears all workspace tiles that are not OnHold.
+    /// For local tiles, it ensures that a valid copy remains.
     ///
-    /// Note that Modified, local tiles are currently not released but that this
-    /// behavior may change in the future and should not be relied apon.
+    /// Note that local tiles are currently not released if it would leave all
+    /// remaining tiles invalid, but this behavior may change in the future
+    /// and should not be relied on.
     void releaseWorkspace()
     {
         storage_->releaseWorkspace();
@@ -1584,14 +1586,16 @@ void BaseMatrix<scalar_t>::tileErase(int64_t i, int64_t j, int device)
 }
 
 //------------------------------------------------------------------------------
-/// Erase the tile {i, j}'s instance on device if it is a workspace tile
-/// that is not modified and no hold is set on it.
+/// Erase the tile {i, j}'s instance on device if it is a workspace tile with
+/// no hold is set on it.
 /// If tile's memory was allocated by SLATE,
 /// via tileInsert(i, j, dev) or tileInsertWorkspace(i, j, dev),
 /// then the memory is released to the allocator pool.
+/// For local tiles, it ensures that a valid copy remains.
 ///
-/// Note that Modified, local tiles are currently not released but that this
-/// behavior may change in the future and should not be relied apon.
+/// Note that local tiles are currently not released if it would leave all
+/// remaining tiles invalid, but this behavior may change in the future
+/// and should not be relied on.
 ///
 /// @param[in] i
 ///     Tile's block row index. 0 <= i < mt.

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2551,7 +2551,8 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::tileAcquire(int64_t i, int64_t j, int device,
                                        Layout layout)
 {
-    auto& tile_instance = storage_->tileAcquire(globalIndex(i, j, device), layout);
+    auto& tile_instance = storage_->tileInsert( globalIndex(i, j, device),
+                                                TileKind::Workspace, layout );
     auto tile = tile_instance.tile();
 
     // Change ColMajor <=> RowMajor if needed.
@@ -2656,7 +2657,8 @@ void BaseMatrix<scalar_t>::tileGet(int64_t i, int64_t j, int dst_device,
 
     if (! tile_node.existsOn(dst_device)) {
         // Create a copy on the destination.
-        storage_->tileAcquire(globalIndex(i, j, dst_device), target_layout);
+        storage_->tileInsert( globalIndex(i, j, dst_device),
+                              TileKind::Workspace, target_layout );
     }
 
     if (dst_tile_instance->getState() == MOSI::Invalid) {

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -301,14 +301,6 @@ public:
 
     MOSI tileState( int64_t i, int64_t j, int device=HostNum );
 
-    void tileState(int64_t i, int64_t j, int device, MOSI mosi);
-
-    /// Sets tile(i, j)'s state on host.
-    void tileState(int64_t i, int64_t j, MOSI mosi)
-    {
-        tileState( i, j, HostNum, mosi );
-    }
-
     bool tileOnHold( int64_t i, int64_t j, int device=HostNum );
 
     void tileUnsetHold( int64_t i, int64_t j, int device=HostNum );
@@ -1633,28 +1625,6 @@ MOSI BaseMatrix<scalar_t>::tileState(int64_t i, int64_t j, int device)
     assert(iter != storage_->end());
 
     return iter->second->at(device).getState();
-}
-
-//------------------------------------------------------------------------------
-/// Sets tile(i, j)'s state on device.
-/// Asserts if tile does not exist.
-///
-/// @param[in] i
-///     Tile's block row index. 0 <= i < mt.
-///
-/// @param[in] j
-///     Tile's block column index. 0 <= j < nt.
-///
-/// @param[in] device
-///     Tile's device ID.
-///
-template <typename scalar_t>
-void BaseMatrix<scalar_t>::tileState(int64_t i, int64_t j, int device, MOSI mosi)
-{
-    auto tileIter = storage_->find(globalIndex(i, j, device));
-    assert(tileIter != storage_->end());
-
-    tileIter->second->at(device).setState(mosi);
 }
 
 //------------------------------------------------------------------------------

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3986,15 +3986,8 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::releaseLocalWorkspaceTile(int64_t i, int64_t j)
 {
     if (this->tileIsLocal( i, j )) {
-        auto& tile_node = this->storage_->at( this->globalIndex( i, j ) );
-
-        LockGuard guard( tile_node.getLock() );
-
         for (int device = HostNum; device < this->num_devices(); ++device) {
-            if (tile_node.existsOn( device )
-                && tile_node[ device ].tile()->workspace()) {
-                tileRelease( i, j, device );
-            }
+            tileRelease( i, j, device );
         }
     }
 }

--- a/include/slate/HermitianBandMatrix.hh
+++ b/include/slate/HermitianBandMatrix.hh
@@ -285,19 +285,8 @@ void HermitianBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag, 
         for (int64_t i = istart; i <= iend; ++i) {
 
             // If receiving the tile.
-            if (! this->tileIsLocal(i, j)) {
-                // Create tile to receive data, with life span.
-                // If tile already exists, add to its life span.
-                LockGuard guard(this->storage_->getTilesMapLock()); // todo: accessor
-                auto iter = this->storage_->find( this->globalIndex( i, j, HostNum ) );
-
-                int64_t life = life_factor;
-                if (iter == this->storage_->end())
-                    this->tileInsertWorkspace( i, j, HostNum );
-                else
-                    life += this->tileLife(i, j); // todo: use temp tile to receive
-                this->tileLife(i, j, life);
-            }
+            this->storage_->tilePrepareToRecieve( this->globalIndex( i, j ),
+                                                 life_factor, this->layout_ );
 
             // Send across MPI ranks.
             // Previous used MPI bcast: tileBcastToSet(i, j, rank_set);

--- a/include/slate/HermitianBandMatrix.hh
+++ b/include/slate/HermitianBandMatrix.hh
@@ -285,7 +285,7 @@ void HermitianBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag, 
         for (int64_t i = istart; i <= iend; ++i) {
 
             // If receiving the tile.
-            this->storage_->tilePrepareToRecieve( this->globalIndex( i, j ),
+            this->storage_->tilePrepareToReceive( this->globalIndex( i, j ),
                                                  life_factor, this->layout_ );
 
             // Send across MPI ranks.

--- a/include/slate/TriangularBandMatrix.hh
+++ b/include/slate/TriangularBandMatrix.hh
@@ -299,19 +299,8 @@ void TriangularBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag,
         for (int64_t i = istart; i <= iend; ++i) {
 
             // If receiving the tile.
-            if (! this->tileIsLocal(i, j)) {
-                // Create tile to receive data, with life span.
-                // If tile already exists, add to its life span.
-                LockGuard guard(this->storage_->getTilesMapLock()); // todo: accessor
-                auto iter = this->storage_->find( this->globalIndex( i, j, HostNum ) );
-
-                int64_t life = life_factor;
-                if (iter == this->storage_->end())
-                    this->tileInsertWorkspace( i, j, HostNum );
-                else
-                    life += this->tileLife(i, j); // todo: use temp tile to receive
-                this->tileLife(i, j, life);
-            }
+            this->storage_->tilePrepareToRecieve( this->globalIndex( i, j ),
+                                                 life_factor, this->layout_ );
 
             // Send across MPI ranks.
             // Previous used MPI bcast: tileBcastToSet(i, j, rank_set);

--- a/include/slate/TriangularBandMatrix.hh
+++ b/include/slate/TriangularBandMatrix.hh
@@ -299,7 +299,7 @@ void TriangularBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag,
         for (int64_t i = istart; i <= iend; ++i) {
 
             // If receiving the tile.
-            this->storage_->tilePrepareToRecieve( this->globalIndex( i, j ),
+            this->storage_->tilePrepareToReceive( this->globalIndex( i, j ),
                                                  life_factor, this->layout_ );
 
             // Send across MPI ranks.

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -347,8 +347,8 @@ public:
     void      releaseWorkspaceBuffer(scalar_t* data, int device);
 
 private:
-    // Iterator routines should only be called with in a Tiles Map LockGuard
-    // Otherwise, there may be race conditions with the returned iterator
+    // Iterator routines should be called only within a Tiles Map LockGuard.
+    // Otherwise, there may be race conditions with the returned iterator.
 
     //--------------------------------------------------------------------------
     /// @return TileNode(i, j) if it has instance on device, end() otherwise
@@ -459,7 +459,8 @@ public:
         Layout layout=Layout::ColMajor);
     TileInstance<scalar_t>& tileAcquire(ijdev_tuple ijdev, Layout layout);
 
-    bool tileExists( ijdev_tuple ijdev ) {
+    bool tileExists( ijdev_tuple ijdev )
+    {
         LockGuard guard( getTilesMapLock() );
         int64_t i  = std::get<0>(ijdev);
         int64_t j  = std::get<1>(ijdev);

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -519,7 +519,7 @@ public:
 
     /// Ensures the tile node exists and increments both the tile life and
     /// recieve count
-    void tilePrepareToRecieve(ij_tuple ij, int life, Layout layout)
+    void tilePrepareToReceive(ij_tuple ij, int life, Layout layout)
     {
         if (! tileIsLocal(ij)) {
             // Create tile to receive data, with life span.

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -457,7 +457,6 @@ public:
     TileInstance<scalar_t>& tileInsert(
         ijdev_tuple ijdev, scalar_t* data, int64_t lda,
         Layout layout=Layout::ColMajor);
-    TileInstance<scalar_t>& tileAcquire(ijdev_tuple ijdev, Layout layout);
 
     bool tileExists( ijdev_tuple ijdev )
     {
@@ -1185,21 +1184,6 @@ template <typename scalar_t>
 void MatrixStorage<scalar_t>::releaseWorkspaceBuffer(scalar_t* data, int device)
 {
     memory_.free(data, device);
-}
-
-//------------------------------------------------------------------------------
-/// Acquires tile {i, j} on given device, which can be host,
-/// allocating new memory for it.
-/// TileNode(i, j) is assumed to pre-exist (equivalently the origin tile),
-/// thus, tile kind is set to TileKind::Workspace,
-///
-/// @return Reference to newly inserted TileInstance.
-///
-template <typename scalar_t>
-TileInstance<scalar_t>& MatrixStorage<scalar_t>::tileAcquire(
-    ijdev_tuple ijdev, Layout layout)
-{
-    return tileInsert( ijdev, TileKind::Workspace, layout );
 }
 
 //------------------------------------------------------------------------------

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -199,7 +199,7 @@ void Debug::printTiles_(
                 if (multi && device > HostNum)
                     msg += ' ';
 
-                LockGuard(A.storage_->getTilesMapLock());
+                LockGuard guard(A.storage_->getTilesMapLock());
                 auto iter = A.storage_->find( A.globalIndex( i, j, device ) );
                 if (iter != A.storage_->end()) {
                     auto tile = iter->second->at( device ).tile();

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -199,6 +199,7 @@ void Debug::printTiles_(
                 if (multi && device > HostNum)
                     msg += ' ';
 
+                LockGuard(A.storage_->getTilesMapLock());
                 auto iter = A.storage_->find( A.globalIndex( i, j, device ) );
                 if (iter != A.storage_->end()) {
                     auto tile = iter->second->at( device ).tile();

--- a/unit_test/test_lq.cc
+++ b/unit_test/test_lq.cc
@@ -115,7 +115,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
     // || L1 Q - A1 ||_1 + || L2 Q - A2 ||_1, bound on || L Q - A ||_1.
     for (size_t i = 0; i < A1data.size(); ++i)
         A1data[i] -= A1save[i];
-    for (size_t i = 0; i < A2data.size(); ++i)
+    for (size_t i = 0; i < L2data.size(); ++i)
         L2data[i] -= A2save[i];
     auto err = lapack::lantr( Norm::One, Uplo::Lower,
                               Diag::NonUnit, k, k, A1.data(), A1.stride() )


### PR DESCRIPTION
This PR works to start cleaning up MOSI and the organization of BaseMatrix and MatrixStorage.

* Remove `BaseMatrix::tileState(int64_t i, int64_t j, int device, MOSI mosi)` since it's only purpose appears to be to putting MOSI in an illegal state (3f1afb)
  * 💥 This is a breaking change to the user-accessible API, but if users are calling this function, their code is probably broken anyways
* Fix a tile release bug (43e280)
  * Previously, if origin was invalid and all valid tiles were shared, SLATE would sometimes release the last valid copy of a tile
* Make MatrixStorage iterator private to that class and ensure iterators are always protected by the map lock (0506e3)
* De-duplicate some duplicated logic
  * `BaseMatrix<scalar_t>::releaseLocalWorkspaceTile` checked things that `BaseMatrix::tileRelease` already checks. (704972)
  * All of the `tileGetFor*` routines taking sets of tiles duplicated the same preallocation code (350db3)
  * The logic to inserting a workspace tile & set its life for receiving remote tiles was duplicated in 3 spots (0506e3)