### PR TITLE
Remove TileInstance Class

### DIFF
--- a/include/slate/BaseBandMatrix.hh
+++ b/include/slate/BaseBandMatrix.hh
@@ -305,7 +305,7 @@ void BaseBandMatrix<scalar_t>::tileUpdateAllOrigin()
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < this->num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d]->mosiState() != MOSI::Invalid)
+                                && tile_node[d]->state() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;

--- a/include/slate/BaseBandMatrix.hh
+++ b/include/slate/BaseBandMatrix.hh
@@ -300,12 +300,12 @@ void BaseBandMatrix<scalar_t>::tileUpdateAllOrigin()
 
                 // find on host
                 if (tile_node.existsOn( HostNum )
-                    && tile_node[ HostNum ].tile()->origin()) {
-                    if (tile_node[ HostNum ].stateOn( MOSI::Invalid )) {
+                    && tile_node[ HostNum ]->origin()) {
+                    if (tile_node[ HostNum ]->stateOn( MOSI::Invalid )) {
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < this->num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d].getState() != MOSI::Invalid)
+                                && tile_node[d]->getState() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;
@@ -316,8 +316,8 @@ void BaseBandMatrix<scalar_t>::tileUpdateAllOrigin()
                 else {
                     auto device = this->tileDevice(i, j);
                     if (tile_node.existsOn(device) &&
-                        tile_node[device].tile()->origin()) {
-                        if (tile_node[device].stateOn(MOSI::Invalid)) {
+                        tile_node[device]->origin()) {
+                        if (tile_node[device]->stateOn(MOSI::Invalid)) {
                             // tileGetForReading(i, j, device, LayoutConvert::None);
                             tiles_set_dev[device].insert({i, j});
                         }

--- a/include/slate/BaseBandMatrix.hh
+++ b/include/slate/BaseBandMatrix.hh
@@ -305,7 +305,7 @@ void BaseBandMatrix<scalar_t>::tileUpdateAllOrigin()
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < this->num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d]->getState() != MOSI::Invalid)
+                                && tile_node[d]->mosiState() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -1702,13 +1702,13 @@ void BaseMatrix<scalar_t>::tileModified(int64_t i, int64_t j, int device, bool p
     if (tile->stateOn(MOSI::Modified))
         return;
 
-    tile->setState(MOSI::Modified);
+    tile->mosiState(MOSI::Modified);
 
     for (int d = HostNum; d < num_devices(); ++d) {
         if (d != device && tile_node.existsOn(d)) {
             if (! permissive)
                 slate_assert(tile_node[d]->stateOn(MOSI::Modified) == false);
-            tile_node[d]->setState(MOSI::Invalid);
+            tile_node[d]->mosiState(MOSI::Invalid);
         }
     }
 }
@@ -2622,14 +2622,14 @@ void BaseMatrix<scalar_t>::tileGet(int64_t i, int64_t j, int dst_device,
     LockGuard guard(tile_node.getLock());
 
     if ((! tile_node.existsOn(dst_device)) ||
-        (  tile_node[dst_device]->getState() == MOSI::Invalid)) {
+        (  tile_node[dst_device]->mosiState() == MOSI::Invalid)) {
 
         // find a valid source (Modified/Shared) tile
         for (int d = num_devices()-1; d >= HostNum; --d) {
             // Most current systems have higher GPU->GPU than GPU->CPU
             // TODO Poll hardware topolgy to determine order
             if (d != dst_device && tile_node.existsOn(d)) {
-                if (tile_node[d]->getState() != MOSI::Invalid) {
+                if (tile_node[d]->mosiState() != MOSI::Invalid) {
                     src_device = d;
                     src_tile = tile_node[d];
                     break;
@@ -2657,20 +2657,20 @@ void BaseMatrix<scalar_t>::tileGet(int64_t i, int64_t j, int dst_device,
     }
 
     Tile<scalar_t>* dst_tile = tile_node[dst_device];
-    if (dst_tile->getState() == MOSI::Invalid) {
+    if (dst_tile->mosiState() == MOSI::Invalid) {
         // Update the destination tile's data.
 
         tileCopyDataLayout( src_tile, dst_tile, target_layout, async );
 
-        dst_tile->setState(MOSI::Shared);
+        dst_tile->mosiState(MOSI::Shared);
         if (src_tile->stateOn(MOSI::Modified))
-            src_tile->setState(MOSI::Shared);
+            src_tile->mosiState(MOSI::Shared);
     }
     if (modify) {
         tileModified(i, j, dst_device);
     }
     if (hold) {
-        dst_tile->setState(MOSI::OnHold);
+        dst_tile->mosiState(MOSI::OnHold);
     }
 
     // Change ColMajor <=> RowMajor if needed.
@@ -3199,7 +3199,7 @@ void BaseMatrix<scalar_t>::tileUpdateAllOrigin()
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d]->getState() != MOSI::Invalid)
+                                && tile_node[d]->mosiState() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -519,19 +519,19 @@ public:
     /// Returns Layout of tile(i, j, device)
     Layout tileLayout( int64_t i, int64_t j, int device=HostNum )
     {
-        return storage_->at(globalIndex(i, j, device)).tile()->layout();
+        return storage_->at( globalIndex(i, j, device) )->layout();
     }
 
     /// Sets Layout of tile(i, j, device)
     void tileLayout(int64_t i, int64_t j, int device, Layout layout)
     {
-        storage_->at(globalIndex(i, j, device)).tile()->layout(layout);
+        storage_->at( globalIndex(i, j, device) )->layout(layout);
     }
 
     /// Sets Layout of tile(i, j, host)
     void tileLayout(int64_t i, int64_t j, Layout layout)
     {
-        storage_->at( globalIndex( i, j, HostNum ) ).tile()->layout( layout );
+        storage_->at( globalIndex(i, j, HostNum) )->layout( layout );
     }
 
     bool tileLayoutIsConvertible( int64_t i, int64_t j, int device=HostNum );
@@ -1338,7 +1338,7 @@ template <typename scalar_t>
 Tile<scalar_t> BaseMatrix<scalar_t>::operator()(
     int64_t i, int64_t j, int device)
 {
-    auto tile = *(storage_->at(globalIndex(i, j, device)).tile());
+    auto tile = *(storage_->at( globalIndex(i, j, device) ));
 
     // Set op first, before setting offset, mb, nb!
     tile.op(op_);
@@ -3271,7 +3271,7 @@ void BaseMatrix<scalar_t>::tileUpdateAllOrigin()
 template <typename scalar_t>
 bool BaseMatrix<scalar_t>::tileLayoutIsConvertible(int64_t i, int64_t j, int device)
 {
-    return storage_->at(globalIndex(i, j, device)).tile()->isTransposable();
+    return storage_->at( globalIndex(i, j, device) )->isTransposable();
 }
 
 //------------------------------------------------------------------------------
@@ -3301,8 +3301,9 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::tileLayoutConvert(
     int64_t i, int64_t j, int device, Layout layout, bool reset, bool async)
 {
-    LockGuard guard(storage_->at(globalIndex(i, j, device)).getLock());
-    auto tile = storage_->at(globalIndex(i, j, device)).tile();
+    auto& tile_node = storage_->at( globalIndex(i, j) );
+    LockGuard guard( tile_node.getLock() );
+    auto tile = tile_node[ HostNum ].tile();
     if (tile->layout() != layout) {
         if (! tile->isTransposable()) {
             assert(! reset); // cannot reset if not transposable
@@ -3394,7 +3395,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
             int64_t i = std::get<0>(*iter);
             int64_t j = std::get<1>(*iter);
 
-            auto tile = storage_->at(globalIndex(i, j, device)).tile();
+            auto tile = storage_->at( globalIndex(i, j, device) );
 
             // if we need to convert layout
             if (tile->layout() != layout) {
@@ -3534,7 +3535,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
                 {
                     int64_t i = std::get<0>(*iter);
                     int64_t j = std::get<1>(*iter);
-                    auto tile = storage_->at(globalIndex(i, j, device)).tile();
+                    auto tile = storage_->at( globalIndex(i, j, device) );
                     storage_->tileLayoutReset(tile);
                 }
             }

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -782,12 +782,12 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
 
                 // find on host
                 if (tile_node.existsOn( HostNum )
-                    && tile_node[ HostNum ].tile()->origin()) {
-                    if (tile_node[ HostNum ].stateOn( MOSI::Invalid )) {
+                    && tile_node[ HostNum ]->origin()) {
+                    if (tile_node[ HostNum ]->stateOn( MOSI::Invalid )) {
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < this->num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d].getState() != MOSI::Invalid)
+                                && tile_node[d]->getState() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;
@@ -798,8 +798,8 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
                 else {
                     auto device = this->tileDevice(i, j);
                     if (tile_node.existsOn(device) &&
-                        tile_node[device].tile()->origin()) {
-                        if (tile_node[device].stateOn(MOSI::Invalid)) {
+                        tile_node[device]->origin()) {
+                        if (tile_node[device]->stateOn(MOSI::Invalid)) {
                             // tileGetForReading(i, j, device, LayoutConvert::None);
                             tiles_set_dev[device].insert({i, j});
                         }
@@ -1142,15 +1142,15 @@ void BaseTrapezoidMatrix<scalar_t>::tileLayoutReset()
             if (this->tileIsLocal(i, j)) {
 
                 auto tile = this->tileUpdateOrigin(i, j);
-                if (tile->layout() != this->layout()) {
-                    assert(tile->isTransposable());
+                if (tile.layout() != this->layout()) {
+                    assert(tile.isTransposable());
                 }
 
-                if (tile->device() == HostNum) {
+                if (tile.device() == HostNum) {
                     tiles_set_host.insert({i, j});
                 }
                 else {
-                    tiles_set_dev[tile->device()].insert({i, j});
+                    tiles_set_dev[tile.device()].insert({i, j});
                 }
             }
         }

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -787,7 +787,7 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < this->num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d]->mosiState() != MOSI::Invalid)
+                                && tile_node[d]->state() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -787,7 +787,7 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
                         // tileGetForReading(i, j, LayoutConvert::None);
                         for (int d = 0; d < this->num_devices(); ++d) {
                             if (tile_node.existsOn(d)
-                                && tile_node[d]->getState() != MOSI::Invalid)
+                                && tile_node[d]->mosiState() != MOSI::Invalid)
                             {
                                 tiles_set_host[d].insert({i, j});
                                 break;

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -321,7 +321,7 @@ public:
     /// To check the OnHold flag, use stateOn.
     /// Note that this is the MOSI state from when the tile was accessed and
     /// may not be up to date with the canonical version.
-    MOSI mosiState()
+    MOSI state()
     {
         return MOSI(mosi_state_ & MOSI_State(~MOSI::OnHold));
     }
@@ -381,7 +381,7 @@ protected:
         ext_data_ = data;
     }
 
-    void mosiState(MOSI_State stateIn)
+    void state(MOSI_State stateIn)
     {
         switch (stateIn) {
             case MOSI::Modified:

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -134,9 +134,11 @@ public:
     Tile();
 
     Tile(int64_t mb, int64_t nb,
-         scalar_t* A, int64_t lda, int device, TileKind kind, Layout layout=Layout::ColMajor);
+         scalar_t* A, int64_t lda, int device, TileKind kind,
+         Layout layout=Layout::ColMajor, MOSI_State mosi_state=MOSI::Invalid);
 
-    Tile(Tile<scalar_t> src_tile, scalar_t* A, int64_t lda, TileKind kind);
+    Tile(Tile<scalar_t> src_tile, scalar_t* A, int64_t lda, TileKind kind,
+         MOSI_State mosi_state=MOSI::Invalid);
 
     // defaults okay (tile doesn't own data, doesn't allocate/deallocate data)
     // 1. destructor
@@ -314,14 +316,100 @@ public:
         layoutConvert(nullptr, queue, async);
     }
 
+    /// Returns the MOSI status of the tile.
+    ///
+    /// To check the OnHold flag, use stateOn.
+    /// Note that this is the MOSI state from when the tile was accessed and
+    /// may not be up to date with the canonical version.
+    MOSI mosiState()
+    {
+        return MOSI(mosi_state_ & MOSI_State(~MOSI::OnHold));
+    }
+    // TODO remove this in favor of clearer names
+    MOSI getState()
+    {
+        return mosiState();
+    }
+
+    /// returns whether the Modified/Shared/Invalid state or the OnHold flag is On
+    bool stateOn(MOSI_State stateIn) const
+    {
+        switch (stateIn) {
+            case MOSI::Modified:
+            case MOSI::Shared:
+            case MOSI::Invalid:
+                return (mosi_state_ & ~MOSI::OnHold) == stateIn;
+                break;
+            case MOSI::OnHold:
+                return (mosi_state_ & MOSI::OnHold) == stateIn;
+                break;
+            default:
+                assert(false);  // Unknown state
+                break;
+        }
+        return false;
+    }
+
 protected:
     // BaseMatrix sets mb, nb, offset.
     template <typename T>
     friend class BaseMatrix;
 
+    // MatrixStorage manages the tiles it owns
+    template <typename T>
+    friend class TileNode;
+    template <typename T>
+    friend class MatrixStorage;
+
+
     void mb(int64_t in_mb);
     void nb(int64_t in_nb);
     void offset(int64_t i, int64_t j);
+
+    void kind(TileKind kind)
+    {
+        kind_ = kind;
+    }
+
+    void data(scalar_t* data)
+    {
+        data_ = data;
+    }
+
+    void userData(scalar_t* data)
+    {
+        user_data_ = data;
+    }
+
+    void extData(scalar_t* data)
+    {
+        ext_data_ = data;
+    }
+
+    void mosiState(MOSI_State stateIn)
+    {
+        switch (stateIn) {
+            case MOSI::Modified:
+            case MOSI::Shared:
+            case MOSI::Invalid:
+                mosi_state_ = (mosi_state_ & MOSI::OnHold) | stateIn;
+                break;
+            case MOSI::OnHold:
+                mosi_state_ |= stateIn;
+                break;
+            case ~MOSI::OnHold:
+                mosi_state_ &= stateIn;
+                break;
+            default:
+                assert(false);  // Unknown state
+                break;
+        }
+    }
+    // TODO remove this in favor of clearer names
+    void setState(MOSI_State stateIn)
+    {
+        mosiState(stateIn);
+    }
 
     //--------------------
     // begin/end markup used by generate_matrix.py script; do not modify!
@@ -347,6 +435,7 @@ protected:
     Layout user_layout_; // Temporarily store user-provided-memory's layout
 
     int device_;
+    MOSI_State mosi_state_;
 
     // @end data members
     //--------------------
@@ -368,7 +457,8 @@ Tile<scalar_t>::Tile()
       kind_(TileKind::UserOwned),
       layout_(Layout::ColMajor),
       user_layout_(Layout::ColMajor),
-      device_(HostNum)
+      device_(HostNum),
+      mosi_state_(MOSI::Invalid)
 {}
 
 //------------------------------------------------------------------------------
@@ -407,7 +497,7 @@ Tile<scalar_t>::Tile()
 template <typename scalar_t>
 Tile<scalar_t>::Tile(
     int64_t mb, int64_t nb,
-    scalar_t* A, int64_t lda, int device, TileKind kind, Layout layout)
+    scalar_t* A, int64_t lda, int device, TileKind kind, Layout layout, MOSI_State mosi_state)
     : mb_(mb),
       nb_(nb),
       stride_(lda),
@@ -420,7 +510,8 @@ Tile<scalar_t>::Tile(
       kind_(kind),
       layout_(layout),
       user_layout_(layout),
-      device_(device)
+      device_(device),
+      mosi_state_(mosi_state)
 {
     slate_assert(mb >= 0);
     slate_assert(nb >= 0);
@@ -449,7 +540,7 @@ Tile<scalar_t>::Tile(
 ///
 template <typename scalar_t>
 Tile<scalar_t>::Tile(
-    Tile<scalar_t> src_tile, scalar_t* A, int64_t lda, TileKind kind)
+    Tile<scalar_t> src_tile, scalar_t* A, int64_t lda, TileKind kind, MOSI_State mosi_state)
     : mb_(src_tile.mb_),
       nb_(src_tile.nb_),
       stride_(lda),
@@ -462,7 +553,8 @@ Tile<scalar_t>::Tile(
       kind_(kind),
       layout_(src_tile.layout_),
       user_layout_(src_tile.user_layout_),
-      device_(src_tile.device_)
+      device_(src_tile.device_),
+      mosi_state_(mosi_state)
 {
     slate_assert(A != nullptr);
     slate_assert( (src_tile.layout_ == Layout::ColMajor && lda >= src_tile.mb_)

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -325,11 +325,6 @@ public:
     {
         return MOSI(mosi_state_ & MOSI_State(~MOSI::OnHold));
     }
-    // TODO remove this in favor of clearer names
-    MOSI getState()
-    {
-        return mosiState();
-    }
 
     /// returns whether the Modified/Shared/Invalid state or the OnHold flag is On
     bool stateOn(MOSI_State stateIn) const
@@ -404,11 +399,6 @@ protected:
                 assert(false);  // Unknown state
                 break;
         }
-    }
-    // TODO remove this in favor of clearer names
-    void setState(MOSI_State stateIn)
-    {
-        mosiState(stateIn);
     }
 
     //--------------------

--- a/include/slate/enums.hh
+++ b/include/slate/enums.hh
@@ -135,6 +135,17 @@ const int HostNum = -1;
 const int AllDevices = -2;
 const int AnyDevice  = -3;
 
+//------------------------------------------------------------------------------
+/// A tile state in the MOSI coherency protocol
+enum MOSI {
+    Modified = 0x100,   ///< tile data is modified, other instances should be Invalid, cannot be purged
+    OnHold = 0x1000,  ///< a hold is placed on this tile instance, cannot be purged
+    Shared = 0x010,   ///< tile data is up-to-date, other instances may be Shared, or Invalid, may be purged
+    Invalid = 0x001,   ///< tile data is obsolete, other instances may be Modified, Shared, or Invalid, may be purged
+};
+typedef short MOSI_State;
+
+
 } // namespace slate
 
 #endif // SLATE_ENUMS_HH

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -278,7 +278,8 @@ public:
         int device = std::get<2>(ijdev);
         auto& tile_node = at( {i, j} );
 
-        LockGuard guard(tile_node.getLock());
+        // TODO ideally, this would be accessed with a lock on the tile node,
+        // but that breaks BaseMatrix::tileLayoutConvert(set<ij>, ...)
         return tile_node.at(device);
     }
 

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -89,7 +89,7 @@ public:
     {
         slate_assert(device >= -1 && device+1 < int(tiles_.size()));
         slate_assert(tiles_[device+1] == nullptr);
-        tile->mosiState( MOSI(state) );
+        tile->state( MOSI(state) );
         tiles_[device+1] = tile;
         ++num_instances_;
     }
@@ -109,7 +109,7 @@ public:
     {
         slate_assert(device >= -1 && device+1 < int(tiles_.size()));
         if (tiles_[device+1] != nullptr) {
-            tiles_[device+1]->mosiState(MOSI::Invalid);
+            tiles_[device+1]->state(MOSI::Invalid);
             delete tiles_[device+1];
             tiles_[device+1] = nullptr;
             --num_instances_;
@@ -420,7 +420,7 @@ public:
         assert(iter != end());
 
         int device = std::get<2>(ijdev);
-        return iter->second->at(device)->mosiState();
+        return iter->second->at(device)->state();
     }
 
     /// Checks whether the given tile is on hold
@@ -441,7 +441,7 @@ public:
         auto iter = find( ijdev );
         if (iter != end()) {
             int device = std::get<2>(ijdev);
-            iter->second->at(device)->mosiState(~MOSI::OnHold);
+            iter->second->at(device)->state(~MOSI::OnHold);
         }
     }
 

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -209,7 +209,7 @@ void Debug::printTiles_(
                                 : 'w';
                     }
                     if (do_mosi) {
-                        char ch = to_char( iter->second->at( device )->mosiState() );
+                        char ch = to_char( iter->second->at( device )->state() );
                         if (iter->second->at( device )->stateOn( MOSI::OnHold ))
                             ch = toupper( ch );
                         msg += ch;

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -84,7 +84,7 @@ void Debug::checkTilesLives( BaseMatrix<scalar_t> const& A )
                 for (int d = HostNum; d < A.num_devices(); ++d) {
                     if (iter->second->existsOn(d)) {
                         std::cout << " DEV "  << d
-                                  << " data " << iter->second->at(d).tile()->data() << "\n";
+                                  << " data " << iter->second->at(d)->data() << "\n";
                     }
                 }
             }
@@ -113,8 +113,8 @@ bool Debug::checkTilesLayout( BaseMatrix<scalar_t> const& A )
                 index = A.globalIndex(i, j);
                 tmp_tile = A.storage_->tiles_.find(index);
                 if (tmp_tile != tile_end
-                    && tmp_tile->second->at( HostNum ).valid()
-                    && tmp_tile->second->at( HostNum ).tile()->layout() != A.layout()) {
+                    && tmp_tile->second->at( HostNum ) != nullptr
+                    && tmp_tile->second->at( HostNum )->layout() != A.layout()) {
                     return false;
                 }
             }
@@ -202,15 +202,15 @@ void Debug::printTiles_(
                 LockGuard guard(A.storage_->getTilesMapLock());
                 auto iter = A.storage_->find( A.globalIndex( i, j, device ) );
                 if (iter != A.storage_->end()) {
-                    auto tile = iter->second->at( device ).tile();
+                    auto tile = iter->second->at( device );
                     if (do_kind) {
                         msg += tile->origin()
                                 ? (tile->allocated() ? 'o' : 'u')
                                 : 'w';
                     }
                     if (do_mosi) {
-                        char ch = to_char( iter->second->at( device ).getState() );
-                        if (iter->second->at( device ).stateOn( MOSI::OnHold ))
+                        char ch = to_char( iter->second->at( device )->getState() );
+                        if (iter->second->at( device )->stateOn( MOSI::OnHold ))
                             ch = toupper( ch );
                         msg += ch;
                     }

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -74,7 +74,7 @@ void Debug::checkTilesLives( BaseMatrix<scalar_t> const& A )
 
         if (! A.tileIsLocal(i, j)) {
             if (iter->second->lives() != 0 ||
-                iter->second->numInstances() != 0) {
+                ! iter->second->empty()) {
 
                 std::cout << "RANK "  << std::setw(3) << A.mpi_rank_
                           << " TILE " << std::setw(3) << std::get<0>(iter->first)
@@ -209,7 +209,7 @@ void Debug::printTiles_(
                                 : 'w';
                     }
                     if (do_mosi) {
-                        char ch = to_char( iter->second->at( device )->getState() );
+                        char ch = to_char( iter->second->at( device )->mosiState() );
                         if (iter->second->at( device )->stateOn( MOSI::OnHold ))
                             ch = toupper( ch );
                         msg += ch;

--- a/src/hb2st.cc
+++ b/src/hb2st.cc
@@ -223,17 +223,19 @@ void hb2st(
                     || (ii > jj && ii - (jj + A.tileNb(j) - 1) <= band + 1) ) )
             {
                 if (i == j && j < A.nt()-1) {
-                    auto T_ptr = A.tileInsertWorkspace( i, j+1 );
+                    auto tile = A.tileInsertWorkspace( i, j+1 );
+                    A.tileModified( i, j+1 );
                     lapack::laset(
-                        lapack::MatrixType::General, T_ptr->mb(), T_ptr->nb(),
-                        zero, zero, T_ptr->data(), T_ptr->stride());
+                        lapack::MatrixType::General, tile.mb(), tile.nb(),
+                        zero, zero, tile.data(), tile.stride());
                 }
 
                 if (j > 0 && i == j + 1) {
-                    auto T_ptr = A.tileInsertWorkspace( i, j-1 );
+                    auto tile = A.tileInsertWorkspace( i, j-1 );
+                    A.tileModified( i, j-1 );
                     lapack::laset(
-                        lapack::MatrixType::General, T_ptr->mb(), T_ptr->nb(),
-                        zero, zero, T_ptr->data(), T_ptr->stride());
+                        lapack::MatrixType::General, tile.mb(), tile.nb(),
+                        zero, zero, tile.data(), tile.stride());
                 }
 
                 if (i == j) {

--- a/src/tb2bd.cc
+++ b/src/tb2bd.cc
@@ -265,17 +265,19 @@ void tb2bd(
                  ( ii < jj && (jj - (ii + A.tileMb(i) - 1)) <= (band+1) ) ) )
             {
                 if (i == j && i > 0) {
-                    auto T_ptr = A.tileInsertWorkspace( i, j-1 );
+                    auto tile = A.tileInsertWorkspace( i, j-1 );
+                    A.tileModified( i, j-1 );
                     lapack::laset(
-                        lapack::MatrixType::General, T_ptr->mb(), T_ptr->nb(),
-                        0, 0, T_ptr->data(), T_ptr->stride());
+                        lapack::MatrixType::General, tile.mb(), tile.nb(),
+                        0, 0, tile.data(), tile.stride());
                 }
 
                 if ((j < A.nt()-1) && (i == (j - 1))) {
-                    auto T_ptr = A.tileInsertWorkspace( i, j+1 );
+                    auto tile = A.tileInsertWorkspace( i, j+1 );
+                    A.tileModified( i, j+1 );
                     lapack::laset(
-                        lapack::MatrixType::General, T_ptr->mb(), T_ptr->nb(),
-                        0, 0, T_ptr->data(), T_ptr->stride());
+                        lapack::MatrixType::General, tile.mb(), tile.nb(),
+                        0, 0, tile.data(), tile.stride());
                 }
 
                 if (i == j) {

--- a/unit_test/test_BandMatrix.cc
+++ b/unit_test/test_BandMatrix.cc
@@ -164,13 +164,13 @@ void test_BandMatrix_tileInsert_new()
                 int ib = std::min( nb, m - ii );
                 int jb = std::min( nb, n - jj );
 
-                auto T_ptr = A.tileInsert( i, j, HostNum );
-                test_assert( T_ptr->mb() == ib );
-                test_assert( T_ptr->nb() == jb );
-                test_assert( T_ptr->op() == slate::Op::NoTrans );
-                test_assert( T_ptr->uplo() == slate::Uplo::General );
+                auto tile = A.tileInsert( i, j, HostNum );
+                test_assert( tile.mb() == ib );
+                test_assert( tile.nb() == jb );
+                test_assert( tile.op() == slate::Op::NoTrans );
+                test_assert( tile.uplo() == slate::Uplo::General );
 
-                T_ptr->at(0, 0) = i + j / 10000.;
+                tile.at(0, 0) = i + j / 10000.;
             }
             ii += A.tileMb(i);
         }
@@ -238,16 +238,16 @@ void test_BandMatrix_tileInsert_data()
                 int ib = std::min( nb, m - ii );
                 int jb = std::min( nb, n - jj );
 
-                auto T_ptr = A.tileInsert( i, j, &Ad[ index * nb * nb ], nb );
+                auto tile = A.tileInsert( i, j, &Ad[ index * nb * nb ], nb );
                 index += 1;
 
-                test_assert( T_ptr->mb() == ib );
-                test_assert( T_ptr->nb() == jb );
-                test_assert( T_ptr->stride() == nb );
-                test_assert( T_ptr->op() == slate::Op::NoTrans );
-                test_assert( T_ptr->uplo() == slate::Uplo::General );
+                test_assert( tile.mb() == ib );
+                test_assert( tile.nb() == jb );
+                test_assert( tile.stride() == nb );
+                test_assert( tile.op() == slate::Op::NoTrans );
+                test_assert( tile.uplo() == slate::Uplo::General );
 
-                T_ptr->at(0, 0) = i + j / 10000.;
+                tile.at(0, 0) = i + j / 10000.;
             }
             ii += A.tileMb(i);
         }
@@ -366,21 +366,21 @@ void test_TriangularBandMatrix_gatherAll(slate::Uplo uplo)
                 int ib = std::min( nb, m - ii );
                 int jb = std::min( nb, m - jj );
 
-                auto T_ptr = A.tileInsert( i, j, &Ad[ index * nb * nb ], nb );
+                auto tile = A.tileInsert( i, j, &Ad[ index * nb * nb ], nb );
                 if (i == j)
-                    T_ptr->uplo(uplo);
+                    tile.uplo(uplo);
                 index += 1;
 
-                test_assert( T_ptr->mb() == ib );
-                test_assert( T_ptr->nb() == jb );
-                test_assert( T_ptr->stride() == nb );
-                test_assert( T_ptr->op() == slate::Op::NoTrans );
+                test_assert( tile.mb() == ib );
+                test_assert( tile.nb() == jb );
+                test_assert( tile.stride() == nb );
+                test_assert( tile.op() == slate::Op::NoTrans );
                 if (i == j)
-                    test_assert( T_ptr->uplo() == uplo );
+                    test_assert( tile.uplo() == uplo );
                 else
-                    test_assert( T_ptr->uplo() == slate::Uplo::General );
+                    test_assert( tile.uplo() == slate::Uplo::General );
 
-                T_ptr->set(i + j / 10.);
+                tile.set(i + j / 10.);
             }
             ii += A.tileMb(i);
         }

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -908,13 +908,13 @@ void test_Matrix_tileInsert_new()
             int ib = std::min( mb, m - i*mb );
             int jb = std::min( nb, n - j*nb );
 
-            auto T_ptr = A.tileInsert( i, j, HostNum );
-            test_assert( T_ptr->mb() == ib );
-            test_assert( T_ptr->nb() == jb );
-            test_assert( T_ptr->op() == slate::Op::NoTrans );
-            test_assert( T_ptr->uplo() == slate::Uplo::General );
+            auto tile = A.tileInsert( i, j, HostNum );
+            test_assert( tile.mb() == ib );
+            test_assert( tile.nb() == jb );
+            test_assert( tile.op() == slate::Op::NoTrans );
+            test_assert( tile.uplo() == slate::Uplo::General );
 
-            T_ptr->at(0, 0) = i + j / 10000.;
+            tile.at(0, 0) = i + j / 10000.;
         }
     }
 
@@ -985,14 +985,14 @@ void test_Matrix_tileInsert_data()
                 else
                     Td = A22;
             }
-            auto T_ptr = A.tileInsert( i, j, HostNum, Td, ib );
-            test_assert( T_ptr->data() == Td );
-            test_assert( T_ptr->mb() == ib );
-            test_assert( T_ptr->nb() == jb );
-            test_assert( T_ptr->op() == slate::Op::NoTrans );
-            test_assert( T_ptr->uplo() == slate::Uplo::General );
+            auto tile = A.tileInsert( i, j, HostNum, Td, ib );
+            test_assert( tile.data() == Td );
+            test_assert( tile.mb() == ib );
+            test_assert( tile.nb() == jb );
+            test_assert( tile.op() == slate::Op::NoTrans );
+            test_assert( tile.uplo() == slate::Uplo::General );
 
-            T_ptr->at(0, 0) = i + j / 10000.;
+            tile.at(0, 0) = i + j / 10000.;
         }
     }
 


### PR DESCRIPTION
TileInstance mostly existed to store the MOSI and a pointer to a Tile.  I've removed that class by moving MOSI into the Tile class and storing Tile pointers directly in the TileNode.

💥 To protect the consistency of MOSI, the matrix classes should now never return pointers or references to the canonical copy of a tile, only copies of it.  Because of this, I'm changing any external function that returned a pointer or reference to instead return a copy.  This is a breaking change, but I think it'll be a limited impact.
