### PR TITLE
Add additional timers to gesv,  posv,  heev, and svd

### DIFF
--- a/src/gesv.cc
+++ b/src/gesv.cc
@@ -87,17 +87,25 @@ template <typename scalar_t>
 void gesv(Matrix<scalar_t>& A, Pivots& pivots,
           Matrix<scalar_t>& B,
           Options const& opts)
-{
+{   
+    Timer t_gesv;
+
     slate_assert(A.mt() == A.nt());  // square
     slate_assert(B.mt() == A.mt());
 
     // factorization
+    Timer t_getrf;
     getrf(A, pivots, opts);
+    timers[ "gesv::getrf" ] = t_getrf.stop();
 
     // solve
+    Timer t_getrs;
     getrs(A, pivots, B, opts);
+    timers[ "gesv::getrs" ] = t_getrs.stop();
 
     // todo: return value for errors?
+    
+    timers[ "gesv" ] = t_gesv.stop();
 }
 
 //------------------------------------------------------------------------------

--- a/src/gesv.cc
+++ b/src/gesv.cc
@@ -87,7 +87,7 @@ template <typename scalar_t>
 void gesv(Matrix<scalar_t>& A, Pivots& pivots,
           Matrix<scalar_t>& B,
           Options const& opts)
-{   
+{
     Timer t_gesv;
 
     slate_assert(A.mt() == A.nt());  // square
@@ -104,7 +104,7 @@ void gesv(Matrix<scalar_t>& A, Pivots& pivots,
     timers[ "gesv::getrs" ] = t_getrs.stop();
 
     // todo: return value for errors?
-    
+
     timers[ "gesv" ] = t_gesv.stop();
 }
 

--- a/src/heev.cc
+++ b/src/heev.cc
@@ -59,6 +59,8 @@ void heev(
     Matrix<scalar_t>& Z,
     Options const& opts)
 {
+    Timer t_heev;
+
     using real_t = blas::real_type<scalar_t>;
     using std::real;
 
@@ -101,7 +103,9 @@ void heev(
 
     // 1. Reduce to band form.
     TriangularFactors<scalar_t> T;
+    Timer t_he2hb;
     he2hb(A, T, opts);
+    timers[ "heev::he2hb" ] = t_he2hb.stop();
 
     // Copy band.
     // Currently, gathers band matrix to rank 0.
@@ -125,7 +129,9 @@ void heev(
         V.insertLocalTiles();
 
         // 2. Reduce band to real symmetric tri-diagonal.
+	Timer t_hb2st;
         hb2st(Aband, V, opts);
+	timers[ "heev::hb2st" ] = t_hb2st.stop();
 
         // Copy diagonal and super-diagonal to vectors.
         internal::copyhb2st( Aband, Lambda, E );
@@ -138,19 +144,25 @@ void heev(
         MPI_Bcast( &E[0],      n-1, mpi_real_type, 0, A.mpiComm() );
         if (method == MethodEig::QR) {
             // QR iteration to get eigenvalues and eigenvectors of tridiagonal.
+	    Timer t_steqr2;
             steqr2( Job::Vec, Lambda, E, Z );
+	    timers[ "heev::steqr2" ] = t_steqr2.stop();
         }
         else {
             // Divide and conquer to get eigvals and eigvecs of tridiagonal.
             if constexpr (! is_complex<scalar_t>::value) {
                 // real
+                Timer t_stedc;
                 stedc( Lambda, E, Z );
+		timers[ "heev::stedc" ] = t_stedc.stop();
             }
             else {
                 // D&C computes real Z, then copy to complex Z to back-transform.
                 auto Zreal = Z.template emptyLike<real_t>();
                 Zreal.insertLocalTiles();
+		Timer t_stedc;
                 stedc( Lambda, E, Zreal );
+		timers[ "heev::stedc" ] = t_stedc.stop();
                 copy( Zreal, Z );
             }
         }
@@ -165,10 +177,14 @@ void heev(
         redistribute(Z, Z1d, opts);
 
         // Back-transform: Z = Q1 * Q2 * Z.
+	Timer t_unmtr_hb2st;
         unmtr_hb2st( Side::Left, Op::NoTrans, V, Z1d, opts );
+	timers[ "heev::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
 
         redistribute(Z1d, Z, opts);
+	Timer t_unmtr_he2hb;
         unmtr_he2hb( Side::Left, Op::NoTrans, A, T, Z, opts );
+	timers[ "heev::unmtr_he2hb" ] = t_unmtr_he2hb.stop();
     }
     else {
         if (A.mpiRank() == 0) {
@@ -185,6 +201,7 @@ void heev(
         // todo: deal with not all eigenvalues converging, cf. LAPACK.
         blas::scal( n, Anorm/alpha, &Lambda[0], 1 );
     }
+    timers[ "heev" ] = t_heev.stop();
 }
 
 //------------------------------------------------------------------------------

--- a/src/heev.cc
+++ b/src/heev.cc
@@ -129,9 +129,9 @@ void heev(
         V.insertLocalTiles();
 
         // 2. Reduce band to real symmetric tri-diagonal.
-	Timer t_hb2st;
+        Timer t_hb2st;
         hb2st(Aband, V, opts);
-	timers[ "heev::hb2st" ] = t_hb2st.stop();
+        timers[ "heev::hb2st" ] = t_hb2st.stop();
 
         // Copy diagonal and super-diagonal to vectors.
         internal::copyhb2st( Aband, Lambda, E );
@@ -144,9 +144,9 @@ void heev(
         MPI_Bcast( &E[0],      n-1, mpi_real_type, 0, A.mpiComm() );
         if (method == MethodEig::QR) {
             // QR iteration to get eigenvalues and eigenvectors of tridiagonal.
-	    Timer t_steqr2;
+            Timer t_steqr2;
             steqr2( Job::Vec, Lambda, E, Z );
-	    timers[ "heev::steqr2" ] = t_steqr2.stop();
+            timers[ "heev::steqr2" ] = t_steqr2.stop();
         }
         else {
             // Divide and conquer to get eigvals and eigvecs of tridiagonal.
@@ -154,15 +154,15 @@ void heev(
                 // real
                 Timer t_stedc;
                 stedc( Lambda, E, Z );
-		timers[ "heev::stedc" ] = t_stedc.stop();
+                timers[ "heev::stedc" ] = t_stedc.stop();
             }
             else {
                 // D&C computes real Z, then copy to complex Z to back-transform.
                 auto Zreal = Z.template emptyLike<real_t>();
                 Zreal.insertLocalTiles();
-		Timer t_stedc;
+                Timer t_stedc;
                 stedc( Lambda, E, Zreal );
-		timers[ "heev::stedc" ] = t_stedc.stop();
+                timers[ "heev::stedc" ] = t_stedc.stop();
                 copy( Zreal, Z );
             }
         }
@@ -177,14 +177,14 @@ void heev(
         redistribute(Z, Z1d, opts);
 
         // Back-transform: Z = Q1 * Q2 * Z.
-	Timer t_unmtr_hb2st;
+        Timer t_unmtr_hb2st;
         unmtr_hb2st( Side::Left, Op::NoTrans, V, Z1d, opts );
-	timers[ "heev::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
+        timers[ "heev::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
 
         redistribute(Z1d, Z, opts);
-	Timer t_unmtr_he2hb;
+        Timer t_unmtr_he2hb;
         unmtr_he2hb( Side::Left, Op::NoTrans, A, T, Z, opts );
-	timers[ "heev::unmtr_he2hb" ] = t_unmtr_he2hb.stop();
+        timers[ "heev::unmtr_he2hb" ] = t_unmtr_he2hb.stop();
     }
     else {
         if (A.mpiRank() == 0) {

--- a/src/posv.cc
+++ b/src/posv.cc
@@ -74,7 +74,7 @@ void posv(HermitianMatrix<scalar_t>& A,
           Matrix<scalar_t>& B,
           Options const& opts)
 {
-    Timer t_posv;    
+    Timer t_posv;
 
     slate_assert(B.mt() == A.mt());
 
@@ -89,7 +89,7 @@ void posv(HermitianMatrix<scalar_t>& A,
     timers[ "posv::potrs" ] = t_potrs.stop();
 
     // todo: return value for errors?
-    
+
     timers[ "posv" ] = t_posv.stop();
 }
 

--- a/src/posv.cc
+++ b/src/posv.cc
@@ -74,15 +74,23 @@ void posv(HermitianMatrix<scalar_t>& A,
           Matrix<scalar_t>& B,
           Options const& opts)
 {
+    Timer t_posv;    
+
     slate_assert(B.mt() == A.mt());
 
     // factorization
+    Timer t_potrf;
     potrf(A, opts);
+    timers[ "posv::potrf" ] = t_potrf.stop();
 
     // solve
+    Timer t_potrs;
     potrs(A, B, opts);
+    timers[ "posv::potrs" ] = t_potrs.stop();
 
     // todo: return value for errors?
+    
+    timers[ "posv" ] = t_posv.stop();
 }
 
 //------------------------------------------------------------------------------

--- a/src/svd.cc
+++ b/src/svd.cc
@@ -143,6 +143,8 @@ void svd(
     bool lq_path = n > m;
     Matrix<scalar_t> Ahat, Uhat, VThat;
     TriangularFactors<scalar_t> TQ;
+    timers[ "svd::geqrf" ] = 0;
+    timers[ "svd::gelqf" ] = 0;
     if (qr_path) {
         Timer t_geqrf;
         geqrf( A, TQ, opts );
@@ -339,13 +341,13 @@ void svd(
             Timer t_unmbr_ge2tb_U;
             unmbr_ge2tb( Side::Left, Op::NoTrans, Ahat, TU, Uhat, opts );
             timers[ "svd::unmbr_ge2tb_U" ] = t_unmbr_ge2tb_U.stop();
+            Timer t_unmqr;
             if (qr_path) {
                 // When initial QR was used.
                 // U = Q*U;
-                Timer t_unmqr;
                 unmqr( Side::Left, slate::Op::NoTrans, A, TQ, U, opts );
-                timers[ "svd::unmqr" ] = t_unmqr.stop();
             }
+            timers[ "svd::unmqr" ] = t_unmqr.stop();
         }
 
         // Back-transform: VT = VT * VT2 * VT1.
@@ -381,12 +383,12 @@ void svd(
             Timer t_unmbr_ge2tb_V;
             unmbr_ge2tb( Side::Right, Op::NoTrans, Ahat, TV, VThat, opts );
             timers[ "svd::unmbr_ge2tb_V" ] = t_unmbr_ge2tb_V.stop();
+            Timer t_unmlq;
             if (lq_path) {
                 // VT = VT*Q;
-                Timer t_unmlq;
                 unmlq( Side::Right, slate::Op::NoTrans, A, TQ, VT, opts );
-                timers[ "svd::unmlq" ] = t_unmlq.stop();
             }
+            timers[ "svd::unmlq" ] = t_unmlq.stop();
         }
     }
     else {

--- a/src/svd.cc
+++ b/src/svd.cc
@@ -373,7 +373,7 @@ void svd(
             // First: V  = VT2 * V ===> V1d = VT2 * V1d
             Timer t_unmbr_tb2bd_V;
             unmtr_hb2st( Side::Left, Op::NoTrans, VT2, V1d, opts );
-            timers[ "svd::unm_tb2bd_V" ] = t_unmbr_tb2bd_V.stop();
+            timers[ "svd::unmbr_tb2bd_V" ] = t_unmbr_tb2bd_V.stop();
 
             // Redistribute V1d into V
             auto V1dT = conj_transpose(V1d);

--- a/src/svd.cc
+++ b/src/svd.cc
@@ -144,9 +144,9 @@ void svd(
     Matrix<scalar_t> Ahat, Uhat, VThat;
     TriangularFactors<scalar_t> TQ;
     if (qr_path) {
-	Timer t_geqrf;
+        Timer t_geqrf;
         geqrf( A, TQ, opts );
-	timers[ "svd::geqrf" ] = t_geqrf.stop();
+        timers[ "svd::geqrf" ] = t_geqrf.stop();
 
         // Upper triangular part of A (R).
         auto R_ = A.slice(0, n-1, 0, n-1);
@@ -170,9 +170,9 @@ void svd(
         }
     }
     else if (lq_path) {
-	Timer t_gelqf;
+        Timer t_gelqf;
         gelqf( A, TQ, opts );
-	timers[ "svd::gelqf" ] = t_gelqf.stop();
+        timers[ "svd::gelqf" ] = t_gelqf.stop();
         swap(m, n);
 
         // Lower triangular part of A (R).
@@ -244,9 +244,9 @@ void svd(
         U2.insertLocalTiles();
 
         // Reduce band to bi-diagonal.
-	Timer t_tb2db;
+        Timer t_tb2db;
         tb2bd( Aband, U2, VT2, opts );
-	timers[ "svd::tb2bd" ] = t_tb2db.stop();
+        timers[ "svd::tb2bd" ] = t_tb2db.stop();
 
         // Copy diagonal and super-diagonal to vectors.
         internal::copytb2bd(Aband, Sigma, E);
@@ -293,13 +293,13 @@ void svd(
         // QR iteration
         //bdsqr<scalar_t>(jobu, jobvt, Sigma, E, Uhat, VThat, opts);
         // Call the SVD
-	Timer t_bdsqr;
+        Timer t_bdsqr;
         lapack::bdsqr(Uplo::Upper, min_mn, ncvt, nru, 0,
                       &Sigma[0], &E[0],
                       &VT1D_row_cyclic_data[0], ldvt,
                       &U1D_row_cyclic_data[0], ldu,
                       dummy, 1);
-	timers[ "svd::bdsqr" ] = t_bdsqr.stop();
+        timers[ "svd::bdsqr" ] = t_bdsqr.stop();
 
         // If matrix was scaled, then rescale singular values appropriately.
         if (is_scale) {
@@ -328,23 +328,23 @@ void svd(
             redistribute(U1d_row_cyclic, U1d, opts);
 
             // First, U = U2 * U ===> U1d = U2 * U1d
-	    Timer t_unmtr_hb2st;
+            Timer t_unmtr_hb2st;
             unmtr_hb2st( Side::Left, Op::NoTrans, U2, U1d, opts );
-	    timers[ "svd::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
+            timers[ "svd::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
 
             // Redistribute U1d into U
             redistribute(U1d, Uhat, opts);
 
             // Second, U = U1 * U ===> U = Ahat * U
-	    Timer t_unmbr_ge2tb;
+            Timer t_unmbr_ge2tb;
             unmbr_ge2tb( Side::Left, Op::NoTrans, Ahat, TU, Uhat, opts );
-	    timers [ "svd::unmbr_ge2tb" ] = t_unmbr_ge2tb.stop();
+            timers [ "svd::unmbr_ge2tb" ] = t_unmbr_ge2tb.stop();
             if (qr_path) {
                 // When initial QR was used.
                 // U = Q*U;
-		Timer t_unmqr;
+                Timer t_unmqr;
                 unmqr( Side::Left, slate::Op::NoTrans, A, TQ, U, opts );
-		timers [ "svd::unmqr" ] = t_unmqr.stop();
+                timers [ "svd::unmqr" ] = t_unmqr.stop();
             }
         }
 
@@ -369,9 +369,9 @@ void svd(
             redistribute(V, V1d, opts);
 
             // First: V  = VT2 * V ===> V1d = VT2 * V1d
-	    Timer t_unmtr_hb2st;
+            Timer t_unmtr_hb2st;
             unmtr_hb2st( Side::Left, Op::NoTrans, VT2, V1d, opts );
-	    timers [ "svd::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
+            timers [ "svd::unmtr_hb2st" ] = t_unmtr_hb2st.stop();
 
             // Redistribute V1d into V
             auto V1dT = conj_transpose(V1d);
@@ -381,9 +381,9 @@ void svd(
             unmbr_ge2tb( Side::Right, Op::NoTrans, Ahat, TV, VThat, opts );
             if (lq_path) {
                 // VT = VT*Q;
-		Timer t_unmlq;
+                Timer t_unmlq;
                 unmlq( Side::Right, slate::Op::NoTrans, A, TQ, VT, opts );
-		timers [ "svd::unmlq" ] = t_unmlq.stop();
+                timers [ "svd::unmlq" ] = t_unmlq.stop();
             }
         }
     }
@@ -391,14 +391,13 @@ void svd(
         if (A.mpiRank() == 0) {
             // QR iteration
             //bdsqr<scalar_t>(jobu, jobvt, Sigma, E, U, VT, opts);
-	    Timer t_bdsqr;
+            Timer t_bdsqr;
             lapack::bdsqr(Uplo::Upper, min_mn, ncvt, nru, 0,
                           &Sigma[0], &E[0],
                           &VT1D_row_cyclic_data[0], ldvt,
                           &U1D_row_cyclic_data[0], ldu,
                           dummy, 1);
-	    timers [ "svd::bdsqr" ] = t_bdsqr.stop();
-	   
+            timers [ "svd::bdsqr" ] = t_bdsqr.stop();
         }
 
         // If matrix was scaled, then rescale singular values appropriately.

--- a/src/svd.cc
+++ b/src/svd.cc
@@ -246,9 +246,9 @@ void svd(
         U2.insertLocalTiles();
 
         // Reduce band to bi-diagonal.
-        Timer t_tb2db;
+        Timer t_tb2bd;
         tb2bd( Aband, U2, VT2, opts );
-        timers[ "svd::tb2bd" ] = t_tb2db.stop();
+        timers[ "svd::tb2bd" ] = t_tb2bd.stop();
 
         // Copy diagonal and super-diagonal to vectors.
         internal::copytb2bd(Aband, Sigma, E);

--- a/test/test.cc
+++ b/test/test.cc
@@ -442,6 +442,8 @@ Params::Params():
     time8     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
     time9     ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
     time10    ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time11    ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
+    time12    ("time (s)",      9, 3, ParamType::Output, no_data_flag,   0,   0, "extra timer"),
     iters     ("iters",         5,    ParamType::Output,            0,   0,   0, "iterations to solution"),
 
     ref_time  ("ref time (s)", 12, 3, ParamType::Output, no_data_flag,   0,   0, "reference time to solution"),

--- a/test/test.hh
+++ b/test/test.hh
@@ -168,6 +168,8 @@ public:
     testsweeper::ParamDouble     time8;
     testsweeper::ParamDouble     time9;
     testsweeper::ParamDouble     time10;
+    testsweeper::ParamDouble     time11;
+    testsweeper::ParamDouble     time12;
     testsweeper::ParamInt        iters;
 
     testsweeper::ParamDouble     ref_time;

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -310,7 +310,7 @@ void test_gesv_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-	if (timer_level >= 2) {
+        if (timer_level >= 2) {
             params.time2() = slate::timers[ "gesv::getrf" ];
             params.time3() = slate::timers[ "gesv::getrs" ];
         }

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -78,6 +78,10 @@ void test_gesv_work(Params& params, bool run)
     params.matrix.mark();
     params.matrixB.mark();
 
+    // Currently only gesv* supports timer_level >= 2.
+    if (params.routine != "gesv")
+        timer_level = 1;
+
     // NoPiv and CALU ignore threshold.
     double pivot_threshold = params.pivot_threshold();
 
@@ -86,21 +90,23 @@ void test_gesv_work(Params& params, bool run)
     params.gflops();
     params.ref_time();
     params.ref_gflops();
-    params.time2();
-    params.time2.name( "trs time (s)" );
-    params.time2.width( 12 );
-    params.gflops2();
-    params.gflops2.name( "trs gflop/s" );
 
+    bool do_getrs = params.routine == "getrs"
+                    || (check && params.routine == "getrf");
+
+    if (do_getrs) {
+        params.time2();
+        params.time2.name( "trs time (s)" );
+        params.time2.width( 12 );
+        params.gflops2();
+        params.gflops2.name( "trs gflop/s" );
+    }
     if (timer_level >= 2) {
         params.time2();
         params.time3();
         params.time2.name( "getrf (s)" );
         params.time3.name( "getrs (s)" );
     }
-
-    bool do_getrs = params.routine == "getrs"
-                    || (check && params.routine == "getrf");
 
     if (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres") {
         params.iters();

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -70,6 +70,7 @@ void test_gesv_work(Params& params, bool run)
     bool trace = params.trace() == 'y';
     bool nonuniform_nb = params.nonuniform_nb() == 'y';
     int verbose = params.verbose();
+    int timer_level = params.timer_level();
     SLATE_UNUSED(verbose);
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
@@ -90,6 +91,13 @@ void test_gesv_work(Params& params, bool run)
     params.time2.width( 12 );
     params.gflops2();
     params.gflops2.name( "trs gflop/s" );
+
+    if (timer_level >= 2) {
+        params.time2();
+        params.time3();
+        params.time2.name( "getrf (s)" );
+        params.time3.name( "getrs (s)" );
+    }
 
     bool do_getrs = params.routine == "getrs"
                     || (check && params.routine == "getrf");
@@ -301,6 +309,11 @@ void test_gesv_work(Params& params, bool run)
         // compute and save timing/performance
         params.time() = time;
         params.gflops() = gflop / time;
+
+	if (timer_level >= 2) {
+            params.time2() = slate::timers[ "gesv::getrf" ];
+            params.time3() = slate::timers[ "gesv::getrs" ];
+        }
 
         //==================================================
         // Run SLATE test: getrs

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -68,7 +68,7 @@ void test_heev_work(Params& params, bool run)
         params.time6();
         params.time2.name( "he2hb (s)" );
         params.time3.name( "hb2st (s)" );
-        params.time4.name( "stedc (s)" );
+        params.time4.name( "stev (s)" );
         params.time5.name( "unmtr_hb2st (s)" );
         params.time6.name( "unmtr_he2hb (s)" );
     }
@@ -191,7 +191,7 @@ void test_heev_work(Params& params, bool run)
         if (timer_level >= 2) {
             params.time2() = slate::timers[ "heev::he2hb" ];
             params.time3() = slate::timers[ "heev::hb2st" ];
-            params.time4() = slate::timers[ "heev::stedc" ];
+            params.time4() = slate::timers[ "heev::stev" ];
             params.time5() = slate::timers[ "heev::unmtr_hb2st" ];
             params.time6() = slate::timers[ "heev::unmtr_he2hb" ];
         }

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -62,15 +62,15 @@ void test_heev_work(Params& params, bool run)
     params.ortho.name( "Z orth." );
     if (timer_level >= 2) {
         params.time2();
-	params.time3();
-	params.time4();
-	params.time5();
-	params.time6();
-	params.time2.name( "he2hb (s)" );
-	params.time3.name( "hb2st (s)" );
+        params.time3();
+        params.time4();
+        params.time5();
+        params.time6();
+        params.time2.name( "he2hb (s)" );
+        params.time3.name( "hb2st (s)" );
         params.time4.name( "stedc (s)" );
-	params.time5.name( "unmtr_hb2st (s)" );
-	params.time6.name( "unmtr_he2hb (s)" );
+        params.time5.name( "unmtr_hb2st (s)" );
+        params.time6.name( "unmtr_he2hb (s)" );
     }
 
     if (! run)
@@ -188,7 +188,7 @@ void test_heev_work(Params& params, bool run)
 
         // compute and save timing/performance
         params.time() = time;
-	if (timer_level >= 2) {
+        if (timer_level >= 2) {
             params.time2() = slate::timers[ "heev::he2hb" ];
             params.time3() = slate::timers[ "heev::hb2st" ];
             params.time4() = slate::timers[ "heev::stedc" ];

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -46,6 +46,7 @@ void test_heev_work(Params& params, bool run)
     bool check = params.check() == 'y' && ! ref_only;
     bool trace = params.trace() == 'y';
     int verbose = params.verbose();
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     slate::MethodEig method_eig = params.method_eig();
@@ -59,6 +60,18 @@ void test_heev_work(Params& params, bool run)
     params.error.name( "value err" );
     params.error2.name( "back err" );
     params.ortho.name( "Z orth." );
+    if (timer_level >= 2) {
+        params.time2();
+	params.time3();
+	params.time4();
+	params.time5();
+	params.time6();
+	params.time2.name( "he2hb (s)" );
+	params.time3.name( "hb2st (s)" );
+        params.time4.name( "stedc (s)" );
+	params.time5.name( "unmtr_hb2st (s)" );
+	params.time6.name( "unmtr_he2hb (s)" );
+    }
 
     if (! run)
         return;
@@ -175,6 +188,13 @@ void test_heev_work(Params& params, bool run)
 
         // compute and save timing/performance
         params.time() = time;
+	if (timer_level >= 2) {
+            params.time2() = slate::timers[ "heev::he2hb" ];
+            params.time3() = slate::timers[ "heev::hb2st" ];
+            params.time4() = slate::timers[ "heev::stedc" ];
+            params.time5() = slate::timers[ "heev::unmtr_hb2st" ];
+            params.time6() = slate::timers[ "heev::unmtr_he2hb" ];
+        }
 
         if (check && jobz == slate::Job::Vec) {
             //==================================================

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -274,9 +274,9 @@ void test_posv_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-	if (timer_level >= 2) {
+        if (timer_level >= 2) {
             params.time2() = slate::timers[ "posv::potrf" ];
-	    params.time3() = slate::timers[ "posv::potrs" ];
+            params.time3() = slate::timers[ "posv::potrs" ];
         }
 
         //==================================================

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -53,26 +53,32 @@ void test_posv_work(Params& params, bool run)
     slate::Method methodTrsm = params.method_trsm();
     slate::Method methodHemm = params.method_hemm();
 
+    // Currently only posv* supports timer_level >= 2.
+    if (params.routine != "posv")
+        timer_level = 1;
+
     // mark non-standard output values
     params.time();
     params.gflops();
     params.ref_time();
     params.ref_gflops();
-    params.time2();
-    params.time2.name( "trs time (s)" );
-    params.time2.width( 12 );
-    params.gflops2();
-    params.gflops2.name( "trs gflop/s" );
+
+    bool do_potrs = params.routine == "potrs"
+                    || (check && params.routine == "potrf");
+
+    if (do_potrs) {
+        params.time2();
+        params.time2.name( "trs time (s)" );
+        params.time2.width( 12 );
+        params.gflops2();
+        params.gflops2.name( "trs gflop/s" );
+    }
     if (timer_level >= 2) {
         params.time2();
         params.time3();
         params.time2.name( "potrf (s)" );
         params.time3.name( "potrs (s)" );
     }
-
-
-    bool do_potrs = (
-        (check && params.routine == "potrf") || params.routine == "potrs");
 
     if (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres") {
         params.iters();

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -43,6 +43,7 @@ void test_posv_work(Params& params, bool run)
     bool trace = params.trace() == 'y';
     bool hold_local_workspace = params.hold_local_workspace() == 'y';
     int verbose = params.verbose();
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     slate::Dist dev_dist = params.dev_dist();
@@ -62,6 +63,13 @@ void test_posv_work(Params& params, bool run)
     params.time2.width( 12 );
     params.gflops2();
     params.gflops2.name( "trs gflop/s" );
+    if (timer_level >= 2) {
+        params.time2();
+        params.time3();
+        params.time2.name( "potrf (s)" );
+        params.time3.name( "potrs (s)" );
+    }
+
 
     bool do_potrs = (
         (check && params.routine == "potrf") || params.routine == "potrs");
@@ -265,6 +273,11 @@ void test_posv_work(Params& params, bool run)
         // compute and save timing/performance
         params.time() = time;
         params.gflops() = gflop / time;
+
+	if (timer_level >= 2) {
+            params.time2() = slate::timers[ "posv::potrf" ];
+	    params.time3() = slate::timers[ "posv::potrs" ];
+        }
 
         //==================================================
         // Run SLATE test: potrs

--- a/test/test_svd.cc
+++ b/test/test_svd.cc
@@ -73,12 +73,12 @@ void test_svd_work( Params& params, bool run )
         params.time2.name( "geqrf (s)" );
         params.time3.name( "gelqf (s)" );
         params.time4.name( "ge2tb (s)" );
-        params.time5.name( "tb2db (s)" );
+        params.time5.name( "tb2bd (s)" );
         params.time6.name( "bdsvd (s)" );
-        params.time7.name( "unmbr_tb2st_U (s)" );
+        params.time7.name( "unmbr_tb2bd_U (s)" );
         params.time8.name( "unmbr_ge2tb_U (s)" );
         params.time9.name( "unmqr (s) " );
-        params.time10.name( "unmbr_tb2st_V (s)" );
+        params.time10.name( "unmbr_tb2bd_V (s)" );
         params.time11.name( "unmbr_ge2tb_V (s)" );
         params.time12.name( "unmlq (s)" );
     }
@@ -229,12 +229,12 @@ void test_svd_work( Params& params, bool run )
             params.time2() = slate::timers[ "svd::geqrf" ];
             params.time3() = slate::timers[ "svd::gelqf" ];
             params.time4() = slate::timers[ "svd::ge2tb" ];
-            params.time5() = slate::timers[ "svd::tb2db" ];
+            params.time5() = slate::timers[ "svd::tb2bd" ];
             params.time6() = slate::timers[ "svd::bdsvd" ];
-            params.time7() = slate::timers[ "svd::unmtr_tb2st_U" ];
+            params.time7() = slate::timers[ "svd::unmtr_tb2bd_U" ];
             params.time8() = slate::timers[ "svd::unmbr_ge2tb_U" ];
             params.time9() = slate::timers[ "svd::unmqr" ];
-            params.time10() = slate::timers[ "svd::unmbr_tb2st_V" ];
+            params.time10() = slate::timers[ "svd::unmbr_tb2bd_V" ];
             params.time11() = slate::timers[ "svd::unmbr_ge2tb_V" ];
             params.time12() = slate::timers[ "svd::unmlq" ];
         }

--- a/test/test_svd.cc
+++ b/test/test_svd.cc
@@ -231,7 +231,7 @@ void test_svd_work( Params& params, bool run )
             params.time4() = slate::timers[ "svd::ge2tb" ];
             params.time5() = slate::timers[ "svd::tb2bd" ];
             params.time6() = slate::timers[ "svd::bdsvd" ];
-            params.time7() = slate::timers[ "svd::unmtr_tb2bd_U" ];
+            params.time7() = slate::timers[ "svd::unmbr_tb2bd_U" ];
             params.time8() = slate::timers[ "svd::unmbr_ge2tb_U" ];
             params.time9() = slate::timers[ "svd::unmqr" ];
             params.time10() = slate::timers[ "svd::unmbr_tb2bd_V" ];

--- a/test/test_svd.cc
+++ b/test/test_svd.cc
@@ -68,15 +68,19 @@ void test_svd_work( Params& params, bool run )
         params.time8();
         params.time9();
         params.time10();
+        params.time11();
+        params.time12();
         params.time2.name( "geqrf (s)" );
         params.time3.name( "gelqf (s)" );
         params.time4.name( "ge2tb (s)" );
         params.time5.name( "tb2db (s)" );
-        params.time6.name( "bdsqr (s)" );
-        params.time7.name( "unmtr_hb2st (s)" );
-        params.time8.name( "unmbr_ge2tb (s)" );
+        params.time6.name( "bdsvd (s)" );
+        params.time7.name( "unmbr_tb2st_U (s)" );
+        params.time8.name( "unmbr_ge2tb_U (s)" );
         params.time9.name( "unmqr (s) " );
-        params.time10.name( "unmlq (s)" );
+        params.time10.name( "unmbr_tb2st_V (s)" );
+        params.time11.name( "unmbr_ge2tb_V (s)" );
+        params.time12.name( "unmlq (s)" );
     }
 
     if (! run)
@@ -220,16 +224,19 @@ void test_svd_work( Params& params, bool run )
         // compute and save timing/performance
         params.time() = time;
 
+
         if (timer_level >= 2) {
             params.time2() = slate::timers[ "svd::geqrf" ];
             params.time3() = slate::timers[ "svd::gelqf" ];
             params.time4() = slate::timers[ "svd::ge2tb" ];
             params.time5() = slate::timers[ "svd::tb2db" ];
-            params.time6() = slate::timers[ "svd::bdsqr" ];
-            params.time7() = slate::timers[ "svd::unmtr_hb2st" ];
-            params.time8() = slate::timers[ "svd::unmbr_ge2tb" ];
+            params.time6() = slate::timers[ "svd::bdsvd" ];
+            params.time7() = slate::timers[ "svd::unmtr_tb2st_U" ];
+            params.time8() = slate::timers[ "svd::unmbr_ge2tb_U" ];
             params.time9() = slate::timers[ "svd::unmqr" ];
-            params.time10() = slate::timers[ "svd::unmlq" ];
+            params.time10() = slate::timers[ "svd::unmbr_tb2st_V" ];
+            params.time11() = slate::timers[ "svd::unmbr_ge2tb_V" ];
+            params.time12() = slate::timers[ "svd::unmlq" ];
         }
 
         print_matrix("D", 1, min_mn,   &Sigma[0], 1, params);

--- a/test/test_svd.cc
+++ b/test/test_svd.cc
@@ -46,6 +46,7 @@ void test_svd_work( Params& params, bool run )
     bool check = params.check() == 'y' && ! ref_only;
     bool trace = params.trace() == 'y';
     int verbose = params.verbose();
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     params.matrix.mark();
@@ -57,6 +58,26 @@ void test_svd_work( Params& params, bool run )
     params.ortho_V();
     params.error.name( "S - Sref" );
     params.error2.name( "Backward" );
+     if (timer_level >= 2) {
+        params.time2();
+        params.time3();
+        params.time4();
+	params.time5();
+	params.time6();
+	params.time7();
+	params.time8();
+	params.time9();
+	params.time10();
+        params.time2.name( "geqrf (s)" );
+        params.time3.name( "gelqf (s)" );
+        params.time4.name( "ge2tb (s)" );
+	params.time5.name( "tb2db (s)" );
+	params.time6.name( "bdsqr (s)" );
+	params.time7.name( "unmtr_hb2st (s)" );
+	params.time8.name( "unmbr_ge2tb (s)" );
+	params.time9.name( "unmqr (s) " );
+	params.time10.name( "unmlq (s)" );
+    }
 
     if (! run)
         return;
@@ -198,6 +219,18 @@ void test_svd_work( Params& params, bool run )
 
         // compute and save timing/performance
         params.time() = time;
+        
+        if (timer_level >= 2) {
+            params.time2() = slate::timers[ "svd::geqrf" ];
+            params.time3() = slate::timers[ "svd::gelqf" ];
+            params.time4() = slate::timers[ "svd::ge2tb" ];
+	    params.time5() = slate::timers[ "svd::tb2db" ];
+	    params.time6() = slate::timers[ "svd::bdsqr" ];
+	    params.time7() = slate::timers[ "svd::unmtr_hb2st" ];
+	    params.time8() = slate::timers[ "svd::unmbr_ge2tb" ];
+	    params.time9() = slate::timers[ "svd::unmqr" ];
+	    params.time10() = slate::timers[ "svd::unmlq" ];
+        }
 
         print_matrix("D", 1, min_mn,   &Sigma[0], 1, params);
         if (wantu) {

--- a/test/test_svd.cc
+++ b/test/test_svd.cc
@@ -58,25 +58,25 @@ void test_svd_work( Params& params, bool run )
     params.ortho_V();
     params.error.name( "S - Sref" );
     params.error2.name( "Backward" );
-     if (timer_level >= 2) {
+    if (timer_level >= 2) {
         params.time2();
         params.time3();
         params.time4();
-	params.time5();
-	params.time6();
-	params.time7();
-	params.time8();
-	params.time9();
-	params.time10();
+        params.time5();
+        params.time6();
+        params.time7();
+        params.time8();
+        params.time9();
+        params.time10();
         params.time2.name( "geqrf (s)" );
         params.time3.name( "gelqf (s)" );
         params.time4.name( "ge2tb (s)" );
-	params.time5.name( "tb2db (s)" );
-	params.time6.name( "bdsqr (s)" );
-	params.time7.name( "unmtr_hb2st (s)" );
-	params.time8.name( "unmbr_ge2tb (s)" );
-	params.time9.name( "unmqr (s) " );
-	params.time10.name( "unmlq (s)" );
+        params.time5.name( "tb2db (s)" );
+        params.time6.name( "bdsqr (s)" );
+        params.time7.name( "unmtr_hb2st (s)" );
+        params.time8.name( "unmbr_ge2tb (s)" );
+        params.time9.name( "unmqr (s) " );
+        params.time10.name( "unmlq (s)" );
     }
 
     if (! run)
@@ -219,17 +219,17 @@ void test_svd_work( Params& params, bool run )
 
         // compute and save timing/performance
         params.time() = time;
-        
+
         if (timer_level >= 2) {
             params.time2() = slate::timers[ "svd::geqrf" ];
             params.time3() = slate::timers[ "svd::gelqf" ];
             params.time4() = slate::timers[ "svd::ge2tb" ];
-	    params.time5() = slate::timers[ "svd::tb2db" ];
-	    params.time6() = slate::timers[ "svd::bdsqr" ];
-	    params.time7() = slate::timers[ "svd::unmtr_hb2st" ];
-	    params.time8() = slate::timers[ "svd::unmbr_ge2tb" ];
-	    params.time9() = slate::timers[ "svd::unmqr" ];
-	    params.time10() = slate::timers[ "svd::unmlq" ];
+            params.time5() = slate::timers[ "svd::tb2db" ];
+            params.time6() = slate::timers[ "svd::bdsqr" ];
+            params.time7() = slate::timers[ "svd::unmtr_hb2st" ];
+            params.time8() = slate::timers[ "svd::unmbr_ge2tb" ];
+            params.time9() = slate::timers[ "svd::unmqr" ];
+            params.time10() = slate::timers[ "svd::unmlq" ];
         }
 
         print_matrix("D", 1, min_mn,   &Sigma[0], 1, params);


### PR DESCRIPTION
Add additional timers to the following routines:

- `gesv`
- `posv`
- `heev`
- `svd`

This is being done such that we can capture timings for steps within each routine. 