### PR TITLE
Remove tile life from ge2tb and he2hb

### DIFF
--- a/include/slate/enums.hh
+++ b/include/slate/enums.hh
@@ -42,7 +42,7 @@ enum class TileReleaseStrategy : char {
     None      = 'N',    ///< tiles are not release at all
     Internal  = 'I',    ///< tiles are released by routines in slate::internal namespace
     Slate     = 'S',    ///< tiles are released by routines directly in slate namespace
-    All       = 'A',    ///< tiles are released by rotines in all namespaces
+    All       = 'A',    ///< tiles are released by routines in all namespaces
 };
 
 namespace internal {

--- a/src/ge2tb.cc
+++ b/src/ge2tb.cc
@@ -35,12 +35,19 @@ void ge2tb(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const int queue_0 = 0;
+    const int priority_0 = 0;
 
     // Options
     int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
     int64_t max_panel_threads  = std::max(omp_get_max_threads()/2, 1);
     max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads,
                                              max_panel_threads );
+
+    // Use only TileReleaseStrategy::Slate for gemm.
+    // Internal gemm routine called here won't release
+    // any tiles. This routine will clean up tiles.
+    Options opts2 = opts;
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
 
     int64_t A_mt = A.mt();
     int64_t A_nt = A.nt();
@@ -170,8 +177,6 @@ void ge2tb(
 
     // Workspace for transposed panels needs one column of tiles.
     auto AT = A.emptyLike(0, 0, Op::ConjTrans);
-    // todo: we really only want to insert 1 column's worth at a time.
-    AT.insertLocalTiles();
 
     // No lookahead is possible, so no need to track dependencies --
     // just execute tasks in order. Also, priority isn't needed.
@@ -215,36 +220,26 @@ void ge2tb(
                             std::move(U_panel),
                             std::move(TUl_panel),
                             dwork_array, work_size,
-                            ib, max_panel_threads);
+                            ib, max_panel_threads );
 
             // triangle-triangle reductions
             // ttqrt handles tile transfers internally
             internal::ttqrt<Target::HostTask>(
                             std::move(U_panel),
-                            std::move(TUr_panel));
+                            std::move(TUr_panel), opts2 );
 
-            // if a trailing matrix exists
-            if (k < A_nt-1) {
+            //--------------------
+            // QR update trailing submatrix.
+            if (k+1 < A_nt) {
 
                 // bcast V across row for trailing matrix update
                 if (k < A_mt) {
-                    BcastList bcast_list_V_first;
                     BcastList bcast_list_V;
                     for (int64_t i = k; i < A_mt; ++i) {
-                        // send A(i, k) across row A(i, k+1:nt-1)
-                        // Vs in first_indices (except main diagonal one)
-                        // need three lives.
-                        if ((std::find(first_indices.begin(), first_indices.end(), i) != first_indices.end()) && (i > k)) {
-                            bcast_list_V_first.push_back(
-                                {i, k, {A.sub(i, i, k+1, A_nt-1)}});
-                        }
-                        else {
-                            bcast_list_V.push_back(
-                                {i, k, {A.sub(i, i, k+1, A_nt-1)}});
-                        }
+                        bcast_list_V.push_back(
+                            {i, k, {A.sub(i, i, k+1, A_nt-1)}});
                     }
-                    A.template listBcast(bcast_list_V_first, layout, 0, 3);
-                    A.template listBcast(bcast_list_V, layout, 0, 2);
+                    A.template listBcast(bcast_list_V, layout, 0);
                 }
 
                 // bcast TUlocal across row for trailing matrix update
@@ -270,11 +265,7 @@ void ge2tb(
                     }
                     TUreduce.template listBcast(bcast_list_T, layout);
                 }
-            }
 
-            //--------------------
-            // QR update trailing submatrix.
-            if (k+1 < A_nt) {
                 int64_t j = k+1;
                 auto A_trail_j = A.sub(k, A_mt-1, j, A_nt-1);
 
@@ -284,7 +275,8 @@ void ge2tb(
                                 std::move(U_panel),
                                 std::move(TUl_panel),
                                 std::move(A_trail_j),
-                                W.sub(k, A_mt-1, j, A_nt-1));
+                                W.sub(k, A_mt-1, j, A_nt-1),
+                                priority_0, queue_0, opts2 );
 
                 // Apply triangle-triangle reduction reflectors
                 // ttmqr handles the tile broadcasting internally
@@ -293,7 +285,39 @@ void ge2tb(
                                 std::move(U_panel),
                                 std::move(TUr_panel),
                                 std::move(A_trail_j),
-                                j);
+                                j, opts2 );
+            }
+
+            // Can release tiles parallel to the main execution
+            #pragma omp task
+            {
+                for (int64_t i = k; i < A_mt; ++i) {
+                    if (A.tileIsLocal(i, k)) {
+                        A.tileUpdateOrigin(i, k);
+                        A.releaseLocalWorkspaceTile(i, k);
+                    }
+                    else {
+                        A.releaseRemoteWorkspaceTile(i, k);
+                    }
+                }
+
+                for (int64_t i : first_indices) {
+                    if (TUlocal.tileIsLocal( i, k )) {
+                        // TUlocal and TUreduce have the same process distribution
+                        TUlocal.tileUpdateOrigin( i, k );
+                        TUlocal.releaseLocalWorkspaceTile( i, k );
+                        if (i != k) {
+                            // i == k is the root of the reduction tree
+                            // TUreduce( k, k ) isn't allocated
+                            TUreduce.tileUpdateOrigin( i, k );
+                            TUreduce.releaseLocalWorkspaceTile( i, k );
+                        }
+                    }
+                    else {
+                        TUlocal.releaseRemoteWorkspaceTile( i, k );
+                        TUreduce.releaseRemoteWorkspaceTile( i, k );
+                    }
+                }
             }
 
             //----------------------------------------
@@ -334,7 +358,8 @@ void ge2tb(
                 for (int64_t j = 0; j < V_panel.nt(); ++j) {
                     if (V_panel.tileIsLocal(0, j)) {
                         V_panel.tileGetForReading( 0, j, HostNum, LayoutConvert(layout) );
-                        VT_panel.tileGetForWriting( j, 0, HostNum, LayoutConvert(layout) );
+                        VT_panel.tileInsert( j, 0 );
+                        VT_panel.tileModified( j, 0, HostNum );
                         tile::deepConjTranspose( V_panel(0, j), VT_panel(j, 0) );
                     }
                 }
@@ -344,15 +369,15 @@ void ge2tb(
                                 std::move(VT_panel),
                                 std::move(TVlT_panel),
                                 dwork_array, work_size,
-                                ib, max_panel_threads);
+                                ib, max_panel_threads );
 
                 // Find first local tile, which is triangular factor
                 // (T in I - V T^H V^H), and copy it to TVlocal.
                 for (int64_t i = 0; i < TVlT_panel.mt(); ++i) {
                     if (TVl_panel.tileIsLocal(0, i)) {
-                        TVl_panel.tileInsert(0, i);
                         TVlT_panel.tileGetForReading( i, 0, HostNum, LayoutConvert(layout) );
-                        TVl_panel.tileGetForWriting( 0, i, HostNum, LayoutConvert(layout) );
+                        TVl_panel.tileInsert(0, i);
+                        TVl_panel.tileModified( 0, i, HostNum );
                         tile::gecopy( TVlT_panel(i, 0), TVl_panel(0, i) );
                         break;
                     }
@@ -364,39 +389,30 @@ void ge2tb(
                         VT_panel.tileGetForReading( j, 0, HostNum, LayoutConvert(layout) );
                         V_panel.tileGetForWriting( 0, j, HostNum, LayoutConvert(layout) );
                         tile::deepConjTranspose( VT_panel(j, 0), V_panel(0, j) );
+                        VT_panel.tileErase(j, 0, AllDevices);
                     }
                 }
-                // todo: VT_panel.clear();
                 //----------
 
                 // triangle-triangle reductions
                 // ttlqt handles tile transfers internally
                 internal::ttlqt<Target::HostTask>(
                                 std::move(V_panel),
-                                std::move(TVr_panel));
+                                std::move(TVr_panel),
+                                opts2 );
 
