### PR TITLE
Remove tile life from geqrf, gelqf, unmqr, unmlq

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2543,7 +2543,6 @@ void BaseMatrix<scalar_t>::tileAcquire(int64_t i, int64_t j, int device,
             storage_->tileMakeTransposable(tile);
         }
         tile->setLayout( layout );
-        // tileLayoutConvert(i, j, device, Layout(layout), false);
     }
 }
 

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -78,7 +78,6 @@ void gelqf(
     opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
 
     // Constants
-    const int life_1 = 1;
     const int priority_0 = 0;
     const int priority_1 = 1;
     // Assumes column major
@@ -264,9 +263,7 @@ void gelqf(
                             // send A(k, j) down col A(k+1:mt-1, j)
                             bcast_list_V.push_back({k, j, {A.sub(k+1, A_mt-1, j, j)}});
                         }
-                        const int tag_0 = 0;
-                        A.template listBcast<target>(
-                            bcast_list_V, layout, tag_0, life_1 );
+                        A.template listBcast<target>( bcast_list_V, layout );
                     }
 
                     // bcast Tlocal down col for trailing matrix update
@@ -275,10 +272,7 @@ void gelqf(
                         for (int64_t col : first_indices) {
                             bcast_list_T.push_back({k, col, {Tlocal.sub(k+1, A_mt-1, col, col)}});
                         }
-                        int tag_k = k;
-                        Tlocal.template listBcast<target>(
-                            bcast_list_T, layout,
-                            tag_k, life_1 );
+                        Tlocal.template listBcast<target>( bcast_list_T, layout );
                     }
 
                     // bcast Treduce down col for trailing matrix update

--- a/src/gels.cc
+++ b/src/gels.cc
@@ -93,7 +93,7 @@ void gels(
     Matrix<scalar_t>& BX,
     Options const& opts)
 {
-    Method method = get_option( opts, Option::MethodGels, MethodGels::Cholqr );
+    Method method = get_option( opts, Option::MethodGels, MethodGels::Auto );
 
     if (method == MethodGels::Auto)
         method = MethodGels::select_algo( A, BX, opts );

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -317,18 +317,22 @@ void geqrf(
                 }
 
                 for (int64_t i : first_indices) {
-                    if (Tlocal.tileIsLocal(i, k)) {
-                        Tlocal.tileUpdateOrigin(i, k);
-
-                        Tlocal.releaseLocalWorkspaceTile(i, k);
+                    if (Tlocal.tileIsLocal( i, k )) {
+                        // Tlocal and Treduce have the have process distribution
+                        Tlocal.tileUpdateOrigin( i, k );
+                        Tlocal.releaseLocalWorkspaceTile( i, k );
+                        if (i != k) {
+                            // i == k is the root of the reduction tree
+                            // Treduce( k, k ) isn't allocated
+                            Treduce.tileUpdateOrigin( i, k );
+                            Treduce.releaseLocalWorkspaceTile( i, k );
+                        }
                     }
                     else {
-                        Tlocal.releaseRemoteWorkspaceTile(i, k);
+                        Tlocal.releaseRemoteWorkspaceTile( i, k );
+                        Treduce.releaseRemoteWorkspaceTile( i, k );
                     }
                 }
-
-                Tr_panel.releaseLocalWorkspace();
-                Tr_panel.releaseRemoteWorkspace();
             }
         }
 

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -78,7 +78,6 @@ void geqrf(
 
 
     // Constants
-    const int life_1 = 1;
     const int priority_0 = 0;
     const int priority_1 = 1;
     // Assumes column major
@@ -219,9 +218,7 @@ void geqrf(
                             // send A(i, k) across row A(i, k+1:nt-1)
                             bcast_list_V.push_back({i, k, {A.sub(i, i, k+1, A_nt-1)}});
                         }
-                        const int tag_0  = 0;
-                        A.template listBcast<target>(
-                            bcast_list_V, layout, tag_0, life_1 );
+                        A.template listBcast<target>( bcast_list_V, layout );
                     }
 
                     // bcast Tlocal across row for trailing matrix update
@@ -230,10 +227,7 @@ void geqrf(
                         for (int64_t row : first_indices) {
                             bcast_list_T.push_back({row, k, {Tlocal.sub(row, row, k+1, A_nt-1)}});
                         }
-                        int tag_k = k;
-                        Tlocal.template listBcast<target>(
-                            bcast_list_T, layout,
-                            tag_k, life_1 );
+                        Tlocal.template listBcast<target>( bcast_list_T, layout );
                     }
 
                     // bcast Treduce across row for trailing matrix update

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -112,7 +112,8 @@ template <Target target=Target::HostTask,
           typename src_scalar_t, typename dst_scalar_t>
 void copy(Matrix<src_scalar_t>&& A,
           Matrix<dst_scalar_t>&& B,
-          int priority=0, int queue_index=0);
+          int priority=0, int queue_index=0,
+          Options const& opts = Options());
 
 template <Target target=Target::HostTask,
           typename src_scalar_t, typename dst_scalar_t>
@@ -343,7 +344,8 @@ template <Target target=Target::HostTask, typename scalar_t>
 void trmm(Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
-          int priority=0, int64_t queue_index=0);
+          int priority=0, int64_t queue_index=0,
+          Options const& opts = Options());
 
 //-----------------------------------------
 // trsm()
@@ -581,7 +583,8 @@ void ttmqr(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag=0);
+           int tag=0,
+           Options const& opts = Options());
 
 // ttmlq()
 template <Target target=Target::HostTask, typename scalar_t>
@@ -589,7 +592,8 @@ void ttmlq(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag=0);
+           int tag=0,
+           Options const& opts = Options());
 
 // hettmqr()
 template <Target target=Target::HostTask, typename scalar_t>

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -569,12 +569,14 @@ void he2hb_her2k_offdiag_ranks(
 // ttqrt()
 template <Target target=Target::HostTask, typename scalar_t>
 void ttqrt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T);
+           Matrix<scalar_t>&& T,
+           Options const& opts = Options());
 
 // ttlqt()
 template <Target target=Target::HostTask, typename scalar_t>
 void ttlqt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T);
+           Matrix<scalar_t>&& T,
+           Options const& opts = Options());
 
 //-----------------------------------------
 // ttmqr()

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -611,7 +611,8 @@ void unmqr(Side side, Op op,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
            Matrix<scalar_t>&& W,
-           int priority=0, int64_t queue_index=0);
+           int priority=0, int64_t queue_index=0,
+           Options const& opts = Options());
 
 // unmlq()
 template <Target target=Target::HostTask, typename scalar_t>
@@ -619,7 +620,9 @@ void unmlq(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           Matrix<scalar_t>&& W);
+           Matrix<scalar_t>&& W,
+           int priority=0, int64_t queue_index=0,
+           Options const& opts = Options());
 
 //-----------------------------------------
 // unmtr_hb2st()

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -64,7 +64,7 @@ void add(internal::TargetType<Target::HostTask>,
             if (B.tileIsLocal(i, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate(i, j, alpha, beta, call_tile_tick)  priority(priority)
+                    firstprivate( i, j, alpha, beta, call_tile_tick )  priority(priority)
                 {
                     A.tileGetForReading(i, j, LayoutConvert::None);
                     B.tileGetForWriting(i, j, LayoutConvert::None);
@@ -143,7 +143,8 @@ void add(internal::TargetType<Target::Devices>,
     #pragma omp taskgroup
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task shared(A, B) \
-            firstprivate(device, irange, jrange, queue_index, beta, alpha) priority(priority)
+            firstprivate( device, irange, jrange, queue_index, beta, alpha, call_tile_tick) \
+            priority(priority)
         {
             // temporarily, convert both into same layout
             // todo: this is in-efficient, because both matrices may have same layout already

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -41,9 +41,9 @@ void add(scalar_t alpha, Matrix<scalar_t>&& A,
 /// todo: this function should just be named "add".
 template <typename scalar_t>
 void add(internal::TargetType<Target::HostTask>,
-           scalar_t alpha, Matrix<scalar_t>& A,
-           scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+         scalar_t alpha, Matrix<scalar_t>& A,
+         scalar_t beta, Matrix<scalar_t>& B,
+         int priority, int queue_index, Options const& opts)
 {
     // trace::Block trace_block("add");
 
@@ -85,9 +85,9 @@ void add(internal::TargetType<Target::HostTask>,
 /// todo: this function should just be named "add".
 template <typename scalar_t>
 void add(internal::TargetType<Target::HostNest>,
-           scalar_t alpha, Matrix<scalar_t>& A,
-           scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+         scalar_t alpha, Matrix<scalar_t>& A,
+         scalar_t beta, Matrix<scalar_t>& B,
+         int priority, int queue_index, Options const& opts)
 {
     slate_not_implemented("Target::HostNest isn't yet supported.");
 }
@@ -96,9 +96,9 @@ void add(internal::TargetType<Target::HostNest>,
 /// todo: this function should just be named "add".
 template <typename scalar_t>
 void add(internal::TargetType<Target::HostBatch>,
-           scalar_t alpha, Matrix<scalar_t>& A,
-           scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+         scalar_t alpha, Matrix<scalar_t>& A,
+         scalar_t beta, Matrix<scalar_t>& B,
+         int priority, int queue_index, Options const& opts)
 {
     slate_not_implemented("Target::HostBatch isn't yet supported.");
 }
@@ -113,9 +113,9 @@ void add(internal::TargetType<Target::HostBatch>,
 /// todo: this function should just be named "add".
 template <typename scalar_t>
 void add(internal::TargetType<Target::Devices>,
-           scalar_t alpha, Matrix<scalar_t>& A,
-           scalar_t beta, Matrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+         scalar_t alpha, Matrix<scalar_t>& A,
+         scalar_t beta, Matrix<scalar_t>& B,
+         int priority, int queue_index, Options const& opts)
 {
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
 

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -90,8 +90,8 @@ void copy(internal::TargetType<Target::HostTask>,
                     A.tileGetForReading(i, j, LayoutConvert::None);
                     // tileAcquire() to avoid un-needed copy
                     B.tileAcquire(i, j, A.tileLayout(i, j));
-                    tile::gecopy( A(i, j), B(i, j) );
                     B.tileModified(i, j, HostNum, true);
+                    tile::gecopy( A(i, j), B(i, j) );
                     if (call_tile_tick) {
                         A.tileTick(i, j);
                     }

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -84,7 +84,7 @@ void copy(internal::TargetType<Target::HostTask>,
         for (int64_t j = 0; j < A_nt; ++j) {
             if (B.tileIsLocal(i, j)) {
                 #pragma omp task slate_omp_default_none \
-                    shared( A, B ) firstprivate( i, j, HostNum ) \
+                    shared( A, B ) firstprivate( i, j, HostNum, call_tile_tick ) \
                     priority(priority)
                 {
                     A.tileGetForReading(i, j, LayoutConvert::None);
@@ -164,7 +164,8 @@ void copy(internal::TargetType<Target::Devices>,
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B ) \
-            firstprivate(device, irange, jrange, queue_index) priority(priority)
+            firstprivate( device, irange, jrange, queue_index, call_tile_tick ) \
+            priority(priority)
         {
             std::set<ij_tuple> A_tiles_set;
             for (int64_t i = 0; i < B.mt(); ++i) {

--- a/src/internal/internal_trmm.cc
+++ b/src/internal/internal_trmm.cc
@@ -67,7 +67,7 @@ void trmm(internal::TargetType<Target::HostTask>,
             if (B.tileIsLocal(i, 0)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate(i, layout, side, alpha)
+                    firstprivate( i, layout, side, alpha, call_tile_tick )
                 {
                     A.tileGetForReading(0, 0, LayoutConvert(layout));
                     B.tileGetForWriting(i, 0, LayoutConvert(layout));
@@ -88,7 +88,7 @@ void trmm(internal::TargetType<Target::HostTask>,
             if (B.tileIsLocal(0, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate(j, layout, side, alpha)
+                    firstprivate( j, layout, side, alpha, call_tile_tick )
                 {
                     A.tileGetForReading(0, 0, LayoutConvert(layout));
                     B.tileGetForWriting(0, j, LayoutConvert(layout));
@@ -196,7 +196,8 @@ void trmm(internal::TargetType<Target::Devices>,
     #pragma omp taskgroup
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task shared(A, B) priority(priority) \
-            firstprivate(device, side, sideA, uploA, opA, diagA, alpha, queue_index, layout)
+            firstprivate( device, side, sideA, uploA, opA, diagA, alpha ) \
+            firstprivate( queue_index, layout, call_tile_tick )
         {
             std::set<ij_tuple> B_tiles_set;
             if (side == Side::Right) {

--- a/src/internal/internal_ttlqt.cc
+++ b/src/internal/internal_ttlqt.cc
@@ -81,7 +81,7 @@ void ttlqt(internal::TargetType<Target::HostTask>,
         int nranks = rank_cols.size();
         int nlevels = int( ceil( log2( nranks ) ) );
 
-        // Example: 2D cyclic, p = 7, q = 1, row k = 9
+        // Example: 2D cyclic, p = 1, q = 7, row k = 9
         //                                           Levels
         //               { rank, col }        index  L=0  L=1  L=2
         // rank_cols = [ {    2,   9 },    // 0      src  src  src

--- a/src/internal/internal_ttlqt.cc
+++ b/src/internal/internal_ttlqt.cc
@@ -20,10 +20,11 @@ namespace internal {
 ///
 template <Target target, typename scalar_t>
 void ttlqt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T)
+           Matrix<scalar_t>&& T,
+           Options const& opts)
 {
     ttlqt(internal::TargetType<target>(),
-          A, T);
+          A, T, opts);
 }
 
 //------------------------------------------------------------------------------
@@ -34,8 +35,15 @@ void ttlqt(Matrix<scalar_t>&& A,
 template <typename scalar_t>
 void ttlqt(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& A,
-           Matrix<scalar_t>& T)
+           Matrix<scalar_t>& T,
+           Options const& opts)
 {
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -122,7 +130,9 @@ void ttlqt(internal::TargetType<Target::HostTask>,
 
                 // Send updated tile back. This rank is done!
                 A.tileSend(0, j_src, src);
-                A.tileTick(0, j_src);
+                if (call_tile_tick) {
+                    A.tileTick(0, j_src);
+                }
                 break;
             }
             step *= 2;
@@ -136,25 +146,29 @@ void ttlqt(internal::TargetType<Target::HostTask>,
 template
 void ttlqt<Target::HostTask, float>(
     Matrix<float>&& A,
-    Matrix<float>&& T);
+    Matrix<float>&& T,
+    Options const& opts);
 
 // ----------------------------------------
 template
 void ttlqt<Target::HostTask, double>(
     Matrix<double>&& A,
-    Matrix<double>&& T);
+    Matrix<double>&& T,
+    Options const& opts);
 
 // ----------------------------------------
 template
 void ttlqt< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
-    Matrix< std::complex<float> >&& T);
+    Matrix< std::complex<float> >&& T,
+    Options const& opts);
 
 // ----------------------------------------
 template
 void ttlqt< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
-    Matrix< std::complex<double> >&& T);
+    Matrix< std::complex<double> >&& T,
+    Options const& opts);
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -196,7 +196,8 @@ void ttmlq(internal::TargetType<Target::HostTask>,
 
                         #pragma omp task slate_omp_default_none \
                             shared( A, T, C ) \
-                            firstprivate(i, j, layout, rank_ind, i1, j1, side, op)
+                            firstprivate( i, j, layout, rank_ind, i1, j1, side, op ) \
+                            firstprivate( call_tile_tick )
                         {
                             A.tileGetForReading(0, rank_ind, LayoutConvert(layout));
                             T.tileGetForReading(0, rank_ind, LayoutConvert(layout));

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -88,9 +88,9 @@ void ttmlq(internal::TargetType<Target::HostTask>,
     int nlevels = int( ceil( log2( nranks ) ) );
 
     // Apply reduction tree.
-    // If Left, NoTrans or Right, Trans, apply descending from root to leaves,
+    // If Left, Trans or Right, NoTrans, apply descending from root to leaves,
     // i.e., in reverse order of how they were created.
-    // If Left, Trans or Right, NoTrans, apply ascending from leaves to root,
+    // If Left, NoTrans or Right, Trans, apply ascending from leaves to root,
     // i.e., in same order as they were created.
     // Example for A.mt == 8.
     // Leaves:
@@ -103,7 +103,7 @@ void ttmlq(internal::TargetType<Target::HostTask>,
     //     ttqrt( a4, a6 )
     // Root:
     //     ttqrt( a0, a4 )
-    bool descend = (side == Side::Left) == (op == Op::NoTrans);
+    bool descend = (side == Side::Left) != (op == Op::NoTrans);
     int step;
     if (descend)
         step = pow(2, nlevels - 1);

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -27,10 +27,11 @@ void ttmqr(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag)
+           int tag,
+           Options const& opts )
 {
     ttmqr(internal::TargetType<target>(),
-          side, op, A, T, C, tag);
+          side, op, A, T, C, tag, opts);
 }
 
 //------------------------------------------------------------------------------
@@ -44,7 +45,8 @@ void ttmqr(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& A,
            Matrix<scalar_t>& T,
            Matrix<scalar_t>& C,
-           int tag)
+           int tag,
+           Options const& opts )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -55,6 +57,12 @@ void ttmqr(internal::TargetType<Target::HostTask>,
         assert(A_mt == C.mt());
     else
         assert(A_mt == C.nt());
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     // Find ranks in this column of A.
     std::set<int> ranks_set;
@@ -199,9 +207,11 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                                    A(rank_ind, 0), T(rank_ind, 0),
                                    C(i1, j1), C(i, j));
 
-                            // todo: should tileRelease()?
-                            A.tileTick(rank_ind, 0);
-                            T.tileTick(rank_ind, 0);
+                            if (call_tile_tick) {
+                                // todo: should tileRelease()?
+                                A.tileTick(rank_ind, 0);
+                                T.tileTick(rank_ind, 0);
+                            }
                         }
                     }
                 }
@@ -247,7 +257,9 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                         int     src   = C.tileRank(i1, j1);
                         // Send updated tile back.
                         C.tileSend(i1, j1, src, tag);
-                        C.tileTick(i1, j1);
+                        if (call_tile_tick) {
+                            C.tileTick(i1, j1);
+                        }
                     }
                 }
             }
@@ -268,7 +280,8 @@ void ttmqr<Target::HostTask, float>(
     Matrix<float>&& A,
     Matrix<float>&& T,
     Matrix<float>&& C,
-    int tag);
+    int tag,
+    Options const& opts);
 
 // ----------------------------------------
 template
@@ -277,7 +290,8 @@ void ttmqr<Target::HostTask, double>(
     Matrix<double>&& A,
     Matrix<double>&& T,
     Matrix<double>&& C,
-    int tag);
+    int tag,
+    Options const& opts);
 
 // ----------------------------------------
 template
@@ -286,7 +300,8 @@ void ttmqr< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
-    int tag);
+    int tag,
+    Options const& opts);
 
 // ----------------------------------------
 template
@@ -295,7 +310,8 @@ void ttmqr< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
-    int tag);
+    int tag,
+    Options const& opts);
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -196,7 +196,8 @@ void ttmqr(internal::TargetType<Target::HostTask>,
 
                         #pragma omp task slate_omp_default_none \
                             shared( A, T, C ) \
-                            firstprivate(i, j, layout, rank_ind, i1, j1, side, op)
+                            firstprivate( i, j, layout, rank_ind, i1, j1, side, op ) \
+                            firstprivate( call_tile_tick )
                         {
                             A.tileGetForReading(rank_ind, 0, LayoutConvert(layout));
                             T.tileGetForReading(rank_ind, 0, LayoutConvert(layout));

--- a/src/internal/internal_unmlq.cc
+++ b/src/internal/internal_unmlq.cc
@@ -169,14 +169,14 @@ void unmlq(internal::TargetType<target>,
                 priority, queue_index, opts);
         internal::trmm<target>(
                 Side::Left,
-                one, conj_transpose( V0tr ),
+                one, std::move(V0tr),
                      std::move(Wr),
                 priority, queue_index, opts);
 
         if (trapezoid) {
             // W <- V0b C0b + W
             internal::gemm<target>(
-                    one, conj_transpose( V0b ),
+                    one, std::move(V0b),
                          std::move(C0b),
                     one, std::move(Wr),
                     layout,
@@ -192,7 +192,7 @@ void unmlq(internal::TargetType<target>,
                 Ci.tileGetAndHoldAllOnDevices(LayoutConvert(layout));
             }
             internal::gemm<target>(
-                    one, conj_transpose( V.sub( row, row, 0, 0 ) ),
+                    one, V.sub(0, 0, row, row),
                          std::move(Ci),
                     one, std::move(Wr),
                     layout,

--- a/src/norm.cc
+++ b/src/norm.cc
@@ -43,6 +43,13 @@ norm(
     else if (A.op() == Op::Trans)
         A = transpose(A);
 
+    // TODO update internal to use these batch arrays
+    // They're currently just used when transposing tiles
+    if (target == Target::Devices) {
+        A.allocateBatchArrays();
+        A.reserveDeviceWorkspace();
+    }
+
     //---------
     // max norm
     // max_{i,j} abs( A_{i,j} )
@@ -50,10 +57,6 @@ norm(
 
         real_t local_max;
         real_t global_max;
-
-        // TODO: Allocate batch arrays here, not in internal.
-        if (target == Target::Devices)
-            A.reserveDeviceWorkspace();
 
         #pragma omp parallel
         #pragma omp master
@@ -94,10 +97,6 @@ norm(
 
         std::vector<real_t> local_sums(A.n());
 
-        if (target == Target::Devices) {
-            A.reserveDeviceWorkspace();
-        }
-
         #pragma omp parallel
         #pragma omp master
         {
@@ -125,10 +124,6 @@ norm(
     else if (in_norm == Norm::Inf) {
 
         std::vector<real_t> local_sums(A.m());
-
-        if (target == Target::Devices) {
-            A.reserveDeviceWorkspace();
-        }
 
         #pragma omp parallel
         #pragma omp master
@@ -159,10 +154,6 @@ norm(
         real_t local_values[2];
         real_t local_sumsq;
         real_t global_sumsq;
-
-        if (target == Target::Devices) {
-            A.reserveDeviceWorkspace();
-        }
 
         #pragma omp parallel
         #pragma omp master

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -29,8 +29,17 @@ void unmlq(
     // trace::Block trace_block("unmlq");
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Use only TileReleaseStrategy::Slate for unmlq
+    // Internal routines called here won't release any
+    // tiles. This routine will clean up tiles.
+    Options opts2 = opts;
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
+
     // Assumes column major
     const Layout layout = Layout::ColMajor;
+    const int64_t tag_0 = 0;
+    const int64_t priority_0 = 0;
+    const int64_t queue_0 = 0;
 
     int64_t A_mt = A.mt();
     int64_t A_nt = A.nt();
@@ -133,7 +142,6 @@ void unmlq(
 
                 // Send V(j) across row C(j, 0:nt-1) or col C(0:mt-1, j),
                 // for side = left or right, respectively.
-                BcastList bcast_list_V_top;
                 BcastList bcast_list_V;
                 for (int64_t j = k; j < A_nt; ++j) {
                     if (side == Side::Left) {
@@ -144,20 +152,10 @@ void unmlq(
                         j0 = j;
                         j1 = j;
                     }
-                    if (std::find(first_indices.begin(), first_indices.end(), j) != first_indices.end()) {
-                        bcast_list_V_top.push_back(
-                            {k, j, {C.sub(i0, i1, j0, j1)}});
-                    }
-                    else {
-                        bcast_list_V.push_back(
-                            {k, j, {C.sub(i0, i1, j0, j1)}});
-                    }
+                    bcast_list_V.push_back(
+                        {k, j, {C.sub(i0, i1, j0, j1)}});
                 }
-                // V tiles in first_indices need up to 5 lives: 1 for ttmqr,
-                // 2 + extra 2 if mb > nb (trapezoid) for Vs in unmqr I-VTV^T.
-                // This may leak a few tiles that A.clearWorkspace will cleanup.
-                A.template listBcast(bcast_list_V_top, layout, 0, 5);
-                A.template listBcast(bcast_list_V, layout, 0, 2);
+                A.template listBcast(bcast_list_V, layout, 0, 1);
 
                 // Send Tlocal(j) across row C(j, 0:nt-1) or col C(0:mt-1, j).
                 if (first_indices.size() > 0) {
@@ -218,7 +216,8 @@ void unmlq(
                                     side, op,
                                     std::move(A_panel),
                                     Treduce.sub(k, k, k, A_nt-1),
-                                    std::move(C_trail));
+                                    std::move(C_trail),
+                                    tag_0, opts2);
                 }
 
                 // Apply local reflectors.
@@ -227,7 +226,8 @@ void unmlq(
                                 std::move(A_panel),
                                 Tlocal.sub(k, k, k, A_nt-1),
                                 std::move(C_trail),
-                                std::move(W_trail));
+                                std::move(W_trail),
+                                priority_0, queue_0, opts2);
 
                 // Left,  NoTrans:     Qi C   = Qi_reduce Qi_local C, or
                 // Right, (Conj)Trans: C Qi^H = C Qi_local^H Qi_reduce^H,
@@ -238,8 +238,23 @@ void unmlq(
                                     side, op,
                                     std::move(A_panel),
                                     Treduce.sub(k, k, k, A_nt-1),
-                                    std::move(C_trail));
+                                    std::move(C_trail),
+                                    tag_0, opts2);
                 }
+            }
+
+            #pragma omp task depend(in:block[k])
+            {
+                auto Tlocal_panel = Tlocal.sub(k, k, k, A_nt-1);
+                auto Treduce_panel = Treduce.sub(k, k, k, A_nt-1);
+
+                A_panel.releaseRemoteWorkspace();
+                Tlocal_panel.releaseRemoteWorkspace();
+                Treduce_panel.releaseRemoteWorkspace();
+
+                A_panel.releaseLocalWorkspace();
+                Tlocal_panel.releaseLocalWorkspace();
+                Treduce_panel.releaseLocalWorkspace();
             }
 
             lastk = k;

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -29,8 +29,17 @@ void unmqr(
     // trace::Block trace_block("unmqr");
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
+    // Use only TileReleaseStrategy::Slate for unmqr
+    // Internal routines called here won't release any
+    // tiles. This routine will clean up tiles.
+    Options opts2 = opts;
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
+
     // Assumes column major
     const Layout layout = Layout::ColMajor;
+    const int64_t tag_0 = 0;
+    const int64_t priority_0 = 0;
+    const int64_t queue_0 = 0;
 
     int64_t A_mt = A.mt();
     int64_t A_nt = A.nt();
@@ -137,7 +146,6 @@ void unmqr(
 
                 // Send V(i) across row C(i, 0:nt-1) or col C(0:mt-1, i),
                 // for side = left or right, respectively.
-                BcastList bcast_list_V_top;
                 BcastList bcast_list_V;
                 for (int64_t i = k; i < A_mt; ++i) {
                     if (side == Side::Left) {
@@ -148,20 +156,10 @@ void unmqr(
                         j0 = i;
                         j1 = i;
                     }
-                    if (std::find(first_indices.begin(), first_indices.end(), i) != first_indices.end()) {
-                        bcast_list_V_top.push_back(
-                            {i, k, {C.sub(i0, i1, j0, j1)}});
-                    }
-                    else {
-                        bcast_list_V.push_back(
-                            {i, k, {C.sub(i0, i1, j0, j1)}});
-                    }
+                    bcast_list_V.push_back(
+                        {i, k, {C.sub(i0, i1, j0, j1)}});
                 }
-                // V tiles in first_indices need up to 5 lives: 1 for ttmqr,
-                // 2 + extra 2 if mb > nb (trapezoid) for Vs in unmqr I-VTV^T.
-                // This may leak a few tiles that A.clearWorkspace will cleanup.
-                A.template listBcast(bcast_list_V_top, layout, 0, 5);
-                A.template listBcast(bcast_list_V, layout, 0, 2);
+                A.template listBcast(bcast_list_V, layout, 0, 1);
 
                 // Send Tlocal(i) across row C(i, 0:nt-1) or col C(0:mt-1, i).
                 if (first_indices.size() > 0) {
@@ -222,7 +220,8 @@ void unmqr(
                                     side, op,
                                     std::move(A_panel),
                                     Treduce.sub(k, A_mt-1, k, k),
-                                    std::move(C_trail));
+                                    std::move(C_trail),
+                                    tag_0, opts2);
                 }
 
                 // Apply local reflectors.
@@ -231,7 +230,8 @@ void unmqr(
                                 std::move(A_panel),
                                 Tlocal.sub(k, A_mt-1, k, k),
                                 std::move(C_trail),
-                                std::move(W_trail));
+                                std::move(W_trail),
+                                priority_0, queue_0, opts2);
 
                 // Left,  (Conj)Trans: Qi^H C = Qi_reduce^H Qi_local^H C, or
                 // Right, NoTrans:     C Qi   = C Qi_local Qi_reduce,
@@ -242,8 +242,22 @@ void unmqr(
                                     side, op,
                                     std::move(A_panel),
                                     Treduce.sub(k, A_mt-1, k, k),
-                                    std::move(C_trail));
+                                    std::move(C_trail),
+                                    tag_0, opts2);
                 }
+            }
+            #pragma omp task depend(in:block[k])
+            {
+                auto Tlocal_panel = Tlocal.sub(k, A_mt-1, k, k);
+                auto Treduce_panel = Treduce.sub(k, A_mt-1, k, k);
+
+                A_panel.releaseRemoteWorkspace();
+                Tlocal_panel.releaseRemoteWorkspace();
+                Treduce_panel.releaseRemoteWorkspace();
+
+                A_panel.releaseLocalWorkspace();
+                Tlocal_panel.releaseLocalWorkspace();
+                Treduce_panel.releaseLocalWorkspace();
             }
 
             lastk = k;


### PR DESCRIPTION
This eliminates tile life from the top-level routines of the QR family.  I also made some other related improvements:
* Fix issues with using Row layout, as mentioned in the user group
* Fix a bug in the tree order of `internal::ttmlq`
* Fix `gels` to default to `MethodGels::Auto`
* Update `gelqf` implementation to better match `geqrf` (notably, moving the lookahead to GPU).

Note that both this PR and #116 remove tile life from `src/internal/internal_geadd.cc`.  So, one of them might need to be merged manually.

~Also, This PR doesn't address the segfault that was posted in the SLATE Users mailing list.  I'll work on that as a follow up PR.~ 

Measuring the effect on performance was problematic because the `GEQRF` in master is broken on Frontier and the Cray MPICH issue forced me to use lookahead=0.  But on Frontier, `gelqf` with lookahead 0 had a 6% speedup for `m=n=150000` and a 1% speedup for `m=10000, n=100000` on 4 nodes (after cherry-picking the bugfixes onto master).

On Guyot, I got the following speedups.  Basically, `geqrf` stays about the same, but `unmqr` and `gelqf` get good speedups.   The speedup of `gelqf` is likely due in part to moving more work to the GPU, not just removing tile life.
| `--dim`           | geqrf | unmqr | gels  | gelqf |
|----------------|-------|-------|-------|--------|
| 40000x40000 | 1.01x | 2.08x | 1.07x | 1.87x |
| 80000x10000 | 1.01x | 1.92x | 1.12x |    -     |
| 10000x80000 |    -     |    -     |    -     | 2.78x |
