### PR TITLE
gels: add timers

### DIFF
--- a/include/slate/internal/util.hh
+++ b/include/slate/internal/util.hh
@@ -262,6 +262,33 @@ inline int64_t num_local_rows_cols(
 /// Use to silence compiler warnings regarding an unused variable var.
 #define SLATE_UNUSED(var)  ((void)var)
 
+//------------------------------------------------------------------------------
+/// Simple class around wall-clock timer; currently uses MPI_Wtime.
+class Timer
+{
+public:
+    /// Starts the timer.
+    Timer()
+    {
+        start();
+    }
+
+    /// Starts the timer.
+    void start()
+    {
+        start_ = MPI_Wtime();
+    }
+
+    /// @return time in seconds since timer was started.
+    double stop()
+    {
+        return MPI_Wtime() - start_;
+    }
+
+private:
+    double start_;
+};
+
 } // namespace slate
 
 #endif // SLATE_UTIL_HH

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -33,6 +33,11 @@ namespace slate {
 int version();
 const char* id();
 
+/// Map of timers, in seconds, for top-level routines. For example:
+/// `timers[ "gels" ]` is time for gels,
+/// `timers[ "gels::geqrf" ]` is time for geqrf inside gels.
+extern std::map< std::string, double > timers;
+
 //------------------------------------------------------------------------------
 // Level 2 Auxiliary
 

--- a/src/core/types.cc
+++ b/src/core/types.cc
@@ -16,4 +16,7 @@ MPI_Datatype mpi_type< std::complex<double> >::value = MPI_C_DOUBLE_COMPLEX;
 MPI_Datatype mpi_type< max_loc_type<float>  >::value = MPI_FLOAT_INT;
 MPI_Datatype mpi_type< max_loc_type<double> >::value = MPI_DOUBLE_INT;
 
+//------------------------------------------------------------------------------
+std::map< std::string, double > timers;
+
 } // namespace slate

--- a/test/test.cc
+++ b/test/test.cc
@@ -426,8 +426,16 @@ Params::Params():
     // 12.3 allows 99999999.999 Gflop/s = 100 Pflop/s
     time      ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "time to solution"),
     gflops    ("gflop/s",      12, 3, ParamType::Output, no_data_flag,   0,   0, "Gflop/s rate"),
-    time2     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "time to solution"),
+    time2     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
     gflops2   ("gflop/s",      12, 3, ParamType::Output, no_data_flag,   0,   0, "Gflop/s rate"),
+    time3     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time4     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time5     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time6     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time7     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time8     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time9     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time10    ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
     iters     ("iters",         5,    ParamType::Output,            0,   0,   0, "iterations to solution"),
 
     ref_time  ("ref time (s)", 12, 3, ParamType::Output, no_data_flag,   0,   0, "reference time to solution"),

--- a/test/test.cc
+++ b/test/test.cc
@@ -331,6 +331,11 @@ Params::Params():
     print_precision("print-precision", 0, ParamType::Value, 4,    1, 17,
                     "number of digits to print after the decimal point"),
 
+    timers    ("timers", 0,      ParamType::Value,   1,   1,   2,
+               "timer level of detail:\n"
+               "                     1: driver routine (e.g., gels; default)\n"
+               "                     2: computational routines (e.g., geqrf, unmqr, trsm inside gels)" ),
+
     extended  ("extended",0,    ParamType::Value,   0,   0,   10, "extended tests"),
     cache     ("cache",   0,    ParamType::Value,  20,   1, 1024, "total cache size, in MiB"),
 
@@ -681,6 +686,10 @@ int run(int argc, char** argv)
                 params.help(routine);
             throw;
         }
+
+        // After parsing parameters, call test routine again (with run=false)
+        // to mark any new fields as used (e.g., timers).
+        test_routine( params, false );
 
         slate_assert(params.grid.m() * params.grid.n() == mpi_size);
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -331,10 +331,11 @@ Params::Params():
     print_precision("print-precision", 0, ParamType::Value, 4,    1, 17,
                     "number of digits to print after the decimal point"),
 
-    timers    ("timers", 0,      ParamType::Value,   1,   1,   2,
-               "timer level of detail:\n"
-               "                     1: driver routine (e.g., gels; default)\n"
-               "                     2: computational routines (e.g., geqrf, unmqr, trsm inside gels)" ),
+    timer_level(
+        "timer-level", 0, ParamType::Value,   1,   1,   2,
+        "timer level of detail:\n"
+        "                     1: driver routine (e.g., gels; default)\n"
+        "                     2: computational routines (e.g., geqrf, unmqr, trsm inside gels)" ),
 
     extended  ("extended",0,    ParamType::Value,   0,   0,   10, "extended tests"),
     cache     ("cache",   0,    ParamType::Value,  20,   1, 1024, "total cache size, in MiB"),

--- a/test/test.hh
+++ b/test/test.hh
@@ -159,6 +159,14 @@ public:
     testsweeper::ParamDouble     gflops;
     testsweeper::ParamDouble     time2;
     testsweeper::ParamDouble     gflops2;
+    testsweeper::ParamDouble     time3;
+    testsweeper::ParamDouble     time4;
+    testsweeper::ParamDouble     time5;
+    testsweeper::ParamDouble     time6;
+    testsweeper::ParamDouble     time7;
+    testsweeper::ParamDouble     time8;
+    testsweeper::ParamDouble     time9;
+    testsweeper::ParamDouble     time10;
     testsweeper::ParamInt        iters;
 
     testsweeper::ParamDouble     ref_time;

