### PR TITLE
Improve performance of ttmqr and friends

### DIFF
--- a/src/ge2tb.cc
+++ b/src/ge2tb.cc
@@ -228,7 +228,7 @@ void ge2tb(
                         bcast_list_V.push_back(
                             {i, k, {A.sub(i, i, k+1, A_nt-1)}});
                     }
-                    A.template listBcast(bcast_list_V, layout, 0);
+                    A.template listBcast<target>(bcast_list_V, layout, 0);
                 }
 
                 // bcast TUlocal across row for trailing matrix update
@@ -379,7 +379,7 @@ void ge2tb(
                             bcast_list_V.push_back(
                                 {k, j, {A.sub(k+1, A_mt-1, j, j)}});
                         }
-                        A.template listBcast(bcast_list_V, layout, 0);
+                        A.template listBcast<target>(bcast_list_V, layout, 0);
                     }
 
                     // bcast TVlocal down col for trailing matrix update

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -444,11 +444,11 @@ void he2hb(
                                     W.tileGetForWriting( i, k, HostNum, layoutc );
                                     MPI_Request req;
                                     if (neighbor < mpi_rank) {
-                                        W   .tileIsend( i, k, neighbor, tag_i, &req );
+                                        W  .tileIsend( i, k, neighbor, tag_i, &req );
                                         Wtmp.tileRecv( i, k, neighbor, layout, tag_i1 );
                                     }
                                     else {
-                                        W   .tileIsend( i, k, neighbor, tag_i1, &req );
+                                        W  .tileIsend( i, k, neighbor, tag_i1, &req );
                                         Wtmp.tileRecv( i, k, neighbor, layout, tag_i );
                                     }
                                     MPI_Wait( &req, MPI_STATUS_IGNORE );

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -574,8 +574,9 @@ void he2hb(
                     depend( inout:block[ nt-1 ] ) \
                     depend( inout:fetch_trailing[ 0 ] ) \
                     shared( A ) \
-                    firstprivate( A_panel, Treduce_panel, k, nt, tag_0, opts2 )
+                    firstprivate( A_panel, Treduce_panel, k, nt, opts2 )
                 {
+                    int tag_base = A.mt()*A.mt();
                     // Do 2-sided Hermitian update:
                     // 3. A = Q^H A Q
                     internal::hettmqr<Target::HostTask>(
@@ -583,7 +584,7 @@ void he2hb(
                         std::move( A_panel ),
                         std::move( Treduce_panel ),
                         A.sub( k+1, nt-1 ),
-                        tag_0, opts2 );
+                        tag_base, opts2 );
                 }
             }
 

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -374,16 +374,13 @@ void he2hb(
                         }
                     }
                     int64_t i0 = panel_rank_rows[ 0 ];
-                    int dev_i0k = -1;
-                    if (target == Target::Devices)
-                        dev_i0k = A.tileDevice(i0, k);
 
                     #pragma omp task slate_omp_default_none \
                         depend( inout:block[ k ] ) \
                         shared( A, Asave ) \
-                        firstprivate( zero, one, i0, k, dev_i0k, layoutc )
+                        firstprivate( zero, one, i0, k, layoutc )
                     {
-                        if (A.tileExists( i0, k, dev_i0k)) {
+                        if (A.tileExists( i0, k, AnyDevice )) {
                             A.tileGetForWriting( i0, k, HostNum, layoutc );
                             // Save V0 and set upper(V0) to identity, to avoid trmm's.
                             Asave.tileInsert( i0, k );
@@ -559,9 +556,9 @@ void he2hb(
                     #pragma omp task slate_omp_default_none \
                         depend( inout:block[ k ] ) \
                         shared( A, Asave ) \
-                        firstprivate( i0, k, dev_i0k, layoutc )
+                        firstprivate( i0, k, layoutc )
                     {
-                        if (A.tileExists( i0, k, dev_i0k )) {
+                        if (A.tileExists( i0, k, AnyDevice )) {
                             A.tileGetForWriting( i0, k, layoutc );
                             tile::gecopy( Asave( i0, k ), A( i0, k ) );
                             Asave.tileErase( i0, k );

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -590,7 +590,7 @@ void he2hb(
             // Release workspace tiles
             #pragma omp task slate_omp_default_none \
                 depend( inout:block[ k ] ) \
-                shared( A_panel, Tlocal, Treduce ) \
+                firstprivate( A_panel, Tlocal, Treduce ) \
                 firstprivate( k, nt, first_indices )
             {
                 // Ensure the origin is up to date, then remove the panel's workspace

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -487,10 +487,6 @@ void he2hb(
 
                             // 1d. TVAVT = V^H (A V T) = V^H W.
                             // todo: potentially do gemm+reduce here (block inner-product)
-                            // todo: shouldn't need to set TVAVT = 0 since beta = 0.
-                            // todo: on GPU
-                            TVAVT.tileGetForWriting( 0, 0, HostNum, layoutc );
-                            TVAVT( 0, 0 ).set( zero );
                             internal::he2hb_gemm<target>(
                                 one,  conj_transpose( A.sub( k+1, nt-1, k, k ) ),
                                       W.sub( k+1, nt-1, k, k ),

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -45,7 +45,6 @@ void he2hb(
     const int batch_size_default = 0;
     const int num_queues = 10;
     const int queue_0 = 0;
-    const int tag_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layoutc = LayoutConvert( layout );

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -445,18 +445,17 @@ void he2hb(
                                     Wtmp.tileInsert( i, k );
                                     int tag_i = i;
                                     int tag_i1 = i+1;
+                                    W.tileGetForWriting( i, k, HostNum, layoutc );
+                                    MPI_Request req;
                                     if (neighbor < mpi_rank) {
-                                        W.tileGetForWriting( i, k, HostNum,
-                                                             layoutc );
-                                        W   .tileSend( i, k, neighbor, tag_i );
+                                        W   .tileIsend( i, k, neighbor, tag_i, &req );
                                         Wtmp.tileRecv( i, k, neighbor, layout, tag_i1 );
                                     }
                                     else {
-                                        W.tileGetForWriting( i, k, HostNum,
-                                                             layoutc );
+                                        W   .tileIsend( i, k, neighbor, tag_i1, &req );
                                         Wtmp.tileRecv( i, k, neighbor, layout, tag_i );
-                                        W   .tileSend( i, k, neighbor, tag_i1 );
                                     }
+                                    MPI_Wait( &req, MPI_STATUS_IGNORE );
                                     auto Wtmp_ik = Wtmp( i, k );
                                     auto W_ik = W( i, k );
                                     blas::axpy( W_ik.nb()*W_ik.nb(),

--- a/src/internal/internal_he2hb_gemm.cc
+++ b/src/internal/internal_he2hb_gemm.cc
@@ -69,6 +69,7 @@ void he2hb_gemm(
         #pragma omp task slate_omp_default_none \
             shared( A, B, C ) \
             firstprivate( alpha, beta, panel_rank, i, layoutc, call_tile_tick ) \
+            firstprivate( one, zero ) \
             priority( priority )
         {
             scalar_t beta_ = beta;

--- a/src/internal/internal_hettmqr.cc
+++ b/src/internal/internal_hettmqr.cc
@@ -71,7 +71,7 @@ void hettmqr(
     Matrix<scalar_t>& V,
     Matrix<scalar_t>& T,
     HermitianMatrix<scalar_t>& C,
-    int tag, Options const& opts )
+    int tag_base, Options const& opts )
 {
     trace::Block trace_block("internal::hettmqr");
     using blas::conj;
@@ -140,6 +140,7 @@ void hettmqr(
     // ^H are temporary conj-transposed copies, and
     // (*) shows where conj-transposed tiles come from.
 
+    std::vector<MPI_Request> requests;
     for (int level = 0; level < nlevels; ++level) {
         // index is first node of each pair.
         for (int index = 0; index + step < nranks; index += 2*step) {
@@ -158,44 +159,57 @@ void hettmqr(
                     C.tileGetForWriting(i, i, LayoutConvert(layout));
                     make_hermitian( C(i, i) );
                     int dst = C.tileRank(i2, i1);
+                    int tag = tag_base + i + i*C.mt();
                     C.tileSend(i, i, dst, tag);
                     C.tileRecv(i, i, dst, layout, tag);
                 }
             }
             if (C.tileIsLocal(i2, i1)) {
-                // Receive tiles from sources, apply Q on both sides,
-                // then send updated tiles back.
-                int src11 = C.tileRank(i1, i1);
-                C.tileRecv(i1, i1, src11, layout, tag);
+                #pragma omp task
+                {
+                    // Receive tiles from sources, apply Q on both sides,
+                    // then send updated tiles back.
+                    int src11 = C.tileRank(i1, i1);
+                    int tag_i1 = tag_base + i1 + i1*C.mt();
+                    C.tileRecv(i1, i1, src11, layout, tag_i1);
 
-                int src22 = C.tileRank(i2, i2);
-                C.tileRecv(i2, i2, src22, layout, tag);
+                    int src22 = C.tileRank(i2, i2);
+                    int tag_i2 = tag_base + i2 + i2*C.mt();
+                    C.tileRecv(i2, i2, src22, layout, tag_i2);
 
-                V.tileGetForReading(i2, 0,  LayoutConvert(layout));
-                T.tileGetForReading(i2, 0,  LayoutConvert(layout));
-                C.tileGetForWriting(i2, i1, LayoutConvert(layout));
+                    V.tileGetForReading(i2, 0,  LayoutConvert(layout));
+                    T.tileGetForReading(i2, 0,  LayoutConvert(layout));
+                    C.tileGetForWriting(i2, i1, LayoutConvert(layout));
 
-                // Workspace C(i1, i2) = C(i2, i1)^H.
-                C.tileInsert(i1, i2);
-                tile::deepConjTranspose( C(i2, i1), C(i1, i2) );
+                    // Workspace C(i1, i2) = C(i2, i1)^H.
+                    C.tileInsert(i1, i2);
+                    tile::deepConjTranspose( C(i2, i1), C(i1, i2) );
 
-                int64_t nb = std::min(V.tileMb(i2), V.tileNb(0));
-                tpmqrt(Side::Left, op, nb,
-                       V(i2, 0), T(i2, 0), C(i1, i1), C(i2, i1));  // 1st col
-                tpmqrt(Side::Left, op, nb,
-                       V(i2, 0), T(i2, 0), C(i1, i2), C(i2, i2));  // 2nd col
-                tpmqrt(Side::Right, opR, nb,
-                       V(i2, 0), T(i2, 0), C(i1, i1), C(i1, i2));  // 1st row
-                tpmqrt(Side::Right, opR, nb,
-                       V(i2, 0), T(i2, 0), C(i2, i1), C(i2, i2));  // 2nd row
+                    int64_t nb = std::min(V.tileMb(i2), V.tileNb(0));
+                    #pragma omp task
+                    tpmqrt(Side::Left, op, nb,
+                           V(i2, 0), T(i2, 0), C(i1, i1), C(i2, i1));  // 1st col
+                    #pragma omp task
+                    tpmqrt(Side::Left, op, nb,
+                           V(i2, 0), T(i2, 0), C(i1, i2), C(i2, i2));  // 2nd col
+                    #pragma omp taskwait
+                    #pragma omp task
+                    tpmqrt(Side::Right, opR, nb,
+                           V(i2, 0), T(i2, 0), C(i1, i1), C(i1, i2));  // 1st row
+                    #pragma omp task
+                    tpmqrt(Side::Right, opR, nb,
+                           V(i2, 0), T(i2, 0), C(i2, i1), C(i2, i2));  // 2nd row
 
-                C.tileSend(i1, i1, src11, tag);
-                C.tileSend(i2, i2, src22, tag);
-                if (call_tile_tick) {
-                    C.tileTick(i1, i1);
-                    C.tileTick(i2, i2);
+                    #pragma omp taskwait
+
+                    C.tileSend(i1, i1, src11, tag_i1);
+                    C.tileSend(i2, i2, src22, tag_i2);
+                    if (call_tile_tick) {
+                        C.tileTick(i1, i1);
+                        C.tileTick(i2, i2);
+                    }
+                    C.tileErase(i1, i2);  // Discard results; equals C(i2, i1)^H.
                 }
-                C.tileErase(i1, i2);  // Discard results; equals C(i2, i1)^H.
             }
 
             //--------------------
@@ -213,6 +227,7 @@ void hettmqr(
                 if (j == i1)
                     continue;
 
+                int tag = tag_base + i1 + j*C.mt();
                 if ((i1 >= j && C.tileIsLocal(i1, j)) ||
                     (i1 <  j && C.tileIsLocal(j, i1))) {
                     // First node of each pair sends tile to dst.
@@ -257,10 +272,20 @@ void hettmqr(
                             V.tileTick(i2, 0);
                             T.tileTick(i2, 0);
                         }
+
+                        // Sends updated tile back.
+                        int src = (i1 >= j
+                                  ? C.tileRank(i1, j)
+                                  : C.tileRank(j, i1));
+                        int tag = tag_base + i1 + j*C.mt();
+                        // Send updated tile back.
+                        C.tileSend(i1, j, src, tag);
+                        if (call_tile_tick) {
+                            C.tileTick(i1, j);
+                        }
                     }
                 }
             } // for j
-            #pragma omp taskwait
 
             for (int64_t j = 0; j < i2; ++j) {
                 if (j == i1)
@@ -269,6 +294,7 @@ void hettmqr(
                 if ((i1 >= j && C.tileIsLocal(i1, j)) ||
                     (i1 <  j && C.tileIsLocal(j, i1))) {
                     // Receives updated tile back ().
+                    int tag = tag_base + i1 + j*C.mt();
                     int dst = C.tileRank(i2, j);
                     if (i1 >= j) {
                         C.tileRecv(i1, j, dst, layout, tag);
@@ -278,20 +304,11 @@ void hettmqr(
                         tile::deepConjTranspose(C(j, i1));
                     }
                 }
-                else if (C.tileIsLocal(i2, j)) {
-                    // Sends updated tile back.
-                    int src = (i1 >= j
-                              ? C.tileRank(i1, j)
-                              : C.tileRank(j, i1));
-                    // Send updated tile back.
-                    C.tileSend(i1, j, src, tag);
-                    if (call_tile_tick) {
-                        C.tileTick(i1, j);
-                    }
-                }
             } // for j
-        } // for index
+        }
+        #pragma omp taskwait
 
+        requests.clear();
         for (int index = 0; index + step < nranks; index += 2*step) {
             int64_t j1 = rank_indices[ index ].second;
             int64_t j2 = rank_indices[ index + step ].second;
@@ -299,22 +316,20 @@ void hettmqr(
             //--------------------
             // 3: Multiply [ C(i, j1)  C(i, j2) ] * Q for i = j2+1, ..., mt-1.
             for (int64_t i = j2+1; i < C.mt(); ++i) {
+                int tag = tag_base + i + j1*C.mt();
                 if (C.tileIsLocal(i, j1)) {
                     // First node of each pair sends tile to dst.
                     int dst = C.tileRank(i, j2);
-                    C.tileSend(i, j1, dst, tag);
+                    MPI_Request req;
+                    C.tileIsend( i, j1, dst, tag, &req );
+                    MPI_Request_free( &req );
                 }
                 else if (C.tileIsLocal(i, j2)) {
                     // Second node of each pair receives tile from src.
                     int src = C.tileRank(i, j1);
                     C.tileRecv(i, j1, src, layout, tag);
-                }
-            } // for i
-
-            for (int64_t i = j2+1; i < C.mt(); ++i) {
-                if (C.tileIsLocal(i, j2)) {
                     // Applies Q, then sends updated tile back.
-                    #pragma omp task shared(V, T, C) firstprivate(call_tile_tick)
+                    #pragma omp task shared(V, T, C) firstprivate(call_tile_tick, src, tag)
                     {
                         V.tileGetForReading(j2, 0, LayoutConvert(layout));
                         T.tileGetForReading(j2, 0, LayoutConvert(layout));
@@ -324,6 +339,7 @@ void hettmqr(
                         tpmqrt(Side::Right, opR, std::min(V.tileMb(j2), V.tileNb(0)),
                                V(j2, 0), T(j2, 0), C(i, j1), C(i, j2));
 
+                        C.tileSend(i, j1, src, tag);
                         if (call_tile_tick) {
                             // todo: should tileRelease()?
                             V.tileTick(j2, 0);
@@ -332,25 +348,21 @@ void hettmqr(
                     }
                 }
             } // for i
-            #pragma omp taskwait
 
             for (int64_t i = j2+1; i < C.mt(); ++i) {
+                int tag = tag_base + i + j1*C.mt();
                 if (C.tileIsLocal(i, j1)) {
                     // Receives updated tile back.
                     int dst = C.tileRank(i, j2);
-                    C.tileRecv(i, j1, dst, layout, tag);
-                }
-                else if (C.tileIsLocal(i, j2)) {
-                    int src = C.tileRank(i, j1);
-
-                    // Send updated tile back.
-                    C.tileSend(i, j1, src, tag);
-                    if (call_tile_tick) {
-                        C.tileTick(i, j1);
-                    }
+                    MPI_Request req;
+                    C.tileIrecv( i, j1, dst, layout, tag, &req );
+                    requests.push_back( req );
                 }
             } // for i
         } // for index
+        slate_mpi_call(
+            MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
+        #pragma omp taskwait
 
         //--------------------
         // Next level.

--- a/src/internal/internal_hettmqr.cc
+++ b/src/internal/internal_hettmqr.cc
@@ -292,11 +292,6 @@ void hettmqr(
             } // for j
         } // for index
 
-        //--------------------
-        // Finish updating all rows before updating columns.
-        slate_mpi_call(
-            MPI_Barrier(C.mpiComm()));
-
         for (int index = 0; index + step < nranks; index += 2*step) {
             int64_t j1 = rank_indices[ index ].second;
             int64_t j2 = rank_indices[ index + step ].second;

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -159,7 +159,7 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                         }
                         int dst = C.tileRank(i_dst, j_dst);
                         // Don't need to wait since the tile isn't modified
-                        // until recieving it back
+                        // until receiving it back
                         MPI_Request req;
                         C.tileIsend( i, j, dst, tag+k, &req );
                         MPI_Request_free( &req );

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -127,42 +127,99 @@ void ttmlq(internal::TargetType<Target::HostTask>,
         for (int index = 0; index < nranks; index += step) {
             int64_t rank_ind = rank_indices[ index ].second;
             requests.clear();
-            // if (side == left), scan rows of C for local tiles;
-            // if (side == right), scan cols of C for local tiles
-            // Three for-loops: 1) send, receive 2) update 3) receive, send
-            for (int64_t k = 0; k < k_end; ++k) {
-                if (side == Side::Left) {
-                    i = rank_ind;
-                    j = k;
+
+            if (index % (2*step) == 0) {
+                if (index + step >= nranks) {
+                    break;
                 }
-                else {
-                    i = k;
-                    j = rank_ind;
-                }
-                if (C.tileIsLocal(i, j)) {
-                    if (index % (2*step) == 0) {
-                        if (index + step < nranks) {
-                            // Send tile to dst.
-                            int64_t k_dst = rank_indices[ index + step ].second;
-                            if (side == Side::Left) {
-                                i_dst = k_dst;
-                                j_dst = k;
-                            }
-                            else {
-                                i_dst = k;
-                                j_dst = k_dst;
-                            }
-                            int dst = C.tileRank(i_dst, j_dst);
-                            // Don't need to wait since the tile isn't modified
-                            // until recieving it back
-                            MPI_Request req;
-                            C.tileIsend( i, j, dst, tag, &req );
-                            MPI_Request_free( &req );
-                        }
+                int64_t k_dst = rank_indices[ index + step ].second;
+
+                size_t message_count = 0;
+                // if (side == left), scan rows of C for local tiles;
+                // if (side == right), scan cols of C for local tiles
+                // Three for-loops: 1) send, receive 2) update 3) receive, send
+                for (int64_t k = 0; k < k_end; ++k) {
+                    if (side == Side::Left) {
+                        i = rank_ind;
+                        j = k;
                     }
                     else {
+                        i = k;
+                        j = rank_ind;
+                    }
+                    if (C.tileIsLocal(i, j)) {
+                        // Send tile to dst.
+                        if (side == Side::Left) {
+                            i_dst = k_dst;
+                            j_dst = k;
+                        }
+                        else {
+                            i_dst = k;
+                            j_dst = k_dst;
+                        }
+                        int dst = C.tileRank(i_dst, j_dst);
+                        // Don't need to wait since the tile isn't modified
+                        // until recieving it back
+                        MPI_Request req;
+                        C.tileIsend( i, j, dst, tag+k, &req );
+                        MPI_Request_free( &req );
+                        message_count++;
+                    }
+                }
+
+
+                if (message_count == 0) {
+                    continue;
+                }
+
+                // Avoid incrementally reallocating
+                requests.reserve(message_count);
+
+                for (int64_t k = 0; k < k_end; ++k) {
+                    if (side == Side::Left) {
+                        i = rank_ind;
+                        j = k;
+                    }
+                    else {
+                        i = k;
+                        j = rank_ind;
+                    }
+                    if (C.tileIsLocal(i, j)) {
+                        // Receive updated tile back.
+                        if (side == Side::Left) {
+                            i_dst = k_dst;
+                            j_dst = k;
+                        }
+                        else {
+                            i_dst = k;
+                            j_dst = k_dst;
+                        }
+                        int dst = C.tileRank(i_dst, j_dst);
+                        MPI_Request req;
+                        C.tileIrecv( i, j, dst, layout, tag+k, &req );
+                        requests.push_back( req );
+                    }
+                }
+                slate_mpi_call(
+                    MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
+            }
+            else {
+                int64_t k_src = rank_indices[ index - step ].second;
+                size_t message_count = 0;
+                // if (side == left), scan rows of C for local tiles;
+                // if (side == right), scan cols of C for local tiles
+                // Three for-loops: 1) send, receive 2) update 3) receive, send
+                for (int64_t k = 0; k < k_end; ++k) {
+                    if (side == Side::Left) {
+                        i = rank_ind;
+                        j = k;
+                    }
+                    else {
+                        i = k;
+                        j = rank_ind;
+                    }
+                    if (C.tileIsLocal(i, j)) {
                         // Receive tile from src.
-                        int64_t k_src = rank_indices[ index - step ].second;
                         if (side == Side::Left) {
                             i1 = k_src;
                             j1 = k;
@@ -174,28 +231,29 @@ void ttmlq(internal::TargetType<Target::HostTask>,
 
                         int src = C.tileRank( i1, j1 );
                         MPI_Request req;
-                        C.tileIrecv( i1, j1, src, layout, tag, &req );
+                        C.tileIrecv( i1, j1, src, layout, tag+k, &req );
                         requests.push_back( req );
+                        message_count++;
                     }
                 }
-            }
 
-            // The above and below loops iterate in the same order, so incrementing
-            // this counter gives the right request object
-            int64_t recv_index = 0;
-            #pragma omp taskgroup
-            for (int64_t k = 0; k < k_end; ++k) {
-                if (side == Side::Left) {
-                    i = rank_ind;
-                    j = k;
+                if (message_count == 0) {
+                    continue;
                 }
-                else {
-                    i = k;
-                    j = rank_ind;
-                }
-                if (C.tileIsLocal(i, j)) {
-                    if (!(index % (2*step) == 0)) {
-                        int64_t k_src = rank_indices[ index - step ].second;
+
+                // The above and below loops iterate in the same order, so incrementing
+                // this counter gives the right request object
+                int64_t recv_index = 0;
+                for (int64_t k = 0; k < k_end; ++k) {
+                    if (side == Side::Left) {
+                        i = rank_ind;
+                        j = k;
+                    }
+                    else {
+                        i = k;
+                        j = rank_ind;
+                    }
+                    if (C.tileIsLocal(i, j)) {
                         if (side == Side::Left) {
                             i1 = k_src;
                             j1 = k;
@@ -208,10 +266,10 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                         #pragma omp task slate_omp_default_none \
                             shared( A, T, C, requests ) \
                             firstprivate( i, j, layout, rank_ind, i1, j1, side, op ) \
-                            firstprivate( call_tile_tick, recv_index )
+                            firstprivate( recv_index )
                         {
                             // Don't start compute until the tile's been recieved
-                            MPI_Wait( &requests[recv_index], MPI_STATUS_IGNORE );
+                            MPI_Wait( &requests[ recv_index ], MPI_STATUS_IGNORE );
 
                             A.tileGetForReading(0, rank_ind, LayoutConvert(layout));
                             T.tileGetForReading(0, rank_ind, LayoutConvert(layout));
@@ -222,71 +280,18 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                                    A(0, rank_ind), T(0, rank_ind),
                                    C(i1, j1), C(i, j));
 
-                            if (call_tile_tick) {
-                                // todo: should tileRelease()?
-                                A.tileTick(0, rank_ind);
-                                T.tileTick(0, rank_ind);
-                            }
+                            int src = C.tileRank( i1, j1 );
+                            // Send updated tile back.
+                            C.tileIsend( i1, j1, src, tag+k, &requests[ recv_index ] );
                         }
                         recv_index++;
                     }
                 }
+                #pragma omp taskwait
+                slate_mpi_call(
+                    MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
             }
-
-            // All requests were completed above
-            requests.clear();
-
-            for (int64_t k = 0; k < k_end; ++k) {
-                if (side == Side::Left) {
-                    i = rank_ind;
-                    j = k;
-                }
-                else {
-                    i = k;
-                    j = rank_ind;
-                }
-                if (C.tileIsLocal(i, j)) {
-                    if (index % (2*step) == 0) {
-                        if (index + step < nranks) {
-                            // Receive updated tile back.
-                            int64_t k_dst = rank_indices[ index + step ].second;
-                            if (side == Side::Left) {
-                                i_dst = k_dst;
-                                j_dst = k;
-                            }
-                            else {
-                                i_dst = k;
-                                j_dst = k_dst;
-                            }
-                            int dst = C.tileRank(i_dst, j_dst);
-                            MPI_Request req;
-                            C.tileIrecv( i, j, dst, layout, tag, &req );
-                            requests.push_back( req );
-                        }
-                    }
-                    else {
-                        int64_t k_src = rank_indices[ index - step ].second;
-                        if (side == Side::Left) {
-                            i1 = k_src;
-                            j1 = k;
-                        }
-                        else {
-                            i1 = k;
-                            j1 = k_src;
-                        }
-                        int     src   = C.tileRank(i1, j1);
-                        // Send updated tile back.
-                        MPI_Request req;
-                        C.tileIsend( i1, j1, src, tag, &req );
-                        requests.push_back( req );
-                        //if (call_tile_tick) {
-                        //    C.tileTick(i1, j1);
-                        //}
-                    }
-                }
-            }
-            slate_mpi_call(
-                MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
+            break;
         }
         if (descend)
             step /= 2;

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -157,7 +157,7 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                             // until recieving it back
                             MPI_Request req;
                             C.tileIsend( i, j, dst, tag, &req );
-                            MPI_Request_free( & req );
+                            MPI_Request_free( &req );
                         }
                     }
                     else {
@@ -211,7 +211,7 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                             firstprivate( call_tile_tick, recv_index )
                         {
                             // Don't start compute until the tile's been recieved
-                            MPI_Wait( &requests[recv_index], MPI_STATUS_IGNORE ) );
+                            MPI_Wait( &requests[recv_index], MPI_STATUS_IGNORE );
 
                             A.tileGetForReading(0, rank_ind, LayoutConvert(layout));
                             T.tileGetForReading(0, rank_ind, LayoutConvert(layout));
@@ -245,7 +245,6 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                     i = k;
                     j = rank_ind;
                 }
-                MPI_Request req;
                 if (C.tileIsLocal(i, j)) {
                     if (index % (2*step) == 0) {
                         if (index + step < nranks) {
@@ -260,8 +259,9 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                                 j_dst = k_dst;
                             }
                             int dst = C.tileRank(i_dst, j_dst);
-                            assert( (C.tileState( i, j, HostNum ) & MOSI::Modified) != 0 );
+                            MPI_Request req;
                             C.tileIrecv( i, j, dst, layout, tag, &req );
+                            requests.push_back( req );
                         }
                     }
                     else {
@@ -276,15 +276,17 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                         }
                         int     src   = C.tileRank(i1, j1);
                         // Send updated tile back.
+                        MPI_Request req;
                         C.tileIsend( i1, j1, src, tag, &req );
+                        requests.push_back( req );
                         //if (call_tile_tick) {
                         //    C.tileTick(i1, j1);
                         //}
                     }
                 }
-                slate_mpi_call(
-                    MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
             }
+            slate_mpi_call(
+                MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
         }
         if (descend)
             step /= 2;

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -265,8 +265,8 @@ void ttmlq(internal::TargetType<Target::HostTask>,
 
                         #pragma omp task slate_omp_default_none \
                             shared( A, T, C, requests ) \
-                            firstprivate( i, j, layout, rank_ind, i1, j1, side, op ) \
-                            firstprivate( recv_index )
+                            firstprivate( i, j, k, rank_ind, layout, i1, j1 ) \
+                            firstprivate( side, op, tag, recv_index )
                         {
                             // Don't start compute until the tile's been recieved
                             MPI_Wait( &requests[ recv_index ], MPI_STATUS_IGNORE );

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -160,7 +160,7 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                         }
                         int dst = C.tileRank(i_dst, j_dst);
                         // Don't need to wait since the tile isn't modified
-                        // until recieving it back
+                        // until receiving it back
                         MPI_Request req;
                         C.tileIsend( i, j, dst, tag+k, &req );
                         MPI_Request_free( &req );

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -266,8 +266,8 @@ void ttmqr(internal::TargetType<Target::HostTask>,
 
                         #pragma omp task slate_omp_default_none \
                             shared( A, T, C, requests ) \
-                            firstprivate( i, j, layout, rank_ind, i1, j1, side, op ) \
-                            firstprivate( recv_index )
+                            firstprivate( i, j, k, rank_ind, layout, i1, j1 ) \
+                            firstprivate( side, op, tag, recv_index )
                         {
                             // Don't start compute until the tile's been recieved
                             MPI_Wait( &requests[ recv_index ], MPI_STATUS_IGNORE );

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -63,6 +63,8 @@ void ttmqr(internal::TargetType<Target::HostTask>,
 
     bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
                           || tile_release_strategy == TileReleaseStrategy::All;
+    // This routine assumes that tiles are never ticked for optimization's sake
+    assert( ! call_tile_tick );
 
     // Find ranks in this column of A.
     std::set<int> ranks_set;
@@ -120,9 +122,11 @@ void ttmqr(internal::TargetType<Target::HostTask>,
         k_end = C.mt();
     }
 
+    std::vector<MPI_Request> requests;
     for (int level = 0; level < nlevels; ++level) {
         for (int index = 0; index < nranks; index += step) {
             int64_t rank_ind = rank_indices[ index ].second;
+            requests.clear();
             // if (side == left), scan rows of C for local tiles;
             // if (side == right), scan cols of C for local tiles
             // Three for-loops: 1) send, receive 2) update 3) receive, send
@@ -149,9 +153,11 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                                 j_dst = k_dst;
                             }
                             int dst = C.tileRank(i_dst, j_dst);
-                            // GetForWriting because it will be received in the later loop
-                            C.tileGetForWriting(i, j, LayoutConvert(layout));
-                            C.tileSend(i, j, dst, tag);
+                            // Don't need to wait since the tile isn't modified
+                            // until recieving it back
+                            MPI_Request req;
+                            C.tileIsend( i, j, dst, tag, &req );
+                            MPI_Request_free( &req );
                         }
                     }
                     else {
@@ -166,12 +172,17 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                             j1 = k_src;
                         }
 
-                        int     src   = C.tileRank(i1, j1);
-                        C.tileRecv(i1, j1, src, layout, tag);
+                        int src = C.tileRank( i1, j1 );
+                        MPI_Request req;
+                        C.tileIrecv( i1, j1, src, layout, tag, &req );
+                        requests.push_back( req );
                     }
                 }
             }
 
+            // The above and below loops iterate in the same order, so incrementing
+            // this counter gives the right request object
+            int64_t recv_index = 0;
             #pragma omp taskgroup
             for (int64_t k = 0; k < k_end; ++k) {
                 if (side == Side::Left) {
@@ -195,10 +206,13 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                         }
 
                         #pragma omp task slate_omp_default_none \
-                            shared( A, T, C ) \
+                            shared( A, T, C, requests ) \
                             firstprivate( i, j, layout, rank_ind, i1, j1, side, op ) \
-                            firstprivate( call_tile_tick )
+                            firstprivate( call_tile_tick, recv_index )
                         {
+                            // Don't start compute until the tile's been recieved
+                            MPI_Wait( &requests[recv_index], MPI_STATUS_IGNORE ) );
+
                             A.tileGetForReading(rank_ind, 0, LayoutConvert(layout));
                             T.tileGetForReading(rank_ind, 0, LayoutConvert(layout));
                             C.tileGetForWriting(i, j, LayoutConvert(layout));
@@ -214,9 +228,13 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                                 T.tileTick(rank_ind, 0);
                             }
                         }
+                        recv_index++;
                     }
                 }
             }
+
+            // All requests were completed above
+            requests.clear();
 
             for (int64_t k = 0; k < k_end; ++k) {
                 if (side == Side::Left) {
@@ -227,6 +245,7 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                     i = k;
                     j = rank_ind;
                 }
+                MPI_Request req;
                 if (C.tileIsLocal(i, j)) {
                     if (index % (2*step) == 0) {
                         if (index + step < nranks) {
@@ -242,7 +261,7 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                             }
                             int dst = C.tileRank(i_dst, j_dst);
                             assert( (C.tileState( i, j, HostNum ) & MOSI::Modified) != 0 );
-                            C.tileRecv(i, j, dst, layout, tag);
+                            C.tileIrecv(i, j, dst, layout, tag, &req);
                         }
                     }
                     else {
@@ -255,15 +274,18 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                             i1 = k;
                             j1 = k_src;
                         }
-                        int     src   = C.tileRank(i1, j1);
+                        int src = C.tileRank( i1, j1 );
                         // Send updated tile back.
-                        C.tileSend(i1, j1, src, tag);
-                        if (call_tile_tick) {
-                            C.tileTick(i1, j1);
-                        }
+                        C.tileIsend( i1, j1, src, tag, &req );
+                        //if (call_tile_tick) {
+                        //    C.tileTick(i1, j1);
+                        //}
                     }
                 }
+                requests.push_back( req );
             }
+            slate_mpi_call(
+                MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
         }
         if (descend)
             step /= 2;

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -143,7 +143,7 @@ void unmlq(
                     bcast_list_V.push_back(
                         {k, j, {C.sub(i0, i1, j0, j1)}});
                 }
-                A.template listBcast(bcast_list_V, layout, 0, 1);
+                A.template listBcast<target>(bcast_list_V, layout, 0, 1);
 
                 // Send Tlocal(j) across row C(j, 0:nt-1) or col C(0:mt-1, j).
                 if (first_indices.size() > 0) {

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -147,7 +147,7 @@ void unmqr(
                     bcast_list_V.push_back(
                         {i, k, {C.sub(i0, i1, j0, j1)}});
                 }
-                A.template listBcast(bcast_list_V, layout, 0, 1);
+                A.template listBcast<target>(bcast_list_V, layout, 0, 1);
 
                 // Send Tlocal(i) across row C(i, 0:nt-1) or col C(0:mt-1, i).
                 if (first_indices.size() > 0) {

--- a/unit_test/test_lq.cc
+++ b/unit_test/test_lq.cc
@@ -379,11 +379,14 @@ void test_ttlqt_work( int m, int n, int nb, int ib, int p, int q )
         T_panel.tileBcast( 0, j, T.sub( 0, T.mt()-1, j, j ), slate::Layout::ColMajor );
     }
     if (debug) printf( "rank %2d, ttmlq\n", mpi_rank );
+    slate::Options const opts = {{slate::Option::TileReleaseStrategy,
+                                            slate::TileReleaseStrategy::Slate}};
     slate::internal::ttmlq(
         slate::Side::Right, slate::Op::NoTrans,
         std::move( A_panel ),
         std::move( T ),
-        std::move( L ));
+        std::move( L ),
+        0, opts);
     if (verbose > 1) {
         slate::print( "LQ", L );
     }

--- a/unit_test/test_qr.cc
+++ b/unit_test/test_qr.cc
@@ -380,11 +380,14 @@ void test_ttqrt_work( int m, int n, int nb, int ib, int p, int q )
         T_panel.tileBcast( i, 0, T.sub( i, i, 0, T.nt()-1 ), slate::Layout::ColMajor );
     }
     if (debug) printf( "rank %2d, ttmqr\n", mpi_rank );
+    slate::Options const opts = {{slate::Option::TileReleaseStrategy,
+                                            slate::TileReleaseStrategy::Slate}};
     slate::internal::ttmqr(
         slate::Side::Left, slate::Op::NoTrans,
         std::move( A_panel ),
         std::move( T ),
-        std::move( R ));
+        std::move( R ),
+        0, opts);
     if (verbose > 1) {
         slate::print( "QR", R );
     }


### PR DESCRIPTION
This increases the available parallelism in `ttmqr`, `ttmlq`, and `hettmqr`.  Additionally, I cleaned up a few minor things in `src/he2hb.cc`.

Speedups for various routines on 8 nodes of Frontier with CPU-only MPI and `--origin d --target d --dim 100000` (plus some warm up sizes).
| Routine | Speedup |
|--------|-------|
| he2hb   | 1.17x   |
| ge2tb   | 1.47x   |
| unmqr   | 1.07x   |