-                // if a trailing matrix exists
-                if (k < A_mt-1) {
+                //--------------------
+                // LQ update trailing submatrix
+                if (k+1 < A_mt) {
 
                     // bcast V down col for trailing matrix update
                     if (k+1 < A_nt) {
-                        BcastList bcast_list_V_first;
                         BcastList bcast_list_V;
                         for (int64_t j = k+1; j < A_nt; ++j) {
-                            // send A(k, j) down col A(k+1:mt-1, j)
-                            // Vs in first_indices (except main diagonal one)
-                            // need three lives.
-                            if ((std::find(first_indices.begin(), first_indices.end(), j) != first_indices.end()) && (j > k+1)) {
-                                bcast_list_V_first.push_back(
-                                    {k, j, {A.sub(k+1, A_mt-1, j, j)}});
-                            }
-                            else {
-                                bcast_list_V.push_back(
-                                    {k, j, {A.sub(k+1, A_mt-1, j, j)}});
-                            }
+                            bcast_list_V.push_back(
+                                {k, j, {A.sub(k+1, A_mt-1, j, j)}});
                         }
-                        A.template listBcast(bcast_list_V_first, layout, 0, 3);
-                        A.template listBcast(bcast_list_V, layout, 0, 2);
+                        A.template listBcast(bcast_list_V, layout, 0);
                     }
 
                     // bcast TVlocal down col for trailing matrix update
@@ -422,11 +438,7 @@ void ge2tb(
                         }
                         TVreduce.template listBcast(bcast_list_T, layout);
                     }
-                }
 
-                //--------------------
-                // LQ update trailing submatrix
-                if (k+1 < A_mt) {
                     int64_t i = k+1;
                     auto A_trail_i = A.sub(i, A_mt-1, k+1, A_nt-1);
 
@@ -436,7 +448,8 @@ void ge2tb(
                                     std::move(V_panel),
                                     std::move(TVl_panel),
                                     std::move(A_trail_i),
-                                    W.sub(i, A_mt-1, k+1, A_nt-1));
+                                    W.sub(i, A_mt-1, k+1, A_nt-1),
+                                    priority_0, queue_0, opts2 );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -445,7 +458,39 @@ void ge2tb(
                                     std::move(V_panel),
                                     std::move(TVr_panel),
                                     std::move(A_trail_i),
-                                    i);
+                                    i, opts2 );
+                }
+
+                // Can release tiles parallel to the main execution
+                #pragma omp task
+                {
+                    for (int64_t j = k+1; j < A_nt; ++j) {
+                        if (A.tileIsLocal(k, j)) {
+                            A.tileUpdateOrigin(k, j);
+                            A.releaseLocalWorkspaceTile(k, j);
+                        }
+                        else {
+                            A.releaseRemoteWorkspaceTile(k, j);
+                        }
+                    }
+
+                    for (int64_t j : first_indices) {
+                        if (TVlocal.tileIsLocal( k, j )) {
+                            // TVlocal and TVreduce have the same process distribution
+                            TVlocal.tileUpdateOrigin( k, j );
+                            TVlocal.releaseLocalWorkspaceTile( k, j );
+                            if (j != k+1) {
+                                // j == k+1 is the root of the reduction tree
+                                // TVreduce( k, k+1 ) isn't allocated
+                                TVreduce.tileUpdateOrigin( k, j );
+                                TVreduce.releaseLocalWorkspaceTile( k, j );
+                            }
+                        }
+                        else {
+                            TVlocal.releaseRemoteWorkspaceTile( k, j );
+                            TVreduce.releaseRemoteWorkspaceTile( k, j );
+                        }
+                    }
                 }
             }
         }

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -365,7 +365,7 @@ void gelqf(
 
                 for (int64_t j : first_indices) {
                     if (Tlocal.tileIsLocal( k, j )) {
-                        // Tlocal and Treduce have the have process distribution
+                        // Tlocal and Treduce have the same process distribution
                         Tlocal.tileUpdateOrigin( k, j );
                         Tlocal.releaseLocalWorkspaceTile( k, j );
                         if (j != k) {

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -7,50 +7,11 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "internal/internal.hh"
+#include "internal/internal_util.hh"
 
 namespace slate {
 
 namespace impl {
-
-//------------------------------------------------------------------------------
-/// An auxiliary routine to find each rank's first (top-most) row
-/// in panel k.
-///
-/// @param[in] A_panel
-///     Current panel, which is a sub of the input matrix $A$.
-///
-/// @param[in] k
-///     Index of the current panel in the input matrix $A$.
-///
-/// @param[out] first_indices
-///     The array of computed indices.
-///
-/// @ingroup geqrf_impl
-///
-template <typename scalar_t>
-void gelqf_compute_first_indices(
-    Matrix<scalar_t>& A_panel, int64_t k,
-    std::vector< int64_t >& first_indices )
-{
-    // Find ranks in this row.
-    std::set<int> ranks_set;
-    A_panel.getRanks(&ranks_set);
-    assert(ranks_set.size() > 0);
-
-    // Find each rank's first (left-most) col in this panel,
-    // where the triangular tile resulting from local gelqf panel
-    // will reside.
-    first_indices.reserve(ranks_set.size());
-    for (int r: ranks_set) {
-        for (int64_t j = 0; j < A_panel.nt(); ++j) {
-            if (A_panel.tileRank(0, j) == r) {
-                first_indices.push_back(j+k);
-                break;
-            }
-        }
-    }
-    // TODO try to combine this w/ geqrf version
-}
 
 //------------------------------------------------------------------------------
 /// Distributed parallel LQ factorization.
@@ -197,8 +158,8 @@ void gelqf(
             auto  AT_panel =      AT.sub(k, A_nt-1, k, k);
             auto TlT_panel = TlocalT.sub(k, A_nt-1, k, k);
 
-            std::vector< int64_t > first_indices;
-            gelqf_compute_first_indices(A_panel, k, first_indices);
+            std::vector< int64_t > first_indices
+                            = internal::gelqf_compute_first_indices(A_panel, k);
 
             // panel, high priority
             #pragma omp task depend(inout:block[k]) priority(1)

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -318,7 +318,7 @@ void geqrf(
 
                 for (int64_t i : first_indices) {
                     if (Tlocal.tileIsLocal( i, k )) {
-                        // Tlocal and Treduce have the have process distribution
+                        // Tlocal and Treduce have the same process distribution
                         Tlocal.tileUpdateOrigin( i, k );
                         Tlocal.releaseLocalWorkspaceTile( i, k );
                         if (i != k) {

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -201,8 +201,8 @@ void he2hb(
             #pragma omp task slate_omp_default_none \
                 depend( inout:block[ k ] ) \
                 shared( dwork_array ) \
-                firstprivate(  A_panel, Tlocal_panel, Treduce_panel, \
-                               ib, max_panel_threads, work_size, priority_1 )
+                firstprivate(  A_panel, Tlocal_panel, Treduce_panel, ib, \
+                               max_panel_threads, work_size, priority_1, opts2 )
             {
                 internal::geqrf<target>(
                     std::move( A_panel ),
@@ -405,7 +405,7 @@ void he2hb(
                         firstprivate( zero, half, one, r_one, i0, k, nt, \
                                       panel_rank, panel_rank_rows, \
                                       panel_rank_rows_sub, mpi_rank, \
-                                      layout, layoutc )
+                                      layout, layoutc, priority_0, queue_0, opts2 )
                     {
                         // Compute W = A V T.
                         // 1a. Wi_part = sum_j Aij Vj, local partial sum,
@@ -582,7 +582,7 @@ void he2hb(
                     depend( inout:block[ nt-1 ] ) \
                     depend( inout:fetch_trailing[ 0 ] ) \
                     shared( A ) \
-                    firstprivate( A_panel, Treduce_panel, k, nt )
+                    firstprivate( A_panel, Treduce_panel, k, nt, tag_0, opts2 )
                 {
                     // Do 2-sided Hermitian update:
                     // 3. A = Q^H A Q
@@ -598,8 +598,8 @@ void he2hb(
             // Release workspace tiles
             #pragma omp task slate_omp_default_none \
                 depend( inout:block[ k ] ) \
-                shared( A, Tlocal ) \
-                firstprivate( A_panel, k, nt )
+                shared( A, Tlocal, Treduce ) \
+                firstprivate( k, nt, first_indices )
             {
                 for (int64_t i = k+1; i < nt; ++i) {
                     if (A.tileIsLocal( i, k )) {

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -6,6 +6,7 @@
 #include "slate/slate.hh"
 #include "slate/HermitianMatrix.hh"
 #include "internal/internal.hh"
+#include "internal/internal_util.hh"
 
 namespace slate {
 
@@ -184,16 +185,8 @@ void he2hb(
             // Find each rank's first (top-most) row in this panel,
             // where the triangular tile resulting from local geqrf panel
             // will reside.
-            std::vector< int64_t > first_indices;
-            first_indices.reserve( panel_ranks.size() );
-            for (int r : panel_ranks) {
-                for (int64_t i = 0; i < A_panel.mt(); ++i) {
-                    if (A_panel.tileRank( i, 0 ) == r) {
-                        first_indices.push_back( i+k+1 );
-                        break;
-                    }
-                }
-            }
+            std::vector< int64_t > first_indices
+                          = internal::geqrf_compute_first_indices(A_panel, k+1);
 
             //--------------------
             // QR of panel

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -598,18 +598,13 @@ void he2hb(
             // Release workspace tiles
             #pragma omp task slate_omp_default_none \
                 depend( inout:block[ k ] ) \
-                shared( A, Tlocal, Treduce ) \
+                shared( A_panel, Tlocal, Treduce ) \
                 firstprivate( k, nt, first_indices )
             {
-                for (int64_t i = k+1; i < nt; ++i) {
-                    if (A.tileIsLocal( i, k )) {
-                        A.tileUpdateOrigin( i, k );
-                        A.releaseLocalWorkspaceTile( i, k );
-                    }
-                    else {
-                        A.releaseRemoteWorkspaceTile( i, k );
-                    }
-                }
+                // Ensure the origin is up to date, then remove the panel's workspace
+                A_panel.tileUpdateAllOrigin();
+                A_panel.releaseLocalWorkspace();
+                A_panel.releaseRemoteWorkspace();
 
                 for (int64_t i : first_indices) {
                     if (Tlocal.tileIsLocal( i, k )) {

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -560,7 +560,8 @@ void he2hb_hemm(HermitianMatrix<scalar_t>&& A,
             Matrix<scalar_t>&& B,
             Matrix<scalar_t>&& C,
             std::vector<int64_t>& panel_rank_rows,
-            int priority=0, int64_t queue_index=0);
+            int priority=0, int64_t queue_index=0,
+            Options const& opts = Options());
 
 //-----------------------------------------
 // he2hb_trmm()
@@ -569,7 +570,8 @@ void he2hb_trmm(HermitianMatrix<scalar_t>&& AH,
             Matrix<scalar_t>&& A,
             Matrix<scalar_t>&& B,
             std::vector<int64_t>& panel_rank_rows,
-            int priority=0, int64_t queue_index=0);
+            int priority=0, int64_t queue_index=0,
+            Options const& opts = Options());
 
 
 //-----------------------------------------
@@ -579,7 +581,8 @@ void he2hb_gemm(scalar_t alpha, Matrix<scalar_t>&& A,
                                 Matrix<scalar_t>&& B,
                 scalar_t beta,  Matrix<scalar_t>&& T,
                 int panel_rank,
-                int priority=0, int64_t queue_index=0);
+                int priority=0, int64_t queue_index=0,
+                Options const& opts = Options());
 
 //-----------------------------------------
 // he2hb_her2k_offdiag_ranks()
@@ -589,7 +592,8 @@ void he2hb_her2k_offdiag_ranks(
                         Matrix<scalar_t>&& B,
         scalar_t beta,  HermitianMatrix<scalar_t>&& C,
         std::vector<int64_t>& panel_rank_rows,
-        int priority=0, int64_t queue_index=0);
+        int priority=0, int64_t queue_index=0,
+        Options const& opts = Options());
 
 //-----------------------------------------
 // ttqrt()
@@ -629,7 +633,7 @@ void hettmqr(Op op,
              Matrix<scalar_t>&& A,
              Matrix<scalar_t>&& T,
              HermitianMatrix<scalar_t>&& C,
-             int tag=0);
+             int tag=0, Options const& opts = Options());
 
 //-----------------------------------------
 // unmqr()

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -119,7 +119,8 @@ template <Target target=Target::HostTask,
           typename src_scalar_t, typename dst_scalar_t>
 void copy(BaseTrapezoidMatrix<src_scalar_t>&& A,
           BaseTrapezoidMatrix<dst_scalar_t>&& B,
-          int priority=0, int queue_index=0);
+          int priority=0, int queue_index=0,
+          Options const& opts = Options());
 
 //-----------------------------------------
 // scale()

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -216,10 +216,10 @@ void hemm(Side side,
 // hemmA()
 template <Target target=Target::HostTask, typename scalar_t>
 void hemmA(Side side,
-          scalar_t alpha, HermitianMatrix<scalar_t>&& A,
-                          Matrix<scalar_t>&& B,
-          scalar_t beta,  Matrix<scalar_t>&& C,
-          int priority=0);
+           scalar_t alpha, HermitianMatrix<scalar_t>&& A,
+                           Matrix<scalar_t>&& B,
+           scalar_t beta,  Matrix<scalar_t>&& C,
+           int priority=0, Options const& opts = Options());
 
 //-----------------------------------------
 // herk()

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -151,6 +151,12 @@ void gemm(internal::TargetType<Target::HostNest>,
     assert(A.mt() == C.mt());
     assert(B.nt() == C.nt());
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     int err = 0;
     std::string err_msg;
     int64_t C_mt = C.mt();
@@ -168,9 +174,11 @@ void gemm(internal::TargetType<Target::HostNest>,
                     tile::gemm(
                         alpha, A(i, 0), B(0, j),
                         beta,  C(i, j) );
-                    // todo: shouldn't tileRelease()?
-                    A.tileTick(i, 0);
-                    B.tileTick(0, j);
+                    if (call_tile_tick) {
+                        // todo: shouldn't tileRelease()?
+                        A.tileTick(i, 0);
+                        B.tileTick(0, j);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;
@@ -211,6 +219,12 @@ void gemm(internal::TargetType<Target::HostBatch>,
     assert(B.mt() == 1);
     assert(A.mt() == C.mt());
     assert(B.nt() == C.nt());
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     // load off-diagonal tiles to host, if not there
     // also count tiles
@@ -357,12 +371,14 @@ void gemm(internal::TargetType<Target::HostBatch>,
             // mkl_set_num_threads_local(1);
         }
 
-        for (int64_t i = 0; i < C.mt(); ++i) {
-            for (int64_t j = 0; j < C.nt(); ++j) {
-                if (C.tileIsLocal(i, j)) {
-                    // todo: shouldn't tileRelease()?
-                    A.tileTick(i, 0);
-                    B.tileTick(0, j);
+        if (call_tile_tick) {
+            for (int64_t i = 0; i < C.mt(); ++i) {
+                for (int64_t j = 0; j < C.nt(); ++j) {
+                    if (C.tileIsLocal(i, j)) {
+                        // todo: shouldn't tileRelease()?
+                        A.tileTick(i, 0);
+                        B.tileTick(0, j);
+                    }
                 }
             }
         }

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -163,7 +163,8 @@ void gemm(internal::TargetType<Target::HostNest>,
     int64_t C_nt = C.nt();
 
     #pragma omp parallel for collapse(2) schedule(dynamic, 1) slate_omp_default_none \
-        shared(A, B, C, err, err_msg) firstprivate(C_nt, C_mt, layout, alpha, beta)
+        shared(A, B, C, err, err_msg) firstprivate(C_nt, C_mt, layout, alpha, beta) \
+        firstprivate(call_tile_tick)
     for (int64_t i = 0; i < C_mt; ++i) {
         for (int64_t j = 0; j < C_nt; ++j) {
             if (C.tileIsLocal(i, j)) {

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -161,7 +161,7 @@ void gemmA(internal::TargetType<Target::HostTask>,
     for (int64_t i = 0; i < A.mt(); ++i) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, err ) \
-            firstprivate(i, alpha, beta, zero, one, c_tile_acquired) \
+            firstprivate(i, alpha, beta, zero, one, c_tile_acquired, call_tile_tick) \
             priority(priority)
         {
             try {

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -81,6 +81,12 @@ void gemmA(internal::TargetType<Target::HostTask>,
     assert( A.nt() == B.mt() );
     assert( A.mt() == C.mt() );
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     const scalar_t zero = 0.0;
     const scalar_t one  = 1.0;
 
@@ -176,8 +182,10 @@ void gemmA(internal::TargetType<Target::HostTask>,
 
                             beta_j = one;
 
-                            A.tileTick( i, j );
-                            B.tileTick( j, k );
+                            if (call_tile_tick) {
+                                A.tileTick( i, j );
+                                B.tileTick( j, k );
+                            }
                             Cik_modified = true;
                         }
                     }

--- a/src/internal/internal_he2hb_gemm.cc
+++ b/src/internal/internal_he2hb_gemm.cc
@@ -66,7 +66,7 @@ void he2hb_gemm(
     for (int64_t i = 0; i < A.mt(); ++i) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C ) \
-            firstprivate( alpha, beta, panel_rank, i, layoutc ) \
+            firstprivate( alpha, beta, panel_rank, i, layoutc, call_tile_tick ) \
             priority( priority )
         {
             scalar_t beta_ = beta;
@@ -131,7 +131,7 @@ void he2hb_gemm(
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, err ) \
             firstprivate( alpha, beta, panel_rank, queue_index, device, \
-                          layout, layoutc ) \
+                          layout, layoutc, call_tile_tick ) \
             priority( priority )
         {
             Op opA = A.op();

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -13,7 +13,7 @@ namespace internal {
 
 //------------------------------------------------------------------------------
 /// Apply local reflectors on a Hermitian trailing submatrix. Compute Wi = sum_j Aij Vj.
-/// Wher, A is the Hermitian trailing submatrix.
+/// Where, A is the Hermitian trailing submatrix.
 /// B contains the local reflectors Vj from local QR factorization
 /// of a panel of A
 /// C is the output matrix contains the Wi = sum_j Aij Vj

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -66,7 +66,7 @@ void he2hb_hemm(
     #pragma omp taskgroup
     for (int64_t i = 0; i < mt; ++i) {
         #pragma omp task slate_omp_default_none \
-            shared( A, B, C, panel_rank_rows ) \
+            shared( A, B, C, panel_rank_rows, call_tile_tick ) \
             firstprivate( one, i, layoutc )
         {
             for (int64_t j : panel_rank_rows) {
@@ -202,7 +202,7 @@ void he2hb_hemm(
     for (int device = 0; device < C.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( one, device, mt, num_queues, layout ) \
+            firstprivate( one, device, mt, num_queues, layout, call_tile_tick ) \
             priority( priority )
         {
             trace::Block trace_block( "blas::batch::he2hb_hemm" );

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -28,10 +28,11 @@ void he2hb_hemm(
     Matrix<scalar_t>&& B,
     Matrix<scalar_t>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index)
+    int priority, int64_t queue_index,
+    Options const& opts )
 {
     he2hb_hemm( internal::TargetType<target>(),
-                A, B, C, panel_rank_rows, priority, queue_index );
+                A, B, C, panel_rank_rows, priority, queue_index, opts );
 }
 
 //------------------------------------------------------------------------------
@@ -46,7 +47,8 @@ void he2hb_hemm(
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index)
+    int priority, int64_t queue_index,
+    Options const& opts )
 {
     int64_t mt = A.mt();
     const scalar_t one  = 1;
@@ -54,6 +56,12 @@ void he2hb_hemm(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layoutc = LayoutConvert( layout );
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     #pragma omp taskgroup
     for (int64_t i = 0; i < mt; ++i) {
@@ -77,8 +85,10 @@ void he2hb_hemm(
                             tile::gemm( one, A( i, j ), B( j, 0 ),
                                         one, C( i, 0 ) );
                         }
-                        A.tileTick( i, j );
-                        B.tileTick( j, 0 );
+                        if (call_tile_tick) {
+                            A.tileTick( i, j );
+                            B.tileTick( j, 0 );
+                        }
                     }
                 }
                 else { // upper
@@ -88,8 +98,10 @@ void he2hb_hemm(
                         C.tileGetForWriting( i, 0, layoutc );
                         tile::gemm( one, conj_transpose( A( j, i ) ), B( j, 0 ),
                                     one, C( i, 0 ) );
-                        A.tileTick( j, i );
-                        B.tileTick( j, 0 );
+                        if (call_tile_tick) {
+                            A.tileTick( j, i );
+                            B.tileTick( j, 0 );
+                        }
                     }
                 }
             }
@@ -111,7 +123,8 @@ void he2hb_hemm(
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& C,
     std::vector<int64_t> panel_rank_rows,
-    int priority, int64_t queue_index )
+    int priority, int64_t queue_index,
+    Options const& opts )
 {
     int64_t mt = A.mt();
     const scalar_t one  = 1;
@@ -120,6 +133,12 @@ void he2hb_hemm(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layoutc = LayoutConvert( layout );
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     #pragma omp taskgroup
     for (int device = 0; device < C.num_devices(); ++device) {
@@ -257,31 +276,33 @@ void he2hb_hemm(
                 queue->sync();
             }
 
-            // todo: release tiles in top-level routine.
-            // for (int64_t j : panel_rank_rows) {
-            //     for (int64_t i = 0; i < mt; ++i) {
-            //         if (i >= j) { // lower or diagonal
-            //             if (A.tileIsLocal( i, j )
-            //                 && device == C.tileDevice( i, 0 )) {
-            //                 C.tileModified( i, 0, device );
-            //                 A.tileRelease( i, j, device );
-            //                 B.tileRelease( j, 0, device );
-            //                 A.tileTick( i, j );
-            //                 B.tileTick( j, 0 );
-            //             }
-            //         }
-            //         else { // upper
-            //             if (A.tileIsLocal( j, i )
-            //                 && device == C.tileDevice( i, 0 )) {
-            //                 C.tileModified( i, 0, device );
-            //                 A.tileRelease( j, i, device );
-            //                 B.tileRelease( j, 0, device );
-            //                 A.tileTick( j, i );
-            //                 B.tileTick( j, 0 );
-            //             }
-            //         }
-            //     } //i loop
-            // } // j loop
+            if (call_tile_tick) {
+                // todo: release tiles in top-level routine.
+                // for (int64_t j : panel_rank_rows) {
+                //     for (int64_t i = 0; i < mt; ++i) {
+                //         if (i >= j) { // lower or diagonal
+                //             if (A.tileIsLocal( i, j )
+                //                 && device == C.tileDevice( i, 0 )) {
+                //                 C.tileModified( i, 0, device );
+                //                 A.tileRelease( i, j, device );
+                //                 B.tileRelease( j, 0, device );
+                //                 A.tileTick( i, j );
+                //                 B.tileTick( j, 0 );
+                //             }
+                //         }
+                //         else { // upper
+                //             if (A.tileIsLocal( j, i )
+                //                 && device == C.tileDevice( i, 0 )) {
+                //                 C.tileModified( i, 0, device );
+                //                 A.tileRelease( j, i, device );
+                //                 B.tileRelease( j, 0, device );
+                //                 A.tileTick( j, i );
+                //                 B.tileTick( j, 0 );
+                //             }
+                //         }
+                //     } //i loop
+                // } // j loop
+            }
         } // pragma
     } // devices
 }
@@ -312,6 +333,13 @@ void he2hb_hemm(internal::TargetType<Target::Devices>,
     assert( C.num_devices() > 0 );
     scalar_t alpha = 1.;
     scalar_t beta = 1.;
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
 
     // check if there is a cleanup tile
     int64_t i_interior = mt;
@@ -739,29 +767,31 @@ void he2hb_hemm(internal::TargetType<Target::Devices>,
 
                 queue->sync();
 
-                // todo: release tiles in top-level routine.
-                // for (int64_t i = 0; i < mt; ++i) {
-                //     if (i >= j) { // lower or diagonal
-                //         if (A.tileIsLocal( i, j )) {
-                //             if (device == C.tileDevice( i, 0 )) {
-                //                 A.tileRelease( i, j, device );
-                //                 B.tileRelease( j, 0, device );
-                //                 A.tileTick( i, j );
-                //                 B.tileTick( j, 0 );
-                //             }
-                //         }
-                //     }
-                //     else { // upper
-                //         if (A.tileIsLocal( j, i )) {
-                //             if (device == C.tileDevice( i, 0 )) {
-                //                 A.tileRelease( j, i, device );
-                //                 B.tileRelease( j, 0, device );
-                //                 A.tileTick( j, i );
-                //                 B.tileTick( j, 0 );
-                //             }
-                //         }
-                //     }
-                // }
+                if (call_tile_tick) {
+                    // todo: release tiles in top-level routine.
+                    // for (int64_t i = 0; i < mt; ++i) {
+                    //     if (i >= j) { // lower or diagonal
+                    //         if (A.tileIsLocal( i, j )) {
+                    //             if (device == C.tileDevice( i, 0 )) {
+                    //                 A.tileRelease( i, j, device );
+                    //                 B.tileRelease( j, 0, device );
+                    //                 A.tileTick( i, j );
+                    //                 B.tileTick( j, 0 );
+                    //             }
+                    //         }
+                    //     }
+                    //     else { // upper
+                    //         if (A.tileIsLocal( j, i )) {
+                    //             if (device == C.tileDevice( i, 0 )) {
+                    //                 A.tileRelease( j, i, device );
+                    //                 B.tileRelease( j, 0, device );
+                    //                 A.tileTick( j, i );
+                    //                 B.tileTick( j, 0 );
+                    //             }
+                    //         }
+                    //     }
+                    // }
+                }
             } // j = panel_rank_rows
         } // task
     } // device
@@ -781,7 +811,8 @@ void he2hb_hemm<Target::HostTask, float>(
     Matrix<float>&& B,
     Matrix<float>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -790,7 +821,8 @@ void he2hb_hemm<Target::HostTask, double>(
     Matrix<double>&& B,
     Matrix<double>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -799,7 +831,8 @@ void he2hb_hemm< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& B,
     Matrix< std::complex<float> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -808,7 +841,8 @@ void he2hb_hemm< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& B,
     Matrix< std::complex<double> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -817,7 +851,8 @@ void he2hb_hemm<Target::Devices, float>(
     Matrix<float>&& B,
     Matrix<float>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -826,7 +861,8 @@ void he2hb_hemm<Target::Devices, double>(
     Matrix<double>&& B,
     Matrix<double>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -835,7 +871,8 @@ void he2hb_hemm< Target::Devices, std::complex<float> >(
     Matrix< std::complex<float> >&& B,
     Matrix< std::complex<float> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 // ----------------------------------------
 template
@@ -844,7 +881,8 @@ void he2hb_hemm< Target::Devices, std::complex<double> >(
     Matrix< std::complex<double> >&& B,
     Matrix< std::complex<double> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index);
+    int priority, int64_t queue_index,
+    Options const& opts );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
+++ b/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
@@ -66,7 +66,7 @@ void he2hb_her2k_offdiag_ranks(
     for (int64_t j = 0; j < nt; ++j) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( alpha, beta, j, layoutc )
+            firstprivate( alpha, beta, j, layoutc, call_tile_tick )
         {
             for (int64_t i : panel_rank_rows) {
                 // todo: if HermitianMatrix returned conjTrans
@@ -154,6 +154,7 @@ void he2hb_her2k_offdiag_ranks(
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, err, panel_rank_rows ) \
             firstprivate( alpha, beta, device, nt, layout, layoutc, queue_index ) \
+            firstprivate( call_tile_tick ) \
             priority( priority )
         {
             Op opA = A.op();

--- a/src/internal/internal_he2hb_trmm.cc
+++ b/src/internal/internal_he2hb_trmm.cc
@@ -72,7 +72,7 @@ void he2hb_trmm(
     for (int64_t i = 0; i < B.mt(); ++i) {
         #pragma omp task slate_omp_default_none \
             shared( A0, AH, B, panel_rank_rows ) \
-            firstprivate( one, i, mpi_rank, layoutc ) \
+            firstprivate( one, i, mpi_rank, layoutc, call_tile_tick ) \
             priority( priority )
         {
             int rank_lower = -1;
@@ -147,7 +147,7 @@ void he2hb_trmm(
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, AH, B, panel_rank_rows ) \
-            firstprivate( device, queue_index, mpi_rank, layout, layoutc ) \
+            firstprivate( device, queue_index, mpi_rank, layout, layoutc, call_tile_tick ) \
             priority( priority )
         {
             std::set<ij_tuple> B_tiles_set, A0_tiles_set;

--- a/src/internal/internal_he2hb_trmm.cc
+++ b/src/internal/internal_he2hb_trmm.cc
@@ -13,7 +13,7 @@ namespace internal {
 
 //------------------------------------------------------------------------------
 /// Triangular matrix multiply. Compute B = B A
-/// AH is a Hermitian matrix. It needed here just to check if the rank is an
+/// AH is a Hermitian matrix. It's needed here just to check if the rank is an
 /// upper or lower rank that contribute to compute Bi, i = 0:mt-1.
 /// B is a block cloumn.
 /// A contains upper triangular or trapezoid T.

--- a/src/internal/internal_hemm.cc
+++ b/src/internal/internal_hemm.cc
@@ -171,7 +171,7 @@ void hemm(internal::TargetType<Target::HostNest>,
     int err = 0;
     if (side == Side::Left) {
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(layout, side, alpha, beta)
+            shared(A, B, C, err) firstprivate(layout, side, alpha, beta, call_tile_tick)
         for (int64_t j = 0; j < C.nt(); ++j) {
             if (C.tileIsLocal(0, j)) {
                 try {
@@ -197,7 +197,7 @@ void hemm(internal::TargetType<Target::HostNest>,
     else {
         // side == Right
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(layout, side, alpha, beta)
+            shared(A, B, C, err) firstprivate(layout, side, alpha, beta, call_tile_tick)
         for (int64_t i = 0; i < C.mt(); ++i) {
             if (C.tileIsLocal(i, 0)) {
                 try {

--- a/src/internal/internal_hemm.cc
+++ b/src/internal/internal_hemm.cc
@@ -162,6 +162,12 @@ void hemm(internal::TargetType<Target::HostNest>,
     //       by watching 'layout' and 'C(i, j).layout()'
     const Layout layout = Layout::ColMajor;
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     int err = 0;
     if (side == Side::Left) {
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
@@ -176,9 +182,11 @@ void hemm(internal::TargetType<Target::HostNest>,
                         side,
                         alpha, A(0, 0), B(0, j),
                         beta,  C(0, j) );
-                    // todo: should tileRelease()?
-                    A.tileTick(0, 0);
-                    B.tileTick(0, j);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(0, 0);
+                        B.tileTick(0, j);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;
@@ -200,9 +208,11 @@ void hemm(internal::TargetType<Target::HostNest>,
                         side,
                         alpha, A(0, 0), B(i, 0),
                         beta,  C(i, 0) );
-                    // todo: should tileRelease()?
-                    A.tileTick(0, 0);
-                    B.tileTick(i, 0);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(0, 0);
+                        B.tileTick(i, 0);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;

--- a/src/internal/internal_hemmA.cc
+++ b/src/internal/internal_hemmA.cc
@@ -89,7 +89,8 @@ void hemmA(internal::TargetType<Target::HostTask>,
             if (A.tileIsLocal(i, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B, C, err ) \
-                    firstprivate(i, j, layout, side, alpha, beta) priority(priority)
+                    firstprivate(i, j, layout, side, alpha, beta, call_tile_tick) \
+                    priority(priority)
                 {
                     try {
                         A.tileGetForReading(i, j, LayoutConvert(layout));
@@ -148,7 +149,7 @@ void hemmA(internal::TargetType<Target::HostNest>,
     int err = 0;
     if (side == Side::Left) {
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(side, layout, alpha, beta)
+            shared(A, B, C, err) firstprivate(side, layout, alpha, beta, call_tile_tick)
         for (int64_t j = 0; j < C.nt(); ++j) {
             if (C.tileIsLocal(0, j)) {
                 try {
@@ -174,7 +175,7 @@ void hemmA(internal::TargetType<Target::HostNest>,
     else {
         // side == Right
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(side, layout, alpha, beta)
+            shared(A, B, C, err) firstprivate(side, layout, alpha, beta, call_tile_tick)
         for (int64_t i = 0; i < C.mt(); ++i) {
             if (C.tileIsLocal(i, 0)) {
                 try {

--- a/src/internal/internal_her2k.cc
+++ b/src/internal/internal_her2k.cc
@@ -183,7 +183,7 @@ void her2k(internal::TargetType<Target::HostNest>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, B, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));
@@ -210,7 +210,7 @@ void her2k(internal::TargetType<Target::HostNest>,
 
     //  #pragma omp parallel for collapse(2) schedule(dynamic, 1) num_threads(...) default(none)
     #pragma omp parallel for collapse(2) schedule(dynamic, 1) slate_omp_default_none \
-        shared(A, B, C, err) firstprivate(C_nt, C_mt, layout, alpha, beta_)
+        shared(A, B, C, err) firstprivate(C_nt, C_mt, layout, alpha, beta_, call_tile_tick)
     for (int64_t j = 0; j < C_nt; ++j) {
         for (int64_t i = 0; i < C_mt; ++i) {  // full
             if (i >= j+1) {                     // strictly lower
@@ -286,7 +286,7 @@ void her2k(internal::TargetType<Target::HostBatch>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, B, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));

--- a/src/internal/internal_herk.cc
+++ b/src/internal/internal_herk.cc
@@ -167,7 +167,7 @@ void herk(internal::TargetType<Target::HostNest>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));
@@ -193,7 +193,7 @@ void herk(internal::TargetType<Target::HostNest>,
 
     // #pragma omp parallel for collapse(2) schedule(dynamic, 1) num_threads(...) default(none)
     #pragma omp parallel for collapse(2) schedule(dynamic, 1) slate_omp_default_none \
-        shared(A, C, err) firstprivate(C_nt, C_mt, layout, beta_, alpha_)
+        shared(A, C, err) firstprivate(C_nt, C_mt, layout, beta_, alpha_, call_tile_tick)
     for (int64_t j = 0; j < C_nt; ++j) {
         for (int64_t i = 0; i < C_mt; ++i) {  // full
             if (i >= j+1) {                    // strictly lower
@@ -258,7 +258,7 @@ void herk(internal::TargetType<Target::HostBatch>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));

--- a/src/internal/internal_hettmqr.cc
+++ b/src/internal/internal_hettmqr.cc
@@ -52,10 +52,10 @@ void hettmqr(
     Matrix<scalar_t>&& V,
     Matrix<scalar_t>&& T,
     HermitianMatrix<scalar_t>&& C,
-    int tag)
+    int tag, Options const& opts )
 {
     hettmqr( internal::TargetType<target>(),
-             op, V, T, C, tag );
+             op, V, T, C, tag, opts );
 }
 
 //------------------------------------------------------------------------------
@@ -71,7 +71,7 @@ void hettmqr(
     Matrix<scalar_t>& V,
     Matrix<scalar_t>& T,
     HermitianMatrix<scalar_t>& C,
-    int tag )
+    int tag, Options const& opts )
 {
     trace::Block trace_block("internal::hettmqr");
     using blas::conj;
@@ -82,6 +82,12 @@ void hettmqr(
     int64_t V_mt = V.mt();
     assert(V.nt() == 1);
     assert(V_mt == C.mt());
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     // Find ranks in this column of V.
     std::set<int> ranks_set;
@@ -185,8 +191,10 @@ void hettmqr(
 
                 C.tileSend(i1, i1, src11, tag);
                 C.tileSend(i2, i2, src22, tag);
-                C.tileTick(i1, i1);
-                C.tileTick(i2, i2);
+                if (call_tile_tick) {
+                    C.tileTick(i1, i1);
+                    C.tileTick(i2, i2);
+                }
                 C.tileErase(i1, i2);  // Discard results; equals C(i2, i1)^H.
             }
 
@@ -244,9 +252,11 @@ void hettmqr(
                         tpmqrt(Side::Left, op, std::min(V.tileMb(i2), V.tileNb(0)),
                                V(i2, 0), T(i2, 0), C(i1, j), C(i2, j));
 
-                        // todo: should tileRelease()?
-                        V.tileTick(i2, 0);
-                        T.tileTick(i2, 0);
+                        if (call_tile_tick) {
+                            // todo: should tileRelease()?
+                            V.tileTick(i2, 0);
+                            T.tileTick(i2, 0);
+                        }
                     }
                 }
             } // for j
@@ -275,7 +285,9 @@ void hettmqr(
                               : C.tileRank(j, i1));
                     // Send updated tile back.
                     C.tileSend(i1, j, src, tag);
-                    C.tileTick(i1, j);
+                    if (call_tile_tick) {
+                        C.tileTick(i1, j);
+                    }
                 }
             } // for j
         } // for index
@@ -317,9 +329,11 @@ void hettmqr(
                         tpmqrt(Side::Right, opR, std::min(V.tileMb(j2), V.tileNb(0)),
                                V(j2, 0), T(j2, 0), C(i, j1), C(i, j2));
 
-                        // todo: should tileRelease()?
-                        V.tileTick(j2, 0);
-                        T.tileTick(j2, 0);
+                        if (call_tile_tick) {
+                            // todo: should tileRelease()?
+                            V.tileTick(j2, 0);
+                            T.tileTick(j2, 0);
+                        }
                     }
                 }
             } // for i
@@ -336,7 +350,9 @@ void hettmqr(
 
                     // Send updated tile back.
                     C.tileSend(i, j1, src, tag);
-                    C.tileTick(i, j1);
+                    if (call_tile_tick) {
+                        C.tileTick(i, j1);
+                    }
                 }
             } // for i
         } // for index
@@ -359,7 +375,7 @@ void hettmqr<Target::HostTask, float>(
     Matrix<float>&& V,
     Matrix<float>&& T,
     HermitianMatrix<float>&& C,
-    int tag);
+    int tag, Options const& opts);
 
 // ----------------------------------------
 template
@@ -368,7 +384,7 @@ void hettmqr<Target::HostTask, double>(
     Matrix<double>&& V,
     Matrix<double>&& T,
     HermitianMatrix<double>&& C,
-    int tag);
+    int tag, Options const& opts);
 
 // ----------------------------------------
 template
@@ -377,7 +393,7 @@ void hettmqr< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& V,
     Matrix< std::complex<float> >&& T,
     HermitianMatrix< std::complex<float> >&& C,
-    int tag);
+    int tag, Options const& opts);
 
 // ----------------------------------------
 template
@@ -386,7 +402,7 @@ void hettmqr< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& V,
     Matrix< std::complex<double> >&& T,
     HermitianMatrix< std::complex<double> >&& C,
-    int tag);
+    int tag, Options const& opts);
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_hettmqr.cc
+++ b/src/internal/internal_hettmqr.cc
@@ -241,7 +241,7 @@ void hettmqr(
 
                 if (C.tileIsLocal(i2, j)) {
                     // Applies Q, then sends updated tile back.
-                    #pragma omp task shared(V, T, C)
+                    #pragma omp task shared(V, T, C) firstprivate(call_tile_tick)
                     {
                         V.tileGetForReading(i2, 0, LayoutConvert(layout));
                         T.tileGetForReading(i2, 0, LayoutConvert(layout));
@@ -319,7 +319,7 @@ void hettmqr(
             for (int64_t i = j2+1; i < C.mt(); ++i) {
                 if (C.tileIsLocal(i, j2)) {
                     // Applies Q, then sends updated tile back.
-                    #pragma omp task shared(V, T, C)
+                    #pragma omp task shared(V, T, C) firstprivate(call_tile_tick)
                     {
                         V.tileGetForReading(j2, 0, LayoutConvert(layout));
                         T.tileGetForReading(j2, 0, LayoutConvert(layout));

--- a/src/internal/internal_symm.cc
+++ b/src/internal/internal_symm.cc
@@ -162,6 +162,12 @@ void symm(internal::TargetType<Target::HostNest>,
     //       by watching 'layout' and 'C(i, j).layout()'
     const Layout layout = Layout::ColMajor;
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     int err = 0;
     if (side == Side::Left) {
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
@@ -176,9 +182,11 @@ void symm(internal::TargetType<Target::HostNest>,
                         side,
                         alpha, A(0, 0), B(0, j),
                         beta,  C(0, j) );
-                    // todo: should tileRelease()?
-                    A.tileTick(0, 0);
-                    B.tileTick(0, j);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(0, 0);
+                        B.tileTick(0, j);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;
@@ -200,9 +208,11 @@ void symm(internal::TargetType<Target::HostNest>,
                         side,
                         alpha, A(0, 0), B(i, 0),
                         beta,  C(i, 0) );
-                    // todo: should tileRelease()?
-                    A.tileTick(0, 0);
-                    B.tileTick(i, 0);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(0, 0);
+                        B.tileTick(i, 0);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;

--- a/src/internal/internal_symm.cc
+++ b/src/internal/internal_symm.cc
@@ -171,7 +171,7 @@ void symm(internal::TargetType<Target::HostNest>,
     int err = 0;
     if (side == Side::Left) {
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(layout, side, alpha, beta)
+            shared(A, B, C, err) firstprivate(layout, side, alpha, beta, call_tile_tick)
         for (int64_t j = 0; j < C.nt(); ++j) {
             if (C.tileIsLocal(0, j)) {
                 try {
@@ -197,7 +197,7 @@ void symm(internal::TargetType<Target::HostNest>,
     else {
         // side == Right
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(layout, side, alpha, beta)
+            shared(A, B, C, err) firstprivate(layout, side, alpha, beta, call_tile_tick)
         for (int64_t i = 0; i < C.mt(); ++i) {
             if (C.tileIsLocal(i, 0)) {
                 try {

--- a/src/internal/internal_syr2k.cc
+++ b/src/internal/internal_syr2k.cc
@@ -176,7 +176,7 @@ void syr2k(internal::TargetType<Target::HostNest>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, B, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));
@@ -203,7 +203,7 @@ void syr2k(internal::TargetType<Target::HostNest>,
 
 //  #pragma omp parallel for collapse(2) schedule(dynamic, 1) num_threads(...) default(none)
     #pragma omp parallel for collapse(2) schedule(dynamic, 1) slate_omp_default_none \
-        shared(A, B, C, err) firstprivate(C_mt, C_nt, layout, alpha, beta)
+        shared(A, B, C, err) firstprivate(C_mt, C_nt, layout, alpha, beta, call_tile_tick)
     for (int64_t j = 0; j < C_nt; ++j) {
         for (int64_t i = 0; i < C_mt; ++i) {  // full
             if (i >= j+1) {                     // strictly lower
@@ -277,7 +277,7 @@ void syr2k(internal::TargetType<Target::HostBatch>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, B, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));

--- a/src/internal/internal_syrk.cc
+++ b/src/internal/internal_syrk.cc
@@ -150,6 +150,12 @@ void syrk(internal::TargetType<Target::HostNest>,
     //       by watching 'layout' and 'C(i, j).layout()'
     assert(layout == Layout::ColMajor);
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     // Lower, NoTrans
     int err = 0;
     #pragma omp taskgroup
@@ -165,9 +171,11 @@ void syrk(internal::TargetType<Target::HostNest>,
                     tile::syrk(
                         alpha, A(j, 0),
                         beta,  C(j, j) );
-                    // todo: should tileRelease()?
-                    A.tileTick(j, 0);
-                    A.tileTick(j, 0);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(j, 0);
+                        A.tileTick(j, 0);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;
@@ -194,9 +202,11 @@ void syrk(internal::TargetType<Target::HostNest>,
                         tile::gemm(
                             alpha, A(i, 0), transpose( Aj0 ),
                             beta,  C(i, j) );
-                        // todo: should tileRelease()?
-                        A.tileTick(i, 0);
-                        A.tileTick(j, 0);
+                        if (call_tile_tick) {
+                            // todo: should tileRelease()?
+                            A.tileTick(i, 0);
+                            A.tileTick(j, 0);
+                        }
                     }
                     catch (std::exception& e) {
                         err = __LINE__;
@@ -232,6 +242,12 @@ void syrk(internal::TargetType<Target::HostBatch>,
     //       by watching 'layout' and 'C(i, j).layout()'
     assert(layout == Layout::ColMajor);
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     // diagonal tiles by syrk on host
     int err = 0;
     #pragma omp taskgroup
@@ -247,9 +263,11 @@ void syrk(internal::TargetType<Target::HostBatch>,
                     tile::syrk(
                         alpha, A(j, 0),
                         beta,  C(j, j) );
-                    // todo: should tileRelease()?
-                    A.tileTick(j, 0);
-                    A.tileTick(j, 0);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(j, 0);
+                        A.tileTick(j, 0);
+                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;
@@ -356,12 +374,14 @@ void syrk(internal::TargetType<Target::HostBatch>,
             // mkl_set_num_threads_local(1);
         }
 
-        for (int64_t j = 0; j < C.nt(); ++j) {
-            for (int64_t i = j+1; i < C.mt(); ++i) {  // strictly lower
-                if (C.tileIsLocal(i, j)) {
-                    // todo: should tileRelease()?
-                    A.tileTick(i, 0);
-                    A.tileTick(j, 0);
+        if (call_tile_tick) {
+            for (int64_t j = 0; j < C.nt(); ++j) {
+                for (int64_t i = j+1; i < C.mt(); ++i) {  // strictly lower
+                    if (C.tileIsLocal(i, j)) {
+                        // todo: should tileRelease()?
+                        A.tileTick(i, 0);
+                        A.tileTick(j, 0);
+                    }
                 }
             }
         }

--- a/src/internal/internal_syrk.cc
+++ b/src/internal/internal_syrk.cc
@@ -163,7 +163,7 @@ void syrk(internal::TargetType<Target::HostNest>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));
@@ -189,7 +189,7 @@ void syrk(internal::TargetType<Target::HostNest>,
 
 //  #pragma omp parallel for collapse(2) schedule(dynamic, 1) num_threads(...) default(none)
     #pragma omp parallel for collapse(2) schedule(dynamic, 1) slate_omp_default_none \
-        shared(A, C, err) firstprivate(C_nt, C_mt, layout, alpha, beta)
+        shared(A, C, err) firstprivate(C_nt, C_mt, layout, alpha, beta, call_tile_tick)
     for (int64_t j = 0; j < C_nt; ++j) {
         for (int64_t i = 0; i < C_mt; ++i) {  // full
             if (i >= j+1) {                     // strictly lower
@@ -255,7 +255,7 @@ void syrk(internal::TargetType<Target::HostBatch>,
         if (C.tileIsLocal(j, j)) {
             #pragma omp task slate_omp_default_none \
                 shared( A, C, err ) \
-                firstprivate(j, layout, alpha, beta)
+                firstprivate(j, layout, alpha, beta, call_tile_tick)
             {
                 try {
                     A.tileGetForReading(j, 0, LayoutConvert(layout));

--- a/src/internal/internal_trsm.cc
+++ b/src/internal/internal_trsm.cc
@@ -53,6 +53,12 @@ void trsm(internal::TargetType<Target::HostTask>,
     assert(layout == Layout::ColMajor);
     assert(A.mt() == 1);
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     if (B.numLocalTiles() > 0) {
         A.tileGetForReading(0, 0, LayoutConvert(layout));
     }
@@ -71,8 +77,10 @@ void trsm(internal::TargetType<Target::HostTask>,
                     tile::trsm(
                         side, A.diag(),
                         alpha, A(0, 0), B(i, 0) );
-                    // todo: should tileRelease()?
-                    A.tileTick(0, 0);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(0, 0);
+                    }
                 }
             }
         }
@@ -89,8 +97,10 @@ void trsm(internal::TargetType<Target::HostTask>,
                     tile::trsm(
                         side, A.diag(),
                         alpha, A(0, 0), B(0, j) );
-                    // todo: should tileRelease()?
-                    A.tileTick(0, 0);
+                    if (call_tile_tick) {
+                        // todo: should tileRelease()?
+                        A.tileTick(0, 0);
+                    }
                 }
             }
         }

--- a/src/internal/internal_trsm.cc
+++ b/src/internal/internal_trsm.cc
@@ -71,7 +71,7 @@ void trsm(internal::TargetType<Target::HostTask>,
             if (B.tileIsLocal(i, 0)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate(i, layout, side, alpha) priority(priority)
+                    firstprivate(i, layout, side, alpha, call_tile_tick) priority(priority)
                 {
                     B.tileGetForWriting(i, 0, LayoutConvert(layout));
                     tile::trsm(
@@ -91,7 +91,7 @@ void trsm(internal::TargetType<Target::HostTask>,
             if (B.tileIsLocal(0, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate(j, layout, side, alpha) priority(priority)
+                    firstprivate(j, layout, side, alpha, call_tile_tick) priority(priority)
                 {
                     B.tileGetForWriting(0, j, LayoutConvert(layout));
                     tile::trsm(

--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -74,7 +74,7 @@ void copy(internal::TargetType<Target::HostTask>,
                 if (B.tileIsLocal(i, j)) {
                     #pragma omp task slate_omp_default_none \
                         shared( A, B ) priority( priority ) \
-                        firstprivate(i, j)
+                        firstprivate(i, j, call_tile_tick)
                     {
                         A.tileGetForReading(i, j, LayoutConvert::None);
                         B.tileAcquire(i, j, A.tileLayout(i, j));
@@ -92,7 +92,7 @@ void copy(internal::TargetType<Target::HostTask>,
                 if (B.tileIsLocal(i, j)) {
                     #pragma omp task slate_omp_default_none \
                         shared( A, B ) priority( priority ) \
-                        firstprivate(i, j)
+                        firstprivate(i, j, call_tile_tick)
                     {
                         A.tileGetForReading(i, j, LayoutConvert::None);
                         B.tileAcquire(i, j, A.tileLayout(i, j));
@@ -160,7 +160,7 @@ void copy(internal::TargetType<Target::Devices>,
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B ) priority( priority ) \
-            firstprivate(device, irange, jrange, lower, queue_index)
+            firstprivate(device, irange, jrange, lower, queue_index, call_tile_tick)
         {
             std::set<ij_tuple> A_tiles, B_diag_tiles;
             for (int64_t i = 0; i < B.mt(); ++i) {

--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -23,11 +23,12 @@ namespace internal {
 template <Target target, typename src_scalar_t, typename dst_scalar_t>
 void copy(BaseTrapezoidMatrix<src_scalar_t>&& A,
           BaseTrapezoidMatrix<dst_scalar_t>&& B,
-          int priority, int queue_index)
+          int priority, int queue_index,
+          Options const& opts)
 {
     copy(internal::TargetType<target>(),
          A, B,
-         priority, queue_index);
+         priority, queue_index, opts);
 }
 
 //------------------------------------------------------------------------------
@@ -41,7 +42,8 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::HostTask>,
           BaseTrapezoidMatrix<src_scalar_t>& A,
           BaseTrapezoidMatrix<dst_scalar_t>& B,
-          int priority, int queue_index)
+          int priority, int queue_index,
+          Options const& opts)
 {
     // trace::Block trace_block("copy");
 
@@ -51,13 +53,21 @@ void copy(internal::TargetType<Target::HostTask>,
     assert(A.mt() == B.mt());
     assert(A.nt() == B.nt());
 
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
+
     #pragma omp taskgroup
     for (int64_t j = 0; j < B.nt(); ++j) {
         if (j < B.mt() && B.tileIsLocal(j, j)) {
             A.tileGetForReading(j, j, LayoutConvert::None);
             B.tileGetForWriting(j, j, LayoutConvert( A.tileLayout(j, j) ));
             tile::tzcopy( A(j, j), B(j, j) );
-            A.tileTick(j, j);
+            if (call_tile_tick) {
+                A.tileTick(j, j);
+            }
         }
         if (lower) {
             for (int64_t i = j+1; i < B.mt(); ++i) {
@@ -70,7 +80,9 @@ void copy(internal::TargetType<Target::HostTask>,
                         B.tileAcquire(i, j, A.tileLayout(i, j));
                         B.tileModified(i, j, HostNum, true);
                         tile::gecopy( A(i, j), B(i, j) );
-                        A.tileTick(i, j);
+                        if (call_tile_tick) {
+                            A.tileTick(i, j);
+                        }
                     }
                 }
             }
@@ -86,7 +98,9 @@ void copy(internal::TargetType<Target::HostTask>,
                         B.tileAcquire(i, j, A.tileLayout(i, j));
                         B.tileModified(i, j, HostNum, true);
                         tile::gecopy( A(i, j), B(i, j) );
-                        A.tileTick(i, j);
+                        if (call_tile_tick) {
+                            A.tileTick(i, j);
+                        }
                     }
                 }
             }
@@ -106,11 +120,18 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::Devices>,
           BaseTrapezoidMatrix<src_scalar_t>& A,
           BaseTrapezoidMatrix<dst_scalar_t>& B,
-          int priority, int queue_index)
+          int priority, int queue_index,
+          Options const& opts)
 {
     using ij_tuple = typename BaseMatrix<src_scalar_t>::ij_tuple;
     slate_error_if(A.uplo() != B.uplo());
     bool lower = (B.uplo() == Uplo::Lower);
+
+    TileReleaseStrategy tile_release_strategy = get_option(
+            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
+
+    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
+                          || tile_release_strategy == TileReleaseStrategy::All;
 
     // Define index ranges for regions of matrix.
     // Tiles in each region are all the same size.
@@ -153,7 +174,6 @@ void copy(internal::TargetType<Target::Devices>,
                             B_diag_tiles.insert( { i, j } );
                         }
                         else {
-                            // no need to convert layout
                             B.tileAcquire( i, j, device, Layout::ColMajor );
                             B.tileModified( i, j, device, true );
                         }
@@ -260,17 +280,19 @@ void copy(internal::TargetType<Target::Devices>,
 
             queue->sync();
 
-            for (int64_t i = 0; i < B.mt(); ++i) {
-                for (int64_t j = 0; j < B.nt(); ++j) {
-                    if (B.tileIsLocal(i, j) &&
-                        device == B.tileDevice(i, j) &&
-                        ( (  lower && i >= j) ||
-                          (! lower && i <= j) ) )
-                    {
-                        // erase tmp local and remote device tiles;
-                        A.tileRelease(i, j, device);
-                        // decrement life for remote tiles
-                        A.tileTick(i, j);
+            if (call_tile_tick) {
+                for (int64_t i = 0; i < B.mt(); ++i) {
+                    for (int64_t j = 0; j < B.nt(); ++j) {
+                        if (B.tileIsLocal(i, j) &&
+                            device == B.tileDevice(i, j) &&
+                            ( (  lower && i >= j) ||
+                              (! lower && i <= j) ) )
+                        {
+                            // erase tmp local and remote device tiles;
+                            A.tileRelease(i, j, device);
+                            // decrement life for remote tiles
+                            A.tileTick(i, j);
+                        }
                     }
                 }
             }
@@ -285,100 +307,116 @@ template
 void copy<Target::HostTask, float, float>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy<Target::HostTask, float, double>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy<Target::Devices, float, float>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy<Target::Devices, float, double>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 // ----------------------------------------
 template
 void copy<Target::HostTask, double, double>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy<Target::HostTask, double, float>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy<Target::Devices, double, double>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy<Target::Devices, double, float>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 // ----------------------------------------
 template
 void copy< Target::HostTask, std::complex<float>, std::complex<float> >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy< Target::HostTask, std::complex<float>, std::complex<double> >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy< Target::Devices, std::complex<float>, std::complex<float>  >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy< Target::Devices, std::complex<float>, std::complex<double>  >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 // ----------------------------------------
 template
 void copy< Target::HostTask, std::complex<double>, std::complex<double> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy< Target::HostTask, std::complex<double>, std::complex<float> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy< Target::Devices, std::complex<double>, std::complex<double> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 template
 void copy< Target::Devices, std::complex<double>, std::complex<float> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index);
+    int priority, int queue_index,
+    Options const& opts);
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_util.hh
+++ b/src/internal/internal_util.hh
@@ -70,6 +70,86 @@ inline bool compareSecond(
     return a.second < b.second;
 }
 
+//------------------------------------------------------------------------------
+/// An helper function to find each rank's first (top-most) row in panel k for
+/// the QR-family of routines.
+///
+/// @param[in] A_panel
+///     Current panel, which is a sub of the input matrix $A$.
+///
+/// @param[in] k
+///     Index of the current panel in the input matrix $A$.
+///
+/// @param[out] first_indices
+///     The array of computed indices.
+///
+/// @ingroup geqrf_impl
+///
+template <typename scalar_t>
+std::vector< int64_t > geqrf_compute_first_indices(
+    Matrix<scalar_t>& A_panel, int64_t k)
+{
+    // Find ranks in this column.
+    std::set<int> ranks_set;
+    A_panel.getRanks(&ranks_set);
+    assert(ranks_set.size() > 0);
+
+    // Find each rank's first (top-most) row in this panel,
+    // where the triangular tile resulting from local geqrf panel
+    // will reside.
+    std::vector< int64_t > first_indices;
+    first_indices.reserve(ranks_set.size());
+    for (int r: ranks_set) {
+        for (int64_t i = 0; i < A_panel.mt(); ++i) {
+            if (A_panel.tileRank(i, 0) == r) {
+                first_indices.push_back(i+k);
+                break;
+            }
+        }
+    }
+    return first_indices;
+}
+
+//------------------------------------------------------------------------------
+/// An helper function to find each rank's first (left-most) row in panel k for
+/// the LQ-family of routines.
+///
+/// @param[in] A_panel
+///     Current panel, which is a sub of the input matrix $A$.
+///
+/// @param[in] k
+///     Index of the current panel in the input matrix $A$.
+///
+/// @param[out] first_indices
+///     The array of computed indices.
+///
+/// @ingroup gelqf_impl
+///
+template <typename scalar_t>
+std::vector< int64_t > gelqf_compute_first_indices(
+    Matrix<scalar_t> A_panel, int64_t k)
+{
+    // Find ranks in this column.
+    std::set<int> ranks_set;
+    A_panel.getRanks(&ranks_set);
+    assert(ranks_set.size() > 0);
+
+    // Find each rank's first (top-most) row in this panel,
+    // where the triangular tile resulting from local geqrf panel
+    // will reside.
+    std::vector< int64_t > first_indices;
+    first_indices.reserve(ranks_set.size());
+    for (int r: ranks_set) {
+        for (int64_t j = 0; j < A_panel.nt(); ++j) {
+            if (A_panel.tileRank(0, j) == r) {
+                first_indices.push_back(j+k);
+                break;
+            }
+        }
+    }
+    return first_indices;
+}
+
 
 //------------------------------------------------------------------------------
 /// Helper function to check convergence in iterative methods

--- a/src/internal/internal_util.hh
+++ b/src/internal/internal_util.hh
@@ -71,7 +71,7 @@ inline bool compareSecond(
 }
 
 //------------------------------------------------------------------------------
-/// An helper function to find each rank's first (top-most) row in panel k for
+/// A helper function to find each rank's first (top-most) row in panel k for
 /// the QR-family of routines.
 ///
 /// @param[in] A_panel
@@ -80,8 +80,7 @@ inline bool compareSecond(
 /// @param[in] k
 ///     Index of the current panel in the input matrix $A$.
 ///
-/// @param[out] first_indices
-///     The array of computed indices.
+/// @return The array of computed indices.
 ///
 /// @ingroup geqrf_impl
 ///
@@ -111,7 +110,7 @@ std::vector< int64_t > geqrf_compute_first_indices(
 }
 
 //------------------------------------------------------------------------------
-/// An helper function to find each rank's first (left-most) row in panel k for
+/// A helper function to find each rank's first (left-most) row in panel k for
 /// the LQ-family of routines.
 ///
 /// @param[in] A_panel
@@ -120,8 +119,7 @@ std::vector< int64_t > geqrf_compute_first_indices(
 /// @param[in] k
 ///     Index of the current panel in the input matrix $A$.
 ///
-/// @param[out] first_indices
-///     The array of computed indices.
+/// @return The array of computed indices.
 ///
 /// @ingroup gelqf_impl
 ///

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -8,6 +8,7 @@
 #include "slate/Matrix.hh"
 #include "internal/Tile_tpmlqt.hh"
 #include "internal/internal.hh"
+#include "internal/internal_util.hh"
 
 namespace slate {
 
@@ -107,24 +108,11 @@ void unmlq(
 
             auto A_panel = A.sub(k, k, k, A_nt-1);
 
-            // Find ranks in this row.
-            std::set<int> ranks_set;
-            A_panel.getRanks(&ranks_set);
-            assert(ranks_set.size() > 0);
-
             // Find each rank's first (left-most) col in this panel,
             // where the triangular tile resulting from local gelqf
             // panel will reside.
-            std::vector< int64_t > first_indices;
-            first_indices.reserve(ranks_set.size());
-            for (int r: ranks_set) {
-                for (int64_t j = 0; j < A_panel.nt(); ++j) {
-                    if (A_panel.tileRank(0, j) == r) {
-                        first_indices.push_back(j+k);
-                        break;
-                    }
-                }
-            }
+            std::vector< int64_t > first_indices
+                            = internal::gelqf_compute_first_indices(A_panel, k);
 
             #pragma omp task depend(inout:block[k]) \
                              depend(in:block[lastk])


### PR DESCRIPTION
This puts a good dent into #119 (especially since I also addressed some of the unrelated BLAS routines).

I also did some related cleanup:
* In ge2tb, only store the tiles of `VT` for the short time we use them (reducing the total memory footprint of values-only svd)
* De-duplicate the logic to compute the first indices into helper functions