--- a/test/test.hh
+++ b/test/test.hh
@@ -62,7 +62,7 @@ public:
     testsweeper::ParamInt    print_edgeitems;
     testsweeper::ParamInt    print_width;
     testsweeper::ParamInt    print_precision;
-    testsweeper::ParamInt    timers;
+    testsweeper::ParamInt    timer_level;
     testsweeper::ParamInt    extended;
     testsweeper::ParamInt    cache;
 

--- a/test/test.hh
+++ b/test/test.hh
@@ -62,6 +62,7 @@ public:
     testsweeper::ParamInt    print_edgeitems;
     testsweeper::ParamInt    print_width;
     testsweeper::ParamInt    print_precision;
+    testsweeper::ParamInt    timers;
     testsweeper::ParamInt    extended;
     testsweeper::ParamInt    cache;
 

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -20,18 +20,6 @@
 #include <utility>
 
 //------------------------------------------------------------------------------
-// Defined in src/gels_qr.cc
-// todo: add as PAPI SDE counters?
-namespace slate {
-
-extern double time_gels;
-extern double time_gels_geqrf;
-extern double time_gels_unmqr;
-extern double time_gels_trsm;
-
-}
-
-//------------------------------------------------------------------------------
 template <typename scalar_t>
 void test_gels_work(Params& params, bool run)
 {
@@ -57,6 +45,7 @@ void test_gels_work(Params& params, bool run)
     bool check = params.check() == 'y' && ! ref_only;
     bool trace = params.trace() == 'y';
     int verbose = params.verbose();
+    int timers = params.timers();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     slate::Method methodGels = params.method_gels();
@@ -76,12 +65,14 @@ void test_gels_work(Params& params, bool run)
     params.gflops();
     params.ref_time();
     params.ref_gflops();
-    params.time2();
-    params.time3();
-    params.time4();
-    params.time2.name( "geqrf (s)" );
-    params.time3.name( "unmqr (s)" );
-    params.time4.name( "trsm (s)" );
+    if (timers >= 2) {
+        params.time2();
+        params.time3();
+        params.time4();
+        params.time2.name( "geqrf (s)" );
+        params.time3.name( "unmqr (s)" );
+        params.time4.name( "trsm (s)" );
+    }
 
     if (! run)
         return;
@@ -250,9 +241,12 @@ void test_gels_work(Params& params, bool run)
         // compute and save timing/performance
         params.time() = time;
         params.gflops() = gflop / time;
-        params.time2() = slate::time_gels_geqrf;
-        params.time3() = slate::time_gels_unmqr;
-        params.time4() = slate::time_gels_trsm;
+
+        if (timers >= 2) {
+            params.time2() = slate::timers[ "gels::geqrf" ];
+            params.time3() = slate::timers[ "gels::unmqr" ];
+            params.time4() = slate::timers[ "gels::trsm"  ];
+        }
 
         print_matrix( "A2", A, params );
         print_matrix( "BX2", BX, params );

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -20,6 +20,18 @@
 #include <utility>
 
 //------------------------------------------------------------------------------
+// Defined in src/gels_qr.cc
+// todo: add as PAPI SDE counters?
+namespace slate {
+
+extern double time_gels;
+extern double time_gels_geqrf;
+extern double time_gels_unmqr;
+extern double time_gels_trsm;
+
+}
+
+//------------------------------------------------------------------------------
 template <typename scalar_t>
 void test_gels_work(Params& params, bool run)
 {
@@ -64,6 +76,12 @@ void test_gels_work(Params& params, bool run)
     params.gflops();
     params.ref_time();
     params.ref_gflops();
+    params.time2();
+    params.time3();
+    params.time4();
+    params.time2.name( "geqrf (s)" );
+    params.time3.name( "unmqr (s)" );
+    params.time4.name( "trsm (s)" );
 
     if (! run)
         return;
@@ -232,6 +250,9 @@ void test_gels_work(Params& params, bool run)
         // compute and save timing/performance
         params.time() = time;
         params.gflops() = gflop / time;
+        params.time2() = slate::time_gels_geqrf;
+        params.time3() = slate::time_gels_unmqr;
+        params.time4() = slate::time_gels_trsm;
 
         print_matrix( "A2", A, params );
         print_matrix( "BX2", BX, params );

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -45,7 +45,7 @@ void test_gels_work(Params& params, bool run)
     bool check = params.check() == 'y' && ! ref_only;
     bool trace = params.trace() == 'y';
     int verbose = params.verbose();
-    int timers = params.timers();
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     slate::Method methodGels = params.method_gels();
@@ -65,7 +65,7 @@ void test_gels_work(Params& params, bool run)
     params.gflops();
     params.ref_time();
     params.ref_gflops();
-    if (timers >= 2) {
+    if (timer_level >= 2) {
         params.time2();
         params.time3();
         params.time4();
@@ -242,7 +242,7 @@ void test_gels_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-        if (timers >= 2) {
+        if (timer_level >= 2) {
             params.time2() = slate::timers[ "gels::geqrf" ];
             params.time3() = slate::timers[ "gels::unmqr" ];
             params.time4() = slate::timers[ "gels::trsm"  ];


### PR DESCRIPTION
Prototype for adding timers in `gels` to capture steps: `geqrf`, `unmqr`, `trsm`.