### PR TITLE
Managing a tile's layout, stride, and buffer together

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3248,7 +3248,7 @@ void BaseMatrix<scalar_t>::tileUpdateAllOrigin()
 ///
 // todo: validate working for sub- and sliced- matrix
 template <typename scalar_t>
-[[deprecated( "SLATE now managed convertibility internally. Will be removed 2024-10." )]]
+[[deprecated( "SLATE now manages convertibility internally. Will be removed 2024-10." )]]
 bool BaseMatrix<scalar_t>::tileLayoutIsConvertible(int64_t i, int64_t j, int device)
 {
     return storage_->at( globalIndex(i, j, device) )->isTransposable();

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2660,8 +2660,7 @@ void BaseMatrix<scalar_t>::tileGet(int64_t i, int64_t j, int dst_device,
     }
 
     // Change ColMajor <=> RowMajor if needed.
-    if (layout != LayoutConvert::None &&
-        dst_tile->layout() != Layout(layout)) {
+    if (layout != LayoutConvert::None && dst_tile->layout() != Layout(layout)) {
         tileLayoutConvert(i, j, dst_device, Layout(layout), false, async);
     }
 }
@@ -3285,7 +3284,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
     auto tile = tile_node[ HostNum ];
     if (tile->layout() != layout) {
         if (! tile->isTransposable()) {
-            assert(! reset); // cannot reset if not transposable
+            assert(! reset); // Can't change to ext buffer then reset
             storage_->tileMakeTransposable(tile);
         }
 

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3280,8 +3280,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
 {
     auto& tile_node = storage_->at( globalIndex(i, j) );
     LockGuard guard( tile_node.getLock() );
-    // TODO shouldn't this be tile_node[ device ]; ?
-    auto tile = tile_node[ HostNum ];
+    auto tile = tile_node[ device ];
     if (tile->layout() != layout) {
         if (! tile->isTransposable()) {
             assert(! reset); // Can't change to ext buffer then reset

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -523,12 +523,14 @@ public:
     }
 
     /// Sets Layout of tile(i, j, device)
+    [[deprecated( "Use tileGetFor* instead. Will be removed 2024-10." )]]
     void tileLayout(int64_t i, int64_t j, int device, Layout layout)
     {
         storage_->at( globalIndex(i, j, device) )->setLayout(layout);
     }
 
     /// Sets Layout of tile(i, j, host)
+    [[deprecated( "Use tileGetFor* instead. Will be removed 2024-10." )]]
     void tileLayout(int64_t i, int64_t j, Layout layout)
     {
         tileLayout( i, j, HostNum, layout );
@@ -3246,6 +3248,7 @@ void BaseMatrix<scalar_t>::tileUpdateAllOrigin()
 ///
 // todo: validate working for sub- and sliced- matrix
 template <typename scalar_t>
+[[deprecated( "SLATE now managed convertibility internally. Will be removed 2024-10." )]]
 bool BaseMatrix<scalar_t>::tileLayoutIsConvertible(int64_t i, int64_t j, int device)
 {
     return storage_->at( globalIndex(i, j, device) )->isTransposable();

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -671,7 +671,6 @@ void BaseTrapezoidMatrix<scalar_t>::gather(scalar_t* A, int64_t lda)
                                           &A[(size_t)lda*jj + ii], lda );
                         auto Aij = this->at(i, j);
                         Aij.recv(this->tileRank(i, j), this->mpi_comm_, this->layout());
-                        this->tileLayout(i, j, this->layout_);
                     }
                     else {
                         this->tileGetForReading(i, j, LayoutConvert(this->layout()));

--- a/include/slate/BaseTriangularBandMatrix.hh
+++ b/include/slate/BaseTriangularBandMatrix.hh
@@ -248,7 +248,6 @@ void BaseTriangularBandMatrix<scalar_t>::gather(scalar_t* A, int64_t lda)
                                           &A[(size_t)lda*jj + ii], lda );
                         auto Aij = this->at(i, j);
                         Aij.recv(this->tileRank(i, j), this->mpi_comm_, this->layout());
-                        this->tileLayout(i, j, this->layout_);
                     }
                     else {
                         this->tileGetForReading(i, j, LayoutConvert(this->layout()));

--- a/include/slate/Matrix.hh
+++ b/include/slate/Matrix.hh
@@ -778,7 +778,6 @@ void Matrix<scalar_t>::gather(scalar_t* A, int64_t lda)
                                       &A[(size_t)lda*jj + ii], lda );
                     auto Aij = this->at(i, j);
                     Aij.recv(this->tileRank(i, j), this->mpi_comm_, this->layout());
-                    this->tileLayout(i, j, this->layout_);
                 }
                 else {
                     this->tileGetForReading(i, j, LayoutConvert(this->layout()));

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -845,7 +845,7 @@ void Tile<scalar_t>::layoutConvert(scalar_t* work_data)
             src_data = work_data;
             src_stride = old_mb;
 
-            std::memcpy(data_, work_data, bytes());
+            std::memcpy(work_data, data_, bytes());
         }
         tile::transpose(
             old_mb, old_nb,

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -299,7 +299,7 @@ public:
     int64_t layoutBackStride() const
     {
         if (data_ == user_data_)
-            return stride_; // todo: validate
+            return user_layout_ != Layout::ColMajor ? mb_ : nb_;
         else
             return user_stride_;
     }
@@ -364,21 +364,6 @@ protected:
     void kind(TileKind kind)
     {
         kind_ = kind;
-    }
-
-    void data(scalar_t* data)
-    {
-        data_ = data;
-    }
-
-    void userData(scalar_t* data)
-    {
-        user_data_ = data;
-    }
-
-    void extData(scalar_t* data)
-    {
-        ext_data_ = data;
     }
 
     void state(MOSI_State stateIn)
@@ -495,7 +480,7 @@ Tile<scalar_t>::Tile(
       op_(Op::NoTrans),
       uplo_(Uplo::General),
       data_(A),
-      user_data_(nullptr),
+      user_data_(A),
       ext_data_(nullptr),
       kind_(kind),
       layout_(layout),
@@ -538,7 +523,7 @@ Tile<scalar_t>::Tile(
       op_(src_tile.op_),
       uplo_(src_tile.uplo_),
       data_(A),
-      user_data_(nullptr),
+      user_data_(A),
       ext_data_(nullptr),
       kind_(kind),
       layout_(src_tile.layout_),
@@ -727,11 +712,6 @@ template <typename scalar_t>
 void Tile<scalar_t>::makeTransposable(scalar_t* new_data)
 {
     slate_assert(! isTransposable());
-
-    // preserve currrent data pointer and stride
-    user_data_ = data_;
-    user_stride_ = stride_;
-    user_layout_ = layout_;
     ext_data_ = new_data;
 }
 
@@ -767,7 +747,6 @@ template <typename scalar_t>
 void Tile<scalar_t>::layoutReset()
 {
     slate_assert(data_ == user_data_);
-    user_data_ = nullptr;
     ext_data_ = nullptr;
 }
 

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -334,8 +334,9 @@ void copy(internal::TargetType<Target::Devices>,
                     }
                 }
             }
-            // no need to convert layout.
-            A.tileGetForReading(A_tiles_set, device, LayoutConvert::None);
+            // no need to convert layout
+            // TODO kernel assumes column major
+            A.tileGetForReading(A_tiles_set, device, LayoutConvert::ColMajor);
 
             // Usually the output matrix (B) provides all the batch arrays.
             // Here we are using A, because of the possibly different types.
@@ -413,10 +414,6 @@ void copy(internal::TargetType<Target::Devices>,
             for (int64_t i = 0; i < B.mt(); ++i) {
                 for (int64_t j = 0; j < B.nt(); ++j) {
                     if (B.tileIsLocal(i, j) && device == B.tileDevice(i, j)) {
-                        B.tileModified(i, j, device);
-                        // update output tile layout
-                        // todo: what if extended?
-                        B.tileLayout(i, j, device, A.tileLayout(i, j, device));
                         // erase tmp local and remote device tiles;
                         A.tileRelease(i, j, device);
                         // decrement life for remote tiles

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -1906,10 +1906,10 @@ void test_Matrix_tileLayoutConvert()
             if (A.tileIsLocal(i, j)) {
                 test_assert(A.tileLayout(i, j) == A.layout());
                 if (A.tileMb(i) == A.tileNb(j)) {
-                    test_assert( A.tileLayoutIsConvertible(i, j) );
+                    test_assert( A(i, j).isTransposable() );
                 }
                 else {
-                    test_assert(! A.tileLayoutIsConvertible(i, j) );
+                    test_assert(! A(i, j).isTransposable() );
                 }
                 A.tileLayoutConvert(i, j, newLayout);
                 test_assert(A.tileLayout(i, j) == newLayout);

--- a/unit_test/test_Tile_kernels.cc
+++ b/unit_test/test_Tile_kernels.cc
@@ -1023,7 +1023,7 @@ void test_device_convert_layout(int m, int n)
 
     scalar_t* dev_work = blas::device_malloc<scalar_t>(lda*n, queue);
 
-    // Setup Atiles_dev[] on CPU with points to Adata_dev[]
+    // Setup Atiles_dev[] on CPU with pointers to Adata_dev[]
     std::vector< slate::Tile<scalar_t> > Atiles_dev( batch_count );
     for (int k = 0; k < batch_count; ++k) {
         Atiles_dev[k] = slate::Tile<scalar_t>( m, n, &Adata_dev[ k*lda*n ], lda,

--- a/unit_test/test_Tile_kernels.cc
+++ b/unit_test/test_Tile_kernels.cc
@@ -1021,33 +1021,14 @@ void test_device_convert_layout(int m, int n)
                         blas::MemcpyKind::HostToDevice,
                         queue);
 
-    scalar_t* Adata_dev_ext;
-    Adata_dev_ext = blas::device_malloc<scalar_t>(Adata.size(), queue);
+    scalar_t* dev_work = blas::device_malloc<scalar_t>(lda*n, queue);
 
-    // Setup Atiles_dev[], Aarray[], Aarray_ext[] on CPU with pointers to Adata_dev[]
+    // Setup Atiles_dev[] on CPU with points to Adata_dev[]
     std::vector< slate::Tile<scalar_t> > Atiles_dev( batch_count );
-    std::vector< scalar_t* > Aarray( batch_count );
-    std::vector< scalar_t* > Aarray_ext( batch_count );
     for (int k = 0; k < batch_count; ++k) {
-        Atiles_dev[k] = slate::Tile<scalar_t>( m, n, &Adata_dev[ k*lda*n ], lda, device, slate::TileKind::UserOwned );
-        Aarray[k] = &Adata_dev[ k*lda*n ];
-        Aarray_ext[k] = &Adata_dev_ext[ k*lda*n ];
+        Atiles_dev[k] = slate::Tile<scalar_t>( m, n, &Adata_dev[ k*lda*n ], lda,
+                                               device, slate::TileKind::UserOwned );
     }
-    // Allocate Aarray_dev[] on device and copy Aarray to it
-    scalar_t** Aarray_dev;
-    Aarray_dev = blas::device_malloc<scalar_t*>(Aarray.size(), queue);
-    blas::device_memcpy<scalar_t*>(Aarray_dev, Aarray.data(),
-                        Aarray.size(),
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
-
-    // Allocate Aarray_dev_ext[] on device and copy Aarray[] to it
-    scalar_t** Aarray_dev_ext;
-    Aarray_dev_ext = blas::device_malloc<scalar_t*>(Aarray_ext.size(), queue);
-    blas::device_memcpy<scalar_t*>(Aarray_dev_ext, Aarray_ext.data(),
-                        Aarray_ext.size(),
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
 
     if (verbose > 1) {
         printf("A = [\n");
@@ -1064,60 +1045,7 @@ void test_device_convert_layout(int m, int n)
     }
 
     //-----------------------------------------
-    // Run kernel.
-    for (int i = 0; i < repeat; ++i) {
-        queue.sync();
-        double time = omp_get_wtime();
-
-        if (m == n)
-            slate::device::transpose_batch(false, n, Aarray_dev, lda, batch_count, queue);
-        else
-            slate::device::transpose_batch(false, m, n, Aarray_dev, lda, Aarray_dev_ext, ldat, batch_count, queue);
-
-        queue.sync();
-        time = omp_get_wtime() - time;
-        if (verbose) {
-            printf( "batch_count %d, m %d, n %d, time %.6f, GB/s (read & write) %.4f batch\n",
-                    batch_count, m, n, time, 2 * Adata.size() * sizeof(scalar_t) * 1e-9 / time);
-        }
-    }
-    if (verbose)
-        printf( "\n" );
-
-    // copy transposed data Adata_dev/Adata_dev_ext from device to Adata (cpu)
-    blas::device_memcpy<scalar_t>(
-        Adata.data(), (m == n ? Adata_dev : Adata_dev_ext), Adata.size(), queue);
-
-    //-----------------------------------------
-    // Run kernel.
-    for (int i = 0; i < repeat; ++i) {
-        queue.sync();
-        double time = omp_get_wtime();
-
-        if (m == n) {
-            for (int k = 0; k < batch_count; ++k) {
-                slate::device::transpose(false, n, Aarray[k], lda, queue);
-            }
-        }
-        else {
-            for (int k = 0; k < batch_count; ++k) {
-                slate::device::transpose(false, m, n, Aarray[k], lda, Aarray_ext[k], ldat, queue);
-                // Atiles[k].stride(ldat);
-            }
-        }
-
-        queue.sync();
-        time = omp_get_wtime() - time;
-        if (verbose) {
-            printf( "batch_count %d, m %d, n %d, time %.6f, GB/s (read & write) %.4f 1-by-1\n",
-                    batch_count, m, n, time, 2 * Adata.size() * sizeof(scalar_t) * 1e-9 / time);
-        }
-    }
-    if (verbose)
-        printf( "\n" );
-
-    //-----------------------------------------
-    // Run kernel.
+    // Transpose the tiles
     for (int i = 0; i < repeat; ++i) {
         queue.sync();
         double time = omp_get_wtime();
@@ -1126,7 +1054,7 @@ void test_device_convert_layout(int m, int n)
             if (m == n)
                 Atiles_dev[k].layoutConvert(queue);
             else
-                Atiles_dev[k].layoutConvert(Aarray_ext[k], queue);
+                Atiles_dev[k].layoutConvert(dev_work, queue);
         }
 
         queue.sync();
@@ -1139,12 +1067,9 @@ void test_device_convert_layout(int m, int n)
     if (verbose)
         printf( "\n" );
 
-    // fetch Adata_dev/Adata_dev_ext from device to Adata (cpu)
-    blas::device_memcpy<scalar_t>(Adata.data(),
-                        (m == n ? Adata_dev : Adata_dev_ext),
-                        Adata.size(),
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+    for (int k = 0; k < batch_count; ++k) {
+        Atiles_dev[k].copyData( &(Atiles[k]), queue, true );
+    }
     queue.sync(); // sync before looking at data
 
     if (verbose > 1) {
@@ -1164,8 +1089,6 @@ void test_device_convert_layout(int m, int n)
     // Verify layout of A changed.
     for (int k = 0; k < batch_count; ++k) {
         test_assert(Atiles_dev[k].layout() == slate::Layout::RowMajor);
-        Atiles[k].layout(slate::Layout::RowMajor);
-        Atiles[k].stride(ldat);
         for (int j = 0; j < n; ++j) {
             for (int i = 0; i < m; ++i) {
                 // A(i, j) takes col/row-major into account.
@@ -1177,6 +1100,9 @@ void test_device_convert_layout(int m, int n)
                             j, i, k, real(Adata[ j + i*Adata_lda + k*lda*n ]),
                             i, j, k, real(Bdata[ i + j*lda + k*lda*n ]) );
                 }
+                // Check that the tile didn't get extended
+                test_assert( !Atiles[k].extended() );
+                // Check values
                 test_assert(Adata[ j + i*Adata_lda + k*lda*n ] == Bdata[ i + j*lda + k*lda*n ]);
                 test_assert(Atiles[k](i, j) == Btiles[k](i, j));
             }
@@ -1184,8 +1110,7 @@ void test_device_convert_layout(int m, int n)
     }
 
     blas::device_free(Adata_dev, queue);
-    blas::device_free(Adata_dev_ext, queue);
-    blas::device_free(Aarray_dev, queue);
+    blas::device_free(dev_work, queue);
 }
 
 void test_device_convert_layout()


### PR DESCRIPTION
There wasn't a central function for changing a tile's layout.  So, the logic for that was duplicated and somewhat error prone.

This PR deprecates both `Tile::layout(Layout)` and `Tile::layoutSetFrontDataExt(bool)` in favor of a single function: `Tile::setLayout(Layout)`.
I also did some related clean up (particularly by taking advantage of the fact that `BaseMatrix::tileAcquire` sets the layout) and fixed some issues in the copy routines.

Finally, this fixes `BaseMatrix::tileLayoutConvert` which previously always tried to convert the Host instance of a tile, even when given a GPU device.