### PR TITLE
Removed tile-life from add routine

### DIFF
--- a/src/add.cc
+++ b/src/add.cc
@@ -25,21 +25,33 @@ void add(
     scalar_t beta,  Matrix<scalar_t>& B,
     Options const& opts )
 {
+    // Constants
+    const int priority_0 = 0;
+    const int queue_0 = 0;
+
     if (target == Target::Devices) {
         B.allocateBatchArrays();
         B.reserveDeviceWorkspace();
     }
 
+    Options opts2 = Options( opts );
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
+
+    bool hold_local_workspace = get_option<bool>(
+            opts2, Option::HoldLocalWorkspace, 0 );
+
     #pragma omp parallel
     #pragma omp master
     {
         internal::add<target>(alpha, std::move(A),
-                                beta, std::move(B));
+                                beta, std::move(B), priority_0, queue_0, opts2);
         #pragma omp taskwait
         B.tileUpdateAllOrigin();
     }
 
-    B.releaseWorkspace();
+    if (hold_local_workspace == false) {
+        B.releaseWorkspace();
+    }
 }
 
 } // namespace impl
@@ -155,21 +167,32 @@ void add(
     scalar_t beta,  BaseTrapezoidMatrix<scalar_t>& B,
     Options const& opts )
 {
+    // Constants
+    const int priority_0 = 0;
+    const int queue_0 = 0;
     if (target == Target::Devices) {
         B.allocateBatchArrays();
         B.reserveDeviceWorkspace();
     }
 
+    Options opts2 = Options( opts );
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
+
+    bool hold_local_workspace = get_option<bool>(
+            opts2, Option::HoldLocalWorkspace, 0 );
+
     #pragma omp parallel
     #pragma omp master
     {
         internal::add<target>(alpha, std::move(A),
-                              beta, std::move(B));
+                              beta, std::move(B), priority_0, queue_0, opts2);
         #pragma omp taskwait
         B.tileUpdateAllOrigin();
     }
 
-    B.releaseWorkspace();
+    if (hold_local_workspace == false) {
+        B.releaseWorkspace();
+    }
 }
 
 } // namespace impl

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -394,12 +394,14 @@ void permuteRowsCols(
 template <Target target=Target::HostTask, typename scalar_t>
 void add(scalar_t alpha, Matrix<scalar_t>&& A,
          scalar_t beta,  Matrix<scalar_t>&& B,
-         int priority=0, int queue_index=0);
+         int priority=0, int queue_index=0,
+         Options const& opts = Options());
 
 template <Target target=Target::HostTask, typename scalar_t>
 void add(scalar_t alpha, BaseTrapezoidMatrix<scalar_t>&& A,
          scalar_t beta,  BaseTrapezoidMatrix<scalar_t>&& B,
-         int priority=0, int queue_index=0);
+         int priority=0, int queue_index=0,
+         Options const& opts = Options());
 
 //------------------------------------------------------------------------------
 // Bidiagonal band reduction

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -388,10 +388,10 @@ void add(internal::TargetType<Target::Devices>,
 
             queue->sync();
 
-            for (int64_t i = 0; i < B.mt(); ++i) {
-                for (int64_t j = 0; j < B.nt(); ++j) {
-                    if (B.tileIsLocal(i, j) && device == B.tileDevice(i, j)) {
-                        if (call_tile_tick) {
+            if (call_tile_tick) {
+                for (int64_t i = 0; i < B.mt(); ++i) {
+                    for (int64_t j = 0; j < B.nt(); ++j) {
+                        if (B.tileIsLocal(i, j) && device == B.tileDevice(i, j)) {
                             // erase tmp local and remote device tiles;
                             A.tileRelease(i, j, device);
                             // decrement life for remote tiles

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -185,12 +185,12 @@ namespace internal {
 template <Target target, typename scalar_t>
 void add(scalar_t alpha, Matrix<scalar_t>&& A,
          scalar_t beta, Matrix<scalar_t>&& B,
-         int priority, int queue_index)
+         int priority, int queue_index, Options const& opts)
 {
     add(internal::TargetType<target>(),
         alpha, A,
         beta,  B,
-        priority, queue_index);
+        priority, queue_index, opts);
 }
 
 //------------------------------------------------------------------------------
@@ -205,7 +205,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostTask>,
            scalar_t alpha, Matrix<scalar_t>& A,
            scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index)
+           int priority, int queue_index, Options const& opts)
 {
     // trace::Block trace_block("add");
 
@@ -214,20 +214,29 @@ void add(internal::TargetType<Target::HostTask>,
     assert(A_mt == B.mt());
     assert(A_nt == B.nt());
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     #pragma omp taskgroup
     for (int64_t i = 0; i < A_mt; ++i) {
         for (int64_t j = 0; j < A_nt; ++j) {
             if (B.tileIsLocal(i, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate(i, j, alpha, beta)  priority(priority)
+                    firstprivate(i, j, alpha, beta, call_tile_tick)  priority(priority)
                 {
                     A.tileGetForReading(i, j, LayoutConvert::None);
                     B.tileGetForWriting(i, j, LayoutConvert::None);
                     tile::add(
                         alpha, A(i, j),
                         beta,  B(i, j) );
-                    A.tileTick(i, j);
+
+                    if (call_tile_tick) {
+                        A.tileTick(i, j);
+                    }
                 }
             }
         }
@@ -240,7 +249,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostNest>,
            scalar_t alpha, Matrix<scalar_t>& A,
            scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index)
+           int priority, int queue_index, Options const& opts)
 {
     slate_not_implemented("Target::HostNest isn't yet supported.");
 }
@@ -251,7 +260,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostBatch>,
            scalar_t alpha, Matrix<scalar_t>& A,
            scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index)
+           int priority, int queue_index, Options const& opts)
 {
     slate_not_implemented("Target::HostBatch isn't yet supported.");
 }
@@ -268,9 +277,15 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::Devices>,
            scalar_t alpha, Matrix<scalar_t>& A,
            scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index)
+           int priority, int queue_index, Options const& opts)
 {
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     // Define index ranges for regions of matrix.
     // Tiles in each region are all the same size.
@@ -376,10 +391,12 @@ void add(internal::TargetType<Target::Devices>,
             for (int64_t i = 0; i < B.mt(); ++i) {
                 for (int64_t j = 0; j < B.nt(); ++j) {
                     if (B.tileIsLocal(i, j) && device == B.tileDevice(i, j)) {
-                        // erase tmp local and remote device tiles;
-                        A.tileRelease(i, j, device);
-                        // decrement life for remote tiles
-                        A.tileTick(i, j);
+                        if (call_tile_tick) {
+                            // erase tmp local and remote device tiles;
+                            A.tileRelease(i, j, device);
+                            // decrement life for remote tiles
+                            A.tileTick(i, j);
+                        }
                     }
                 }
             }
@@ -395,100 +412,100 @@ template
 void add<Target::HostTask, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add<Target::HostNest, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add<Target::HostBatch, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add<Target::Devices, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 // ----------------------------------------
 template
 void add<Target::HostTask, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add<Target::HostNest, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add<Target::HostBatch, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add<Target::Devices, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 // ----------------------------------------
 template
 void add< Target::HostTask, std::complex<float> >(
      std::complex<float> alpha, Matrix< std::complex<float> >&& A,
      std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add< Target::HostNest, std::complex<float> >(
      std::complex<float> alpha, Matrix< std::complex<float> >&& A,
      std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add< Target::HostBatch, std::complex<float> >(
      std::complex<float> alpha, Matrix< std::complex<float> >&& A,
      std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
     std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index, Options const& opts);
 
 // ----------------------------------------
 template
 void add< Target::HostTask, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add< Target::HostNest, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add< Target::HostBatch, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 template
 void add< Target::Devices, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index);
+     int priority, int queue_index, Options const& opts);
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_tzadd.cc
+++ b/src/internal/internal_tzadd.cc
@@ -146,7 +146,7 @@ void add(internal::TargetType<Target::HostTask>,
                 if (B.tileIsLocal(i, j)) {
                     #pragma omp task slate_omp_default_none \
                         shared( A, B ) \
-                        firstprivate(i, j, alpha, beta) priority(priority)
+                        firstprivate(i, j, alpha, beta, call_tile_tick) priority(priority)
                     {
                         A.tileGetForReading(i, j, LayoutConvert::None);
                         B.tileGetForWriting(i, j, LayoutConvert::None);
@@ -167,7 +167,7 @@ void add(internal::TargetType<Target::HostTask>,
                 if (A.tileIsLocal(i, j)) {
                     #pragma omp task slate_omp_default_none \
                         shared( A, B ) \
-                        firstprivate(i, j, alpha, beta) priority(priority)
+                        firstprivate(i, j, alpha, beta, call_tile_tick) priority(priority)
                     {
                         A.tileGetForReading(i, j, LayoutConvert::None);
                         B.tileGetForWriting(i, j, LayoutConvert::None);


### PR DESCRIPTION
Removed tile life in add. The following results before and after these changes show that the performance does not change.

```
// results for few matrices sizes before changes
type  origin  target   A       m       n      alpha       beta    nb    p    q      error   time (s)  ref time (s)  status
   d    host    task   1   75000   75000   3.1+1.4i   2.7+1.7i   192   12    8   0.00e+00     0.0325         0.332  pass
   d    host    task   1  250000  250000   3.1+1.4i   2.7+1.7i   192   12    8   0.00e+00      0.363         4.887  pass
   d    host    task   1  450000  450000   3.1+1.4i   2.7+1.7i   192   12    8   0.00e+00      1.187        14.708  pass   
   d    host     dev   1  256000  256000   3.1+1.4i   2.7+1.7i   640    8    4   0.00e+00      2.572        13.046  pass   

// results for few matrices sizes after these changes
type  origin  target   A       m       n      alpha       beta    nb    p    q      error   time (s)  ref time (s)  status
   d    host    task   1   75000   75000   3.1+1.4i   2.7+1.7i   192   12    8   0.00e+00     0.0326         0.332  pass
   d    host    task   1  250000  250000   3.1+1.4i   2.7+1.7i   192   12    8   0.00e+00      0.363         4.907  pass 
   d    host    task   1  450000  450000   3.1+1.4i   2.7+1.7i   192   12    8   0.00e+00      1.189        14.611  pass     
   d    host     dev   1  256000  256000   3.1+1.4i   2.7+1.7i   640    8    4   0.00e+00      2.754        13.038  pass
```