### PR TITLE
test: add default datatype

### DIFF
--- a/test/test_add.cc
+++ b/test/test_add.cc
@@ -411,10 +411,6 @@ void test_add_dispatch( Params& params, bool run )
 void test_add(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_add_dispatch<float> (params, run);
             break;
@@ -429,6 +425,10 @@ void test_add(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_add_dispatch<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_bdsqr.cc
+++ b/test/test_bdsqr.cc
@@ -203,10 +203,6 @@ void test_bdsqr_work(Params& params, bool run)
 void test_bdsqr(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_bdsqr_work<float> (params, run);
             break;
@@ -221,6 +217,10 @@ void test_bdsqr(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_bdsqr_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -273,10 +273,6 @@ void test_copy_dispatch(Params& params, bool run )
 void test_copy(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_copy_dispatch<float> (params, run);
             break;
@@ -291,6 +287,10 @@ void test_copy(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_copy_dispatch<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbmm.cc
+++ b/test/test_gbmm.cc
@@ -234,10 +234,6 @@ void test_gbmm_work(Params& params, bool run)
 void test_gbmm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbmm_work<float> (params, run);
             break;
@@ -252,6 +248,10 @@ void test_gbmm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gbmm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbnorm.cc
+++ b/test/test_gbnorm.cc
@@ -186,10 +186,6 @@ void test_gbnorm_work(Params& params, bool run)
 void test_gbnorm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbnorm_work<float> (params, run);
             break;
@@ -204,6 +200,10 @@ void test_gbnorm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gbnorm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gbsv.cc
+++ b/test/test_gbsv.cc
@@ -285,10 +285,6 @@ void test_gbsv_work(Params& params, bool run)
 void test_gbsv(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gbsv_work<float>(params, run);
             break;
@@ -303,6 +299,10 @@ void test_gbsv(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gbsv_work<std::complex<double>>(params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_ge2tb.cc
+++ b/test/test_ge2tb.cc
@@ -260,10 +260,6 @@ void test_ge2tb_work(Params& params, bool run)
 void test_ge2tb(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_ge2tb_work<float> (params, run);
             break;
@@ -278,6 +274,10 @@ void test_ge2tb(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_ge2tb_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gecondest.cc
+++ b/test/test_gecondest.cc
@@ -294,10 +294,6 @@ void test_gecondest_work(Params& params, bool run)
 void test_gecondest(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gecondest_work<float> (params, run);
             break;
@@ -312,6 +308,10 @@ void test_gecondest(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gecondest_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gelqf.cc
+++ b/test/test_gelqf.cc
@@ -258,10 +258,6 @@ void test_gelqf_work(Params& params, bool run)
 void test_gelqf(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gelqf_work<float> (params, run);
             break;
@@ -276,6 +272,10 @@ void test_gelqf(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gelqf_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -468,10 +468,6 @@ void test_gels_work(Params& params, bool run)
 void test_gels(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gels_work<float> (params, run);
             break;
@@ -486,6 +482,10 @@ void test_gels(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gels_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -349,10 +349,6 @@ void test_gemm_work(Params& params, bool run)
 void test_gemm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gemm_work<float> (params, run);
             break;
@@ -367,6 +363,10 @@ void test_gemm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gemm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_genorm.cc
+++ b/test/test_genorm.cc
@@ -361,10 +361,6 @@ void test_genorm_work(Params& params, bool run)
 void test_genorm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_genorm_work<float> (params, run);
             break;
@@ -379,6 +375,10 @@ void test_genorm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_genorm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_geqrf.cc
+++ b/test/test_geqrf.cc
@@ -337,10 +337,6 @@ void test_geqrf_work(Params& params, bool run)
 void test_geqrf(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_geqrf_work<float> (params, run);
             break;
@@ -355,6 +351,10 @@ void test_geqrf(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_geqrf_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -504,10 +504,6 @@ void test_gesv_work(Params& params, bool run)
 void test_gesv(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_gesv_work<float> (params, run);
             break;
@@ -522,6 +518,10 @@ void test_gesv(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_gesv_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_getri.cc
+++ b/test/test_getri.cc
@@ -277,10 +277,6 @@ void test_getri_work(Params& params, bool run)
 void test_getri(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_getri_work<float> (params, run);
             break;
@@ -295,6 +291,10 @@ void test_getri(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_getri_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hb2st.cc
+++ b/test/test_hb2st.cc
@@ -244,10 +244,6 @@ void test_hb2st_work(Params& params, bool run)
 void test_hb2st(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hb2st_work<float> (params, run);
             break;
@@ -262,6 +258,10 @@ void test_hb2st(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hb2st_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbmm.cc
+++ b/test/test_hbmm.cc
@@ -214,10 +214,6 @@ void test_hbmm_work(Params& params, bool run)
 void test_hbmm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbmm_work<float> (params, run);
             break;
@@ -232,6 +228,10 @@ void test_hbmm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hbmm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hbnorm.cc
+++ b/test/test_hbnorm.cc
@@ -187,10 +187,6 @@ void test_hbnorm_work(Params& params, bool run)
 void test_hbnorm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hbnorm_work<float> (params, run);
             break;
@@ -205,6 +201,10 @@ void test_hbnorm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hbnorm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_he2hb.cc
+++ b/test/test_he2hb.cc
@@ -178,10 +178,6 @@ void test_he2hb_work(Params& params, bool run)
 void test_he2hb(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_he2hb_work<float> (params, run);
             break;
@@ -196,6 +192,10 @@ void test_he2hb(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_he2hb_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -380,10 +380,6 @@ void test_heev_work(Params& params, bool run)
 void test_heev(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_heev_work<float> (params, run);
             break;
@@ -398,6 +394,10 @@ void test_heev(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_heev_work< std::complex<double> > (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hegst.cc
+++ b/test/test_hegst.cc
@@ -203,10 +203,6 @@ void test_hegst_work(Params& params, bool run)
 void test_hegst(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hegst_work<float>(params, run);
             break;
@@ -221,6 +217,10 @@ void test_hegst(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hegst_work<std::complex<double>>(params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -430,10 +430,6 @@ void test_hegv_work(Params& params, bool run)
 void test_hegv(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hegv_work<float> (params, run);
             break;
@@ -448,6 +444,10 @@ void test_hegv(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hegv_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -346,10 +346,6 @@ void test_hemm_work(Params& params, bool run)
 void test_hemm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hemm_work<float> (params, run);
             break;
@@ -364,6 +360,10 @@ void test_hemm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hemm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_henorm.cc
+++ b/test/test_henorm.cc
@@ -324,10 +324,6 @@ void test_henorm_work(Params& params, bool run)
 void test_henorm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_henorm_work<float> (params, run);
             break;
@@ -342,6 +338,10 @@ void test_henorm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_henorm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -333,10 +333,6 @@ void test_her2k_work(Params& params, bool run)
 void test_her2k(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_her2k_work<float> (params, run);
             break;
@@ -351,6 +347,10 @@ void test_her2k(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_her2k_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -291,10 +291,6 @@ void test_herk_work(Params& params, bool run)
 void test_herk(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_herk_work<float> (params, run);
             break;
@@ -309,6 +305,10 @@ void test_herk(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_herk_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_hesv.cc
+++ b/test/test_hesv.cc
@@ -293,10 +293,6 @@ void test_hesv_work(Params& params, bool run)
 void test_hesv(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_hesv_work<float> (params, run);
             break;
@@ -311,6 +307,10 @@ void test_hesv(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_hesv_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_pbsv.cc
+++ b/test/test_pbsv.cc
@@ -259,10 +259,6 @@ void test_pbsv_work(Params& params, bool run)
 void test_pbsv(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_pbsv_work<float>(params, run);
             break;
@@ -277,6 +273,10 @@ void test_pbsv(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_pbsv_work<std::complex<double>>(params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -437,10 +437,6 @@ void test_posv_work(Params& params, bool run)
 void test_posv(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_posv_work<float> (params, run);
             break;
@@ -455,6 +451,10 @@ void test_posv(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_posv_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_potri.cc
+++ b/test/test_potri.cc
@@ -265,10 +265,6 @@ void test_potri_work(Params& params, bool run)
 void test_potri(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_potri_work<float> (params, run);
             break;
@@ -283,6 +279,10 @@ void test_potri(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_potri_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_scale.cc
+++ b/test/test_scale.cc
@@ -244,10 +244,6 @@ void test_scale_dispatch( Params& params, bool run )
 void test_scale(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_scale_dispatch< float >( params, run );
             break;
@@ -262,6 +258,10 @@ void test_scale(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_scale_dispatch< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_scale_row_col.cc
+++ b/test/test_scale_row_col.cc
@@ -328,7 +328,7 @@ void test_scale_row_col( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_set.cc
+++ b/test/test_set.cc
@@ -243,10 +243,6 @@ void test_set_dispatch(Params& params, bool run )
 void test_set(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_set_dispatch<float> (params, run);
             break;
@@ -261,6 +257,10 @@ void test_set(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_set_dispatch<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_stedc.cc
+++ b/test/test_stedc.cc
@@ -301,7 +301,7 @@ void test_stedc( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_stedc_deflate.cc
+++ b/test/test_stedc_deflate.cc
@@ -522,7 +522,7 @@ void test_stedc_deflate( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_stedc_secular.cc
+++ b/test/test_stedc_secular.cc
@@ -320,7 +320,7 @@ void test_stedc_secular( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_stedc_sort.cc
+++ b/test/test_stedc_sort.cc
@@ -208,7 +208,7 @@ void test_stedc_sort( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_stedc_z_vector.cc
+++ b/test/test_stedc_z_vector.cc
@@ -186,7 +186,7 @@ void test_stedc_z_vector( Params& params, bool run )
             break;
 
         default:
-            throw std::exception();
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_steqr2.cc
+++ b/test/test_steqr2.cc
@@ -167,10 +167,6 @@ void test_steqr2_work(Params& params, bool run)
 void test_steqr2(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_steqr2_work<float> (params, run);
             break;
@@ -185,6 +181,10 @@ void test_steqr2(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_steqr2_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_sterf.cc
+++ b/test/test_sterf.cc
@@ -114,10 +114,6 @@ void test_sterf_work(Params& params, bool run)
 void test_sterf(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_sterf_work<float> (params, run);
             break;
@@ -132,6 +128,10 @@ void test_sterf(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_sterf_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_svd.cc
+++ b/test/test_svd.cc
@@ -454,10 +454,6 @@ void test_svd_work( Params& params, bool run )
 void test_svd( Params& params, bool run )
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_svd_work<float>( params, run );
             break;
@@ -472,6 +468,10 @@ void test_svd( Params& params, bool run )
 
         case testsweeper::DataType::DoubleComplex:
             test_svd_work<std::complex<double>>( params, run );
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_symm.cc
+++ b/test/test_symm.cc
@@ -327,10 +327,6 @@ void test_symm_work(Params& params, bool run)
 void test_symm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_symm_work<float> (params, run);
             break;
@@ -345,6 +341,10 @@ void test_symm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_symm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_synorm.cc
+++ b/test/test_synorm.cc
@@ -322,10 +322,6 @@ void test_synorm_work(Params& params, bool run)
 void test_synorm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_synorm_work<float> (params, run);
             break;
@@ -340,6 +336,10 @@ void test_synorm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_synorm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -333,10 +333,6 @@ void test_syr2k_work(Params& params, bool run)
 void test_syr2k(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_syr2k_work<float> (params, run);
             break;
@@ -351,6 +347,10 @@ void test_syr2k(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_syr2k_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -287,10 +287,6 @@ void test_syrk_work(Params& params, bool run)
 void test_syrk(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_syrk_work<float> (params, run);
             break;
@@ -305,6 +301,10 @@ void test_syrk(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_syrk_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tb2bd.cc
+++ b/test/test_tb2bd.cc
@@ -306,10 +306,6 @@ void test_tb2bd_work(Params& params, bool run)
 void test_tb2bd(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tb2bd_work<float> (params, run);
             break;
@@ -324,6 +320,10 @@ void test_tb2bd(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_tb2bd_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_tbsm.cc
+++ b/test/test_tbsm.cc
@@ -285,10 +285,6 @@ void test_tbsm_work(Params& params, bool run)
 void test_tbsm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_tbsm_work<float> (params, run);
             break;
@@ -303,6 +299,10 @@ void test_tbsm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_tbsm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_trcondest.cc
+++ b/test/test_trcondest.cc
@@ -283,10 +283,6 @@ void test_trcondest_work(Params& params, bool run)
 void test_trcondest(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_trcondest_work<float> (params, run);
             break;
@@ -301,6 +297,10 @@ void test_trcondest(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_trcondest_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -308,10 +308,6 @@ void test_trmm_work(Params& params, bool run)
 void test_trmm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_trmm_work<float> (params, run);
             break;
@@ -326,6 +322,10 @@ void test_trmm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_trmm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_trnorm.cc
+++ b/test/test_trnorm.cc
@@ -347,10 +347,6 @@ void test_trnorm_work(Params& params, bool run)
 void test_trnorm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_trnorm_work<float> (params, run);
             break;
@@ -365,6 +361,10 @@ void test_trnorm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_trnorm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -277,10 +277,6 @@ void test_trsm_work(Params& params, bool run)
 void test_trsm(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_trsm_work<float> (params, run);
             break;
@@ -295,6 +291,10 @@ void test_trsm(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_trsm_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_trtri.cc
+++ b/test/test_trtri.cc
@@ -266,10 +266,6 @@ void test_trtri_work(Params& params, bool run)
 void test_trtri(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_trtri_work<float> (params, run);
             break;
@@ -284,6 +280,10 @@ void test_trtri(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_trtri_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unmqr.cc
+++ b/test/test_unmqr.cc
@@ -201,10 +201,6 @@ void test_unmqr_work(Params& params, bool run)
 void test_unmqr(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unmqr_work<float> (params, run);
             break;
@@ -219,6 +215,10 @@ void test_unmqr(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_unmqr_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unmtr_hb2st.cc
+++ b/test/test_unmtr_hb2st.cc
@@ -191,10 +191,6 @@ void test_unmtr_hb2st_work(Params& params, bool run)
 void test_unmtr_hb2st(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unmtr_hb2st_work<float> (params, run);
             break;
@@ -209,6 +205,10 @@ void test_unmtr_hb2st(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_unmtr_hb2st_work< std::complex<double> > (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }

--- a/test/test_unmtr_he2hb.cc
+++ b/test/test_unmtr_he2hb.cc
@@ -258,10 +258,6 @@ void test_unmtr_he2hb_work(Params& params, bool run)
 void test_unmtr_he2hb(Params& params, bool run)
 {
     switch (params.datatype()) {
-        case testsweeper::DataType::Integer:
-            throw std::exception();
-            break;
-
         case testsweeper::DataType::Single:
             test_unmtr_he2hb_work<float> (params, run);
             break;
@@ -276,6 +272,10 @@ void test_unmtr_he2hb(Params& params, bool run)
 
         case testsweeper::DataType::DoubleComplex:
             test_unmtr_he2hb_work<std::complex<double>> (params, run);
+            break;
+
+        default:
+            throw std::runtime_error( "unknown datatype" );
             break;
     }
 }


### PR DESCRIPTION
Add default datatype, to avoid warning about unhandled types (e.g., Half) in the `switch`.

Cf. https://github.com/icl-utk-edu/slate/actions/runs/6640922845/job/18042302219?pr=133