### PR TITLE
ci: run on idle GPUs

### DIFF
--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -106,6 +106,14 @@ mpicxx --version
 mpif90 --version
 
 #----------------------------------------------------------------- GPU
+# Find idle GPUs. gpu_bind.sh also uses ${idle_gpus}.
+# Arrays can't be exported, effectively.
+export idle_gpus=$(./tools/idle_gpus.py)
+idle_gpus_array=(${idle_gpus})  # convert to array
+gpu_kind=${idle_gpus_array[0]}  # element 0 is gpu_kind: cuda or rocm
+idle_gpus_array=(${idle_gpus_array[@]:1})  # slice elements 1:end
+
+#----------------------------------------------------------------- GPU
 if [ "${device}" = "gpu_nvidia" ]; then
     print "======================================== Load CUDA"
     quiet module load cuda
@@ -114,6 +122,9 @@ if [ "${device}" = "gpu_nvidia" ]; then
     export gpu_backend=cuda
     quiet which nvcc
     nvcc --version
+
+    # Limit tests to 1st idle GPU. gpu_bind.sh overrides this.
+    export CUDA_VISIBLE_DEVICES=${idle_gpus_array[0]}
 
     echo "cuda_arch = volta" >> make.inc
 
@@ -125,6 +136,9 @@ elif [ "${device}" = "gpu_amd" ]; then
     export gpu_backend=hip
     quiet which hipcc
     hipcc --version
+
+    # Limit tests to 1st idle GPU. gpu_bind.sh overrides this.
+    export ROCR_VISIBLE_DEVICES=${idle_gpus_array[0]}
 
     if [ -e ${ROCM_PATH}/lib/rocblas/library ]; then
         # ROCm 5.2

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -11,8 +11,6 @@ source ${mydir}/setup_env.sh
 err=0
 
 export OMP_NUM_THREADS=8
-export CUDA_VISIBLE_DEVICES=0
-export ROCR_VISIBLE_DEVICES=0
 
 # Currently, OpenMP offload tests don't work on our Intel GPU.
 # CI checks only compilation.

--- a/test/gpu_bind.sh
+++ b/test/gpu_bind.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Run job with $CUDA_VISIBLE_DEVICES xor $ROCR_VISIBLE_DEVICES
+# set to the local MPI rank mod num devices.
+# ROCm recognizes both $CUDA_VISIBLE_DEVICES and $ROCR_VISIBLE_DEVICES,
+# and they can interact to hide all GPUs, hence the xor.
+
+#-------------------------------------------------------------------------------
+if [ -n "${MPI_LOCALRANKID+x}" ]; then
+    # IBM MPI, Intel MPI
+    rank_var=MPI_LOCALRANKID
+    local_rank=${MPI_LOCALRANKID}
+
+elif [ -n "${OMPI_COMM_WORLD_LOCAL_RANK+x}" ]; then
+    # Open MPI
+    rank_var=OMPI_COMM_WORLD_LOCAL_RANK
+    local_rank=${OMPI_COMM_WORLD_LOCAL_RANK}
+
+elif [ -n "${PMI_RANK+x}" ]; then
+    # Intel MPI (older? unclear when MPI_LOCALRANKID was added.)
+    # PMI_RANK might work only for single node jobs. Need PMI_RANK % ranks_per_node.
+    # Cf. https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/Environment-variables-defined-by-intel-mpirun/td-p/1096703
+    rank_var=PMI_RANK
+    local_rank=${PMI_RANK}
+
+else
+    # Unknown MPI.
+    rank_var=unknown
+    local_rank=0
+fi
+
+#-------------------------------------------------------------------------------
+# Ignore GPUs that are already have processes.
+# Use cached ${idle_gpus} if it was already set in setup_env.sh
+if [ -z "${idle_gpus+x}" ]; then
+    echo "${local_rank} ../tools/idle_gpus.py"
+    export idle_gpus=$(../tools/idle_gpus.py)
+fi
+
+# Arrays can't be exported, effectively.
+idle_gpus_array=(${idle_gpus})  # convert to array
+gpu_kind=${idle_gpus_array[0]}  # element 0 is gpu_kind: cuda or rocm
+idle_gpus_array=(${idle_gpus_array[@]:1})  # slice elements 1:end
+
+#-------------------------------------------------------------------------------
+# Get max( 1, ndev ), so local_rank % ndev doesn't divide by 0.
+ndev=${#idle_gpus_array[*]}  # length
+ndev=$(( ${ndev} < 1 ? 1 : ${ndev} ))
+
+dev=$(( ${local_rank} % ${ndev} ))
+visible_devices=${idle_gpus_array[ $dev ]}
+echo "local_rank ${local_rank}, gpu_kind ${gpu_kind}, idle_gpus_array ${idle_gpus_array[*]}, ndev ${ndev}, dev ${dev}, visible_devices ${visible_devices}, rank_var ${rank_var}"
+
+if [ "${gpu_kind}" == "cuda" ]; then
+    export CUDA_VISIBLE_DEVICES=${visible_devices}
+
+elif [ "${gpu_kind}" == "rocm" ]; then
+    export ROCR_VISIBLE_DEVICES=${visible_devices}
+fi
+
+# Run program.
+$@

--- a/tools/idle_gpus.py
+++ b/tools/idle_gpus.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Prints the GPU kind (cuda or rocm), then space-delimited ids of
+# idle GPUs, i.e., that do not have a process.
+# Used in CI test.sh and gpu_bind.sh scripts.
+
+import subprocess
+import re
+import shutil
+
+ngpus = 0
+gpu_kind = 'unknown'
+
+# Search for CUDA GPUs.
+if (shutil.which( 'nvidia-smi' )):
+    p = subprocess.run( ['nvidia-smi', '--list-gpus'], capture_output=True )
+    stdout = p.stdout.decode('utf-8').splitlines()
+    ngpus = len( list( filter( lambda line: re.search( 'GPU', line ), stdout ) ) )
+    if (ngpus > 0):
+        gpu_kind = 'cuda'
+# end
+
+# If no CUDA GPUs, search for ROCm GPUs.
+if (ngpus == 0 and shutil.which( 'rocm-smi' )):
+    p = subprocess.run( ['rocm-smi', '--showid'], capture_output=True )
+    stdout = p.stdout.decode('utf-8').splitlines()
+    ngpus = len( list( filter( lambda line: re.search( 'GPU', line ), stdout ) ) )
+    if (ngpus > 0):
+        gpu_kind = 'rocm'
+# end
+
+# Initially, mark all GPUs as idle.
+gpus = { str( gpu ): 1 for gpu in range( ngpus ) }
+
+if (gpu_kind == 'cuda'):
+    # Mark GPUs that have processes.
+    p = subprocess.run( 'nvidia-smi', capture_output=True )
+    stdout = p.stdout.decode('utf-8').splitlines()
+    section = 1
+    for line in stdout:
+        if (re.search( '^\| Processes:', line )):
+            section = 2
+        if (section == 1):
+            # Match GPU lines:
+            # |   0  Tesla V100-SXM2-32GB            On | 00000000:06:00.0 Off |                    0 |
+            # | N/A   39C    P0               60W / 300W|  30487MiB / 32768MiB |      0%      Default |
+            s = re.search( '^\| +(\d+) ', line )
+            if (s):
+                gpu = s.group( 1 )
+
+            # If using > half the memory, assume it is not idle.
+            # Docker can't see processes in section 2.
+            s = re.search( '^\| +N/A +\d+C +\w+ +\d+W +/ +\d+W *\| +(\d+)MiB +/ +(\d+)MiB', line )
+            if (s):
+                used_mem  = int( s.group( 1 ) )
+                total_mem = int( s.group( 2 ) )
+                if (used_mem > 0.5*total_mem):
+                    gpus[ gpu ] = 0
+        else:
+            # Match process lines:
+            # |    0   N/A  N/A   1768154      C   application    30482MiB |
+            s = re.search( '^\| +(\d) ', line )
+            if (s):
+                gpus[ s.group( 1 ) ] = 0
+
+elif (gpu_kind == 'rocm'):
+    # Mark GPUs that have processes.
+    p = subprocess.run( ['rocm-smi', '--showpidgpus'], capture_output=True )
+    stdout = p.stdout.decode('utf-8').splitlines()
+    process = False
+    for line in stdout:
+        # Match process lines:
+        # PID 2167109 is using 2 DRM device(s):
+        # 1 0
+        if (re.search( '^PID \d+ is using', line )):
+            process = True
+        if (process):
+            for gpu in re.findall( r'(\d+)', line ):
+                gpus[ gpu ] = 0
+            process = False
+# end
+
+idle_gpus = filter( lambda key: gpus[ key ], gpus )
+print( gpu_kind, ' '.join( idle_gpus ) )


### PR DESCRIPTION
Occasionally the CI has conflicts with people using 100% of memory on GPUs. This picks idle GPUs to run on. Script from ci_mpi branch but renamed, cf. #48.