### PR TITLE
test matrix generator: zerocol

### DIFF
--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -31,8 +31,8 @@ enum class TestMatrixType {
     randn = int(slate::random::Dist::Normal),
     randb = int(slate::random::Dist::Binary),
     randr = int(slate::random::Dist::BinarySigned),
-    zero,
-    one,
+    zeros,
+    ones,
     identity,
     ij,
     jordan,
@@ -680,8 +680,8 @@ void generate_matrix_usage()
     "\n"
     "%sMatrix%s    |  %sDescription%s\n"
     "----------|-------------\n"
-    "zero      |  all zero\n"
-    "one       |  all one\n"
+    "zeros     |  all zero\n"
+    "ones      |  all one\n"
     "identity  |  ones on diagonal, rest zero\n"
     "ij        |  Aij = i + j / 10^ceil( log10( max( m, n ) ) )\n"
     "jordan    |  ones on diagonal and first subdiagonal, rest zero\n"
@@ -804,8 +804,8 @@ void decode_matrix(
     std::string base = *token_iter;
     ++token_iter;
     type = TestMatrixType::identity;
-    if      (base == "zero"    ) { type = TestMatrixType::zero;     }
-    else if (base == "one"     ) { type = TestMatrixType::one;      }
+    if      (base == "zeros"   ) { type = TestMatrixType::zeros;    }
+    else if (base == "ones"    ) { type = TestMatrixType::ones;     }
     else if (base == "identity") { type = TestMatrixType::identity; }
     else if (base == "ij"      ) { type = TestMatrixType::ij;       }
     else if (base == "jordan"  ) { type = TestMatrixType::jordan;   }
@@ -976,15 +976,14 @@ void decode_matrix(
     }
 
     // Check if cond is known or unused.
-    if (type == TestMatrixType::zero || type == TestMatrixType::one) {
+    if (type == TestMatrixType::zeros
+        || type == TestMatrixType::ones
+        || zero_col >= 0) {
         cond = inf;
     }
     else if (type == TestMatrixType::identity
              || type == TestMatrixType::orthog) {
         cond = 1;
-    }
-    else if (zero_col >= 0) {
-        cond = inf;
     }
     else if (type != TestMatrixType::svd
              && type != TestMatrixType::heev
@@ -1101,8 +1100,8 @@ int64_t configure_seed(MPI_Comm comm, int64_t user_seed)
 ///
 /// Matrix   | Description
 /// ---------|------------
-/// zero     | all zero
-/// one      | all one
+/// zeros    | all zero
+/// ones     | all one
 /// identity | ones on diagonal, rest zero
 /// jordan   | ones on diagonal and first subdiagonal, rest zero
 /// chebspec | Nonsingular Chebyshev spectral differential matrix
@@ -1222,13 +1221,13 @@ void generate_matrix(
 
     // ----- generate matrix
     switch (type) {
-        case TestMatrixType::zero:
+        case TestMatrixType::zeros:
             set(zero, zero, A);
             lapack::laset( lapack::MatrixType::General, Sigma.size(), 1,
                 d_zero, d_zero, Sigma.data(), Sigma.size() );
             break;
 
-        case TestMatrixType::one:
+        case TestMatrixType::ones:
             set(one, one, A);
             lapack::laset( lapack::MatrixType::General, Sigma.size(), 1,
                 d_zero, d_one, Sigma.data(), Sigma.size() );
@@ -1815,13 +1814,13 @@ void generate_matrix(
     int64_t mt = A.mt();
     // ----- generate matrix
     switch (type) {
-        case TestMatrixType::zero:
+        case TestMatrixType::zeros:
             set(zero, zero, A);
             lapack::laset( lapack::MatrixType::General, Sigma.size(), 1,
                 d_zero, d_zero, Sigma.data(), Sigma.size() );
             break;
 
-        case TestMatrixType::one:
+        case TestMatrixType::ones:
             set(one, one, A);
             lapack::laset( lapack::MatrixType::General, Sigma.size(), 1,
                 d_zero, d_one, Sigma.data(), Sigma.size() );

--- a/test/matrix_generator.cc
+++ b/test/matrix_generator.cc
@@ -780,7 +780,7 @@ void decode_matrix(
     std::string kind = params.kind();
 
     //---------------
-    cond = params.cond();
+    cond = params.cond_request();
     bool cond_default = std::isnan( cond );
     if (cond_default) {
         cond = 1 / sqrt( eps );
@@ -994,7 +994,7 @@ void decode_matrix(
         // cond unused
         cond = testsweeper::no_data_flag;
     }
-    params.cond_used() = cond;
+    params.cond_actual() = cond;
 
     // Warn if user set condD and matrix type doesn't use it.
     if (! condD_default

--- a/test/matrix_params.cc
+++ b/test/matrix_params.cc
@@ -10,6 +10,11 @@
 
 using llong = long long;
 using testsweeper::ParamType;
+using testsweeper::no_data_flag;
+
+const ParamType List   = ParamType::List;
+const ParamType Value  = ParamType::Value;
+const ParamType Output = ParamType::Output;
 
 const double inf = std::numeric_limits<double>::infinity();
 
@@ -20,13 +25,21 @@ std::map< std::string, int > matrix_labels;
 MatrixParams::MatrixParams():
     verbose( 0 ),
 
-    //          name,    w, p, type,            default,                 min, max,  help
-    kind      ("matrix", 0,    ParamType::List, "rand",                             "test matrix kind; see 'test --help-matrix'" ),
-    cond      ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix condition number" ),
-    cond_used ("cond",   0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "actual condition number used" ),
-    condD     ("condD",  0, 1, ParamType::List, testsweeper::no_data_flag, 0,  inf,  "matrix D condition number" ),
-    seed      ("seed",   0,    ParamType::List, -1,                        -1, std::numeric_limits<int64_t>::max(), "Randomization seed (-1 randomizes the seed for each matrix)"),
-    label     ("A",      2,    ParamType::Output, 0,                       0,  INT_MAX, "index labeling matrix" ),
+    //          name,     w, p, type,   default,      min, max,  help
+    kind(       "matrix", 0,    List,   "rand",
+                "test matrix kind; see 'test --help-matrix'" ),
+    cond_request(
+                "cond",   0, 1, List,   no_data_flag,   0, inf,
+                "requested matrix condition number" ),
+    cond_actual(
+                "cond",   0, 1, Value,  no_data_flag,   0, inf,
+                "actual condition number used" ),
+    condD(      "condD",  0, 1, List,   no_data_flag,   0, inf,
+                "matrix D condition number" ),
+    seed(       "seed",   0,    List,   -1,            -1, INT64_MAX,
+                "Randomization seed (-1 randomizes the seed for each matrix)"),
+    label(      "A",      2,    Output, 0,              0, INT_MAX,
+                "index labeling matrix" ),
 
     marked_( false )
 {
@@ -39,7 +52,7 @@ void MatrixParams::mark()
     marked_ = true;
 
     kind();
-    cond();
+    cond_request();
     condD();
     seed();
     label();
@@ -57,15 +70,15 @@ void MatrixParams::generate_label()
 
     // Add cond.
     lbl += ", cond ";
-    if (std::isnan( cond_used() )) {
+    if (std::isnan( cond_actual() )) {
         lbl += "unknown";
     }
     else {
-        snprintf( buf, sizeof(buf), "= %.5g", cond_used() );
+        snprintf( buf, sizeof(buf), "= %.5g", cond_actual() );
         lbl += buf;
     }
-    if (! std::isnan( cond() )
-            && (cond() != cond_used() || std::isnan( cond_used() ))) {
+    if (! std::isnan( cond_request() )
+            && (cond_request() != cond_actual() || std::isnan( cond_actual() ))) {
         lbl += " (ignoring --cond)";
     }
 
@@ -74,7 +87,7 @@ void MatrixParams::generate_label()
         snprintf( buf, sizeof(buf), ", cond(D) = %.5g", condD() );
         lbl += buf;
     }
-    // todo: warn if condD is set but not used. Add condD_used like cond_used.
+    // todo: warn if condD is set but not used. Add condD_actual like cond_actual.
 
     // Get label index from matrix_labels, or add to matrix_labels.
     if (matrix_labels.count( lbl ) == 1) {  // map::contains is c++20

--- a/test/matrix_params.hh
+++ b/test/matrix_params.hh
@@ -32,7 +32,7 @@ public:
 
     // ---- test matrix generation parameters
     testsweeper::ParamString kind;
-    testsweeper::ParamScientific cond, cond_used;
+    testsweeper::ParamScientific cond_request, cond_actual;
     testsweeper::ParamScientific condD;
     testsweeper::ParamInt seed;
     testsweeper::ParamInt label;
@@ -50,8 +50,8 @@ public:
     {
         verbose     = y.verbose;
         kind()      = y.kind();
-        cond()      = y.cond();
-        cond_used() = y.cond_used();
+        cond_request() = y.cond_request();
+        cond_actual()  = y.cond_actual();
         condD()     = y.condD();
         seed()      = y.seed();
         return *this;
@@ -72,9 +72,9 @@ inline bool same( double a, double b )
 inline bool operator == ( MatrixParams const& x, MatrixParams const& y )
 {
     return x.kind() == y.kind()
-           && same( x.cond(),      y.cond()      )
-           && same( x.cond_used(), y.cond_used() )
-           && same( x.condD(),     y.condD()     );
+           && same( x.cond_request(), y.cond_request() )
+           && same( x.cond_actual(),  y.cond_actual() )
+           && same( x.condD(),        y.condD() );
 }
 
 //------------------------------------------------------------------------------

--- a/test/test.cc
+++ b/test/test.cc
@@ -455,14 +455,14 @@ Params::Params():
 
     // change names of matrix B's params
     matrixB.kind.name( "matrixB" );
-    matrixB.cond.name( "condB" );
+    matrixB.cond_request.name( "condB" );
     matrixB.condD.name( "condD_B" );
     matrixB.seed.name( "seedB" );
     matrixB.label.name( "B" );
 
     // change names of matrix C's params
     matrixC.kind.name( "matrixC" );
-    matrixC.cond.name( "condC" );
+    matrixC.cond_request.name( "condC" );
     matrixC.condD.name( "condD_C" );
     matrixC.seed.name( "seedC" );
     matrixC.label.name( "C" );


### PR DESCRIPTION
Adds `_zerocolN` for integer N in [ 0, n-1 ], and `_zerocolR` for fraction R in [ 0.0, 1.0 ], as modifier in the test matrix generator. Sets column N or R*n to zero, making a singular matrix.

Reorganize the tokenizer and throw better error messages, which the test main catches and will print on rank 0, instead of generate_matrix printing messages on all ranks).

Rename zero => zeros, one => ones, which is more descriptive and consistent with Matlab, Numpy, etc.