### PR TITLE
Adding Additional Internal Timers for SLATE Routines

### DIFF
--- a/src/gbsv.cc
+++ b/src/gbsv.cc
@@ -79,16 +79,24 @@ int64_t gbsv(
     Matrix<scalar_t>& B,
     Options const& opts)
 {
+    Timer t_gbsv;
+
     slate_assert( A.mt() == A.nt() );  // square
     slate_assert( B.mt() == A.mt() );
 
     // factorization
+    Timer t_gbtrf;
     int64_t info = gbtrf( A, pivots, opts );
+    timers[ "gbsv::gbtrf" ] = t_gbtrf.stop();
 
     // solve
+    Timer t_gbtrs;
     if (info == 0) {
         gbtrs( A, pivots, B, opts );
     }
+    timers[ "gbsv::gbtrs" ] = t_gbtrs.stop();
+
+    timers[ "gbsv" ] = t_gbsv.stop();
 
     return info;
 }

--- a/src/gesv_mixed_gmres.cc
+++ b/src/gesv_mixed_gmres.cc
@@ -214,26 +214,26 @@ int64_t gesv_mixed_gmres(
     else {
         // Solve the system A * X = B in low precision.
         slate::copy( B, X_lo, opts );
-        Timer t_getrs_lo_1;
+        Timer t_getrs_lo;
         getrs( A_lo, pivots, X_lo, opts );
-        timers[ "gesv_mixed_gmres::getrs_lo" ] = t_getrs_lo_1.stop();
+        timers[ "gesv_mixed_gmres::getrs_lo" ] = t_getrs_lo.stop();
         slate::copy( X_lo, X, opts );
 
         // IR
-        timers[ "gesv_mixed_gmres::gemm_lo" ] = 0;
-        timers[ "gesv_mixed_gmres::add_lo" ] = 0;
+        timers[ "gesv_mixed_gmres::gemm_hi" ] = 0;
+        timers[ "gesv_mixed_gmres::add_hi" ] = 0;
         int iiter = 0;
         while (iiter < itermax) {
 
             // Check for convergence
             slate::copy( B, R, opts );
-            Timer t_gemm_lo_1;
+            Timer t_gemm_hi;
             gemm<scalar_hi>(
                 -one, A,
                       X,
                 one,  R,
                 opts);
-            timers[ "gesv_mixed_gmres::gemm_lo" ] += t_gemm_lo_1.stop();
+            timers[ "gesv_mixed_gmres::gemm_hi" ] += t_gemm_hi.stop();
             colNorms( Norm::Max, X, colnorms_X.data(), opts );
             colNorms( Norm::Max, R, colnorms_R.data(), opts );
             if (internal::iterRefConverged<real_hi>( colnorms_R, colnorms_X, cte ))
@@ -282,24 +282,24 @@ int64_t gesv_mixed_gmres(
 
                 // Wj1 = M^-1 A Vj
                 slate::copy( Vj, X_lo, opts );
-                Timer t_getrs_lo_2;
+                t_getrs_lo.start();
                 getrs( A_lo, pivots, X_lo, opts );
-                timers[ "gesv_mixed_gmres::getrs_lo" ] += t_getrs_lo_2.stop();
+                timers[ "gesv_mixed_gmres::getrs_lo" ] += t_getrs_lo.stop();
                 slate::copy( X_lo, Wj1, opts );
 
-                Timer t_gemm_lo_2;
+                t_gemm_hi.start();
                 gemm<scalar_hi>(
                     one,  A,
                           Wj1,
                     zero, Vj1,
                     opts );
-                timers[ "gesv_mixed_gmres::gemm_lo" ] += t_gemm_lo_2.stop();
+                timers[ "gesv_mixed_gmres::gemm_hi" ] += t_gemm_hi.stop();
 
                 // orthogonalize w/ CGS2
                 auto V0j = V.slice( 0, V.m()-1, 0, j );
                 auto V0jT = conj_transpose( V0j );
                 auto Hj = H.slice( 0, j, j, j );
-                Timer t_gemm_lo_3;
+                t_gemm_hi.start();
                 gemm<scalar_hi>(
                     one,  V0jT,
                           Vj1,
@@ -310,9 +310,9 @@ int64_t gesv_mixed_gmres(
                           Hj,
                     one,  Vj1,
                     opts );
-                timers[ "gesv_mixed_gmres::gemm_lo" ] += t_gemm_lo_3.stop();
+                timers[ "gesv_mixed_gmres::gemm_hi" ] += t_gemm_hi.stop();
                 auto zj = z.slice( 0, j, 0, 0 );
-                Timer t_gemm_lo_4;
+                t_gemm_hi.start();
                 gemm<scalar_hi>(
                     one,  V0jT,
                           Vj1,
@@ -323,10 +323,10 @@ int64_t gesv_mixed_gmres(
                           zj,
                     one,  Vj1,
                     opts );
-                timers[ "gesv_mixed_gmres::gemm_lo" ] += t_gemm_lo_4.stop();
-                Timer t_add_lo;
+                timers[ "gesv_mixed_gmres::gemm_hi" ] += t_gemm_hi.stop();
+                Timer t_add_hi;
                 add( one, zj, one, Hj, opts );
-                timers[ "gesv_mixed_gmres::add_lo" ] += t_add_lo.stop();
+                timers[ "gesv_mixed_gmres::add_hi" ] += t_add_hi.stop();
                 auto Vj1_norm = norm( Norm::Fro, Vj1, opts );
                 scale( 1.0, Vj1_norm, Vj1, opts );
                 if (H.tileRank( 0, 0 ) == mpi_rank) {
@@ -363,17 +363,17 @@ int64_t gesv_mixed_gmres(
             auto S_j = S.slice( 0, j-1, 0, 0 );
             auto H_tri = TriangularMatrix<scalar_hi>(
                     Uplo::Upper, Diag::NonUnit, H_j );
-            Timer t_trsm_lo;
+            Timer t_trsm_hi;
             trsm( Side::Left, one, H_tri, S_j, opts );
-            timers[ "gesv_mixed_gmres::trsm_lo" ] += t_trsm_lo.stop();
+            timers[ "gesv_mixed_gmres::trsm_hi" ] += t_trsm_hi.stop();
             auto W_0j = W.slice( 0, W.m()-1, 1, j ); // first column of W is unused
-            Timer t_gemm_lo_5;
+            t_gemm_hi.start();
             gemm<scalar_hi>(
                 one, W_0j,
                      S_j,
                 one, X,
                 opts );
-            timers[ "gesv_mixed_gmres::gemm_lo" ] += t_gemm_lo_5.stop();
+            timers[ "gesv_mixed_gmres::gemm_hi" ] += t_gemm_hi.stop();
         }
     }
 

--- a/src/hegv.cc
+++ b/src/hegv.cc
@@ -102,24 +102,26 @@ void hegv(
     heev( A, Lambda, Z, opts );
     timers[ "hegv::heev" ] = t_heev.stop();
 
+    timers[ "hegv::trsm" ] = 0;
+    timers[ "hegv::trmm" ] = 0;
     if (wantz) {
         // 4. Backtransform eigenvectors to the original problem.
         auto L = TriangularMatrix<scalar_t>( Diag::NonUnit, B );
-        Timer t_trsm;
         if (itype == 1 || itype == 2) {
             // For A x = lambda B x and A B x = lambda x,
             // backtransform eigenvectors: x = inv(L)^H y.
             auto LH = conj_transpose( L );
+            Timer t_trsm;
             trsm( Side::Left, one, LH, Z, opts );
+            timers[ "hegv::trsm" ] += t_trsm.stop();
         }
-        timers[ "hegv::trsm" ] = t_trsm.stop();
-        Timer t_trmm;
         else {
             // For B A x = lambda x,
             // backtransform eigenvectors: x = L y.
+            Timer t_trmm;
             trmm( Side::Left, one, L, Z, opts );
+            timers[ "hegv::trmm" ] += t_trmm.stop();
         }
-        timers[ "hegv::trmm" ] = t_trmm.stop();
     }
     timers[ "hegv" ] = t_hegv.stop();
 }

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -99,6 +99,8 @@ int64_t hesv(
              Matrix<scalar_t>& B,
     Options const& opts )
 {
+    Timer t_hesv;
+
     assert(B.mt() == A.mt());
 
     auto A_ = A;  // local shallow copy to transpose
@@ -108,12 +110,19 @@ int64_t hesv(
         A_ = conj_transpose( A_ );
 
     // factorization
+    Timer t_hetrf;
     int64_t info = hetrf( A_, pivots, T, pivots2, H, opts );
+    timers[ "hesv::hetrf" ] = t_hetrf.stop();
 
     // solve
+    Timer t_hetrs;
     if (info == 0) {
         hetrs( A_, pivots, T, pivots2, B, opts );
     }
+    timers[ "hesv::hetrs" ] = t_hetrs.stop();
+
+    timers[ "hesv" ] = t_hesv.stop();
+
     return info;
 }
 

--- a/test/test_gbsv.cc
+++ b/test/test_gbsv.cc
@@ -53,12 +53,19 @@ void test_gbsv_work(Params& params, bool run)
     bool check = params.check() == 'y' && ! ref_only;
     bool trace = params.trace() == 'y';
     int verbose = params.verbose();
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     params.matrix.mark();
 
     // mark non-standard output values
     params.time();
+    if (timer_level >=2) {
+        params.time2();
+        params.time3();
+        params.time2.name( "gbtrf (s)" );
+        params.time3.name( "gbtrs (s)" );
+    }
     //params.gflops();
     //params.ref_time();
     //params.ref_gflops();
@@ -202,6 +209,10 @@ void test_gbsv_work(Params& params, bool run)
 
         // compute and save timing/performance
         params.time() = time;
+        if (timer_level >= 2) {
+            params.time2() = slate::timers[ "gbsv::gbtrf" ];
+            params.time3() = slate::timers[ "gbsv::gbtrs" ];
+        }
         ///params.gflops() = gflop / time;
 
         if (verbose > 1) {

--- a/test/test_gbsv.cc
+++ b/test/test_gbsv.cc
@@ -60,7 +60,7 @@ void test_gbsv_work(Params& params, bool run)
 
     // mark non-standard output values
     params.time();
-    if (timer_level >=2) {
+    if (timer_level >= 2) {
         params.time2();
         params.time3();
         params.time2.name( "gbtrf (s)" );

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -18,7 +18,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <utility>
-#include <typeinfo>
 
 //------------------------------------------------------------------------------
 template <typename scalar_t>
@@ -66,7 +65,8 @@ void test_gels_work(Params& params, bool run)
     params.gflops();
     params.ref_time();
     params.ref_gflops();
-    if (timer_level >= 2 && int(methodGels) == 0) {
+    if (timer_level >= 2 && (methodGels == slate::MethodGels::Auto
+                             || methodGels == slate::MethodGels::Geqrf)) {
         params.time2();
         params.time3();
         params.time4();
@@ -74,7 +74,7 @@ void test_gels_work(Params& params, bool run)
         params.time3.name( "unmqr (s)" );
         params.time4.name( "trsm (s)" );
     }
-    else if (timer_level >=2 && int(methodGels) == 1) {
+    else if (timer_level >= 2 && methodGels == slate::MethodGels::Cholqr) {
         params.time2();
         params.time3();
         params.time4();
@@ -251,12 +251,13 @@ void test_gels_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-        if (timer_level >= 2 && int(methodGels) == 0) {
+        if (timer_level >= 2 && (methodGels == slate::MethodGels::Auto
+                                 || methodGels == slate::MethodGels::Geqrf)) {
             params.time2() = slate::timers[ "gels::geqrf" ];
             params.time3() = slate::timers[ "gels::unmqr" ];
             params.time4() = slate::timers[ "gels::trsm"  ];
         }
-        else if (timer_level >=2 && int(methodGels) == 1) {
+        else if (timer_level >= 2 && methodGels == slate::MethodGels::Cholqr) {
             params.time2() = slate::timers[ "gels_cholqr::cholqr" ];
             params.time3() = slate::timers[ "gels_cholqr::gemm" ];
             params.time4() = slate::timers[ "gels_cholqr::trsm" ];

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <utility>
+#include <typeinfo>
 
 //------------------------------------------------------------------------------
 template <typename scalar_t>
@@ -65,12 +66,20 @@ void test_gels_work(Params& params, bool run)
     params.gflops();
     params.ref_time();
     params.ref_gflops();
-    if (timer_level >= 2) {
+    if (timer_level >= 2 && int(methodGels) == 0) {
         params.time2();
         params.time3();
         params.time4();
         params.time2.name( "geqrf (s)" );
         params.time3.name( "unmqr (s)" );
+        params.time4.name( "trsm (s)" );
+    }
+    else if (timer_level >=2 && int(methodGels) == 1) {
+        params.time2();
+        params.time3();
+        params.time4();
+        params.time2.name( "cholqr (s)" );
+        params.time3.name( "gemm (s)" );
         params.time4.name( "trsm (s)" );
     }
 
@@ -242,10 +251,15 @@ void test_gels_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-        if (timer_level >= 2) {
+        if (timer_level >= 2 && int(methodGels) == 0) {
             params.time2() = slate::timers[ "gels::geqrf" ];
             params.time3() = slate::timers[ "gels::unmqr" ];
             params.time4() = slate::timers[ "gels::trsm"  ];
+        }
+        else if (timer_level >=2 && int(methodGels) == 1) {
+            params.time2() = slate::timers[ "gels_cholqr::cholqr" ];
+            params.time3() = slate::timers[ "gels_cholqr::gemm" ];
+            params.time4() = slate::timers[ "gels_cholqr::trsm" ];
         }
 
         print_matrix( "A2", A, params );

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -79,7 +79,9 @@ void test_gesv_work(Params& params, bool run)
     params.matrixB.mark();
 
     // Currently only gesv* supports timer_level >= 2.
-    if (params.routine != "gesv" && params.routine != "gesv_mixed")
+    std::vector<std::string> timer_lvl_support{ "gesv", "gesv_mixed", "gesv_mixed_gmres"};
+    bool supported = std::find(timer_lvl_support.begin(), timer_lvl_support.end(), params.routine) != timer_lvl_support.end();
+    if (supported == false)
         timer_level = 1;
 
     // NoPiv and CALU ignore threshold.
@@ -107,7 +109,7 @@ void test_gesv_work(Params& params, bool run)
         params.time2.name( "getrf (s)" );
         params.time3.name( "getrs (s)" );
     }
-    else if (timer_level >=2 && params.routine == "gesv_mixed") {
+    else if (timer_level >=2 && (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres")) {
         params.time2();
         params.time3();
         params.time4();
@@ -120,6 +122,12 @@ void test_gesv_work(Params& params, bool run)
         params.time5.name( "add_lo (s)" );
         params.time6.name( "getrf_hi (s)" );
         params.time7.name( "getrs_hi (s)" );
+        if (params.routine == "gesv_mixed_gmres") {
+            params.time8();
+            params.time9();
+            params.time8.name( "rotations (s)" );
+            params.time9.name( "trsm_lo (s)" );
+        }
     }
 
     bool is_iterative = params.routine == "gesv_mixed"
@@ -355,6 +363,16 @@ void test_gesv_work(Params& params, bool run)
             params.time5() = slate::timers[ "gesv_mixed::add_lo" ];
             params.time6() = slate::timers[ "gesv_mixed::getrf_hi" ];
             params.time7() = slate::timers[ "gesv_mixed::getrs_hi" ];
+        }
+        else if (timer_level >= 2 && params.routine == "gesv_mixed_gmres") {
+            params.time2() = slate::timers[ "gesv_mixed_gmres::getrf_lo" ];
+            params.time3() = slate::timers[ "gesv_mixed_gmres::getrs_lo" ];
+            params.time4() = slate::timers[ "gesv_mixed_gmres::gemm_lo" ];
+            params.time5() = slate::timers[ "gesv_mixed_gmres::add_lo" ];
+            params.time6() = slate::timers[ "gesv_mixed_gmres::getrf_hi" ];
+            params.time7() = slate::timers[ "gesv_mixed_gmres::getrs_hi" ];
+            params.time8() = slate::timers[ "gesv_mixed_gmres::rotations" ];
+            params.time9() = slate::timers[ "gesv_mixed_gmres::trsm_lo" ];
         }
 
         //==================================================

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -79,9 +79,12 @@ void test_gesv_work(Params& params, bool run)
     params.matrixB.mark();
 
     // Currently only gesv* supports timer_level >= 2.
-    std::vector<std::string> timer_lvl_support{ "gesv", "gesv_mixed", "gesv_mixed_gmres"};
-    bool supported = std::find(timer_lvl_support.begin(), timer_lvl_support.end(), params.routine) != timer_lvl_support.end();
-    if (supported == false)
+    std::vector<std::string> timer_lvl_support{ "gesv", "gesv_mixed",
+                                                "gesv_mixed_gmres"};
+    bool supported = std::find( timer_lvl_support.begin(),
+                                timer_lvl_support.end(), params.routine )
+                     != timer_lvl_support.end();
+    if (! supported)
         timer_level = 1;
 
     // NoPiv and CALU ignore threshold.
@@ -109,7 +112,8 @@ void test_gesv_work(Params& params, bool run)
         params.time2.name( "getrf (s)" );
         params.time3.name( "getrs (s)" );
     }
-    else if (timer_level >=2 && (params.routine == "gesv_mixed" || params.routine == "gesv_mixed_gmres")) {
+    else if (timer_level >=2 && (params.routine == "gesv_mixed"
+                                 || params.routine == "gesv_mixed_gmres")) {
         params.time2();
         params.time3();
         params.time4();
@@ -118,15 +122,15 @@ void test_gesv_work(Params& params, bool run)
         params.time7();
         params.time2.name( "getrf_lo (s)" );
         params.time3.name( "getrs_lo (s)" );
-        params.time4.name( "gemm_lo (s)" );
-        params.time5.name( "add_lo (s)" );
+        params.time4.name( "gemm_hi (s)" );
+        params.time5.name( "add_hi (s)" );
         params.time6.name( "getrf_hi (s)" );
         params.time7.name( "getrs_hi (s)" );
         if (params.routine == "gesv_mixed_gmres") {
             params.time8();
             params.time9();
             params.time8.name( "rotations (s)" );
-            params.time9.name( "trsm_lo (s)" );
+            params.time9.name( "trsm_hi (s)" );
         }
     }
 
@@ -359,20 +363,20 @@ void test_gesv_work(Params& params, bool run)
         else if (timer_level >= 2 && params.routine == "gesv_mixed") {
             params.time2() = slate::timers[ "gesv_mixed::getrf_lo" ];
             params.time3() = slate::timers[ "gesv_mixed::getrs_lo" ];
-            params.time4() = slate::timers[ "gesv_mixed::gemm_lo" ];
-            params.time5() = slate::timers[ "gesv_mixed::add_lo" ];
+            params.time4() = slate::timers[ "gesv_mixed::gemm_hi" ];
+            params.time5() = slate::timers[ "gesv_mixed::add_hi" ];
             params.time6() = slate::timers[ "gesv_mixed::getrf_hi" ];
             params.time7() = slate::timers[ "gesv_mixed::getrs_hi" ];
         }
         else if (timer_level >= 2 && params.routine == "gesv_mixed_gmres") {
             params.time2() = slate::timers[ "gesv_mixed_gmres::getrf_lo" ];
             params.time3() = slate::timers[ "gesv_mixed_gmres::getrs_lo" ];
-            params.time4() = slate::timers[ "gesv_mixed_gmres::gemm_lo" ];
-            params.time5() = slate::timers[ "gesv_mixed_gmres::add_lo" ];
+            params.time4() = slate::timers[ "gesv_mixed_gmres::gemm_hi" ];
+            params.time5() = slate::timers[ "gesv_mixed_gmres::add_hi" ];
             params.time6() = slate::timers[ "gesv_mixed_gmres::getrf_hi" ];
             params.time7() = slate::timers[ "gesv_mixed_gmres::getrs_hi" ];
             params.time8() = slate::timers[ "gesv_mixed_gmres::rotations" ];
-            params.time9() = slate::timers[ "gesv_mixed_gmres::trsm_lo" ];
+            params.time9() = slate::timers[ "gesv_mixed_gmres::trsm_hi" ];
         }
 
         //==================================================

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -79,7 +79,7 @@ void test_gesv_work(Params& params, bool run)
     params.matrixB.mark();
 
     // Currently only gesv* supports timer_level >= 2.
-    if (params.routine != "gesv")
+    if (params.routine != "gesv" && params.routine != "gesv_mixed")
         timer_level = 1;
 
     // NoPiv and CALU ignore threshold.
@@ -101,11 +101,25 @@ void test_gesv_work(Params& params, bool run)
         params.gflops2();
         params.gflops2.name( "trs gflop/s" );
     }
-    if (timer_level >= 2) {
+    if (timer_level >= 2 && params.routine == "gesv") {
         params.time2();
         params.time3();
         params.time2.name( "getrf (s)" );
         params.time3.name( "getrs (s)" );
+    }
+    else if (timer_level >=2 && params.routine == "gesv_mixed") {
+        params.time2();
+        params.time3();
+        params.time4();
+        params.time5();
+        params.time6();
+        params.time7();
+        params.time2.name( "getrf_lo (s)" );
+        params.time3.name( "getrs_lo (s)" );
+        params.time4.name( "gemm_lo (s)" );
+        params.time5.name( "add_lo (s)" );
+        params.time6.name( "getrf_hi (s)" );
+        params.time7.name( "getrs_hi (s)" );
     }
 
     bool is_iterative = params.routine == "gesv_mixed"
@@ -330,9 +344,17 @@ void test_gesv_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-        if (timer_level >= 2) {
+        if (timer_level >= 2 && params.routine == "gesv") {
             params.time2() = slate::timers[ "gesv::getrf" ];
             params.time3() = slate::timers[ "gesv::getrs" ];
+        }
+        else if (timer_level >= 2 && params.routine == "gesv_mixed") {
+            params.time2() = slate::timers[ "gesv_mixed::getrf_lo" ];
+            params.time3() = slate::timers[ "gesv_mixed::getrs_lo" ];
+            params.time4() = slate::timers[ "gesv_mixed::gemm_lo" ];
+            params.time5() = slate::timers[ "gesv_mixed::add_lo" ];
+            params.time6() = slate::timers[ "gesv_mixed::getrf_hi" ];
+            params.time7() = slate::timers[ "gesv_mixed::getrs_hi" ];
         }
 
         //==================================================

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -46,6 +46,7 @@ void test_hegv_work(Params& params, bool run)
     bool check = params.check() == 'y' && ! ref_only;
     bool trace = params.trace() == 'y';
     int verbose = params.verbose();
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     params.matrix.mark();
@@ -55,6 +56,18 @@ void test_hegv_work(Params& params, bool run)
     params.time();
     params.ref_time();
     params.error2();
+    if (timer_level >= 2) {
+        params.time2();
+        params.time3();
+        params.time4();
+        params.time5();
+        params.time6();
+        params.time2.name( "potrf (s)" );
+        params.time3.name( "hegst (s)" );
+        params.time4.name( "heev (s)" );
+        params.time5.name( "trsm (s)" );
+        params.time6.name( "trmm (s)" );
+    }
 
     if (! run) {
         // B matrix must be Symmetric Positive Definite (SPD) for scalapack_phegvx
@@ -208,6 +221,14 @@ void test_hegv_work(Params& params, bool run)
 
         // compute and save timing/performance
         params.time() = time;
+        if (timer_level >= 2) {
+            params.time2() = slate::timers[ "hegv::potrf" ];
+            params.time3() = slate::timers[ "hegv::hegst" ];
+            params.time4() = slate::timers[ "hegv::heev" ];
+            params.time5() = slate::timers[ "hegv::trsm" ];
+            params.time6() = slate::timers[ "hegv::trmm" ];
+        }
+
     }
 
     print_matrix("A", A, params);
@@ -407,6 +428,13 @@ void test_hegv_work(Params& params, bool run)
             time = barrier_get_wtime(mpi_comm) - time;
 
             params.ref_time() = time;
+            if (timer_level >= 2) {
+                params.time2() = slate::timers[ "hegv::potrf" ];
+                params.time3() = slate::timers[ "hegv::hegst" ];
+                params.time4() = slate::timers[ "hegv::heev" ];
+                params.time5() = slate::timers[ "hegv::trsm" ];
+                params.time6() = slate::timers[ "hegv::trmm" ];
+            }
 
             if (! ref_only) {
                 // Reference Scalapack was run, check reference eigenvalues

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -62,11 +62,21 @@ void test_hegv_work(Params& params, bool run)
         params.time4();
         params.time5();
         params.time6();
+        params.time7();
+        params.time8();
+        params.time9();
+        params.time10();
+        params.time11();
         params.time2.name( "potrf (s)" );
         params.time3.name( "hegst (s)" );
         params.time4.name( "heev (s)" );
         params.time5.name( "trsm (s)" );
         params.time6.name( "trmm (s)" );
+        params.time7.name( "he2hb (s)" );
+        params.time8.name( "hb2st (s)" );
+        params.time9.name( "stev (s)" );
+        params.time10.name( "unmtr_hb2st (s)" );
+        params.time11.name( "unmtr_he2hb (s)" );
     }
 
     if (! run) {
@@ -227,6 +237,11 @@ void test_hegv_work(Params& params, bool run)
             params.time4() = slate::timers[ "hegv::heev" ];
             params.time5() = slate::timers[ "hegv::trsm" ];
             params.time6() = slate::timers[ "hegv::trmm" ];
+            params.time7() = slate::timers[ "heev::he2hb" ];
+            params.time8() = slate::timers[ "heev::hb2st" ];
+            params.time9() = slate::timers[ "heev::stev" ];
+            params.time10() = slate::timers[ "heev::unmtr_hb2st" ];
+            params.time11() = slate::timers[ "heev::unmtr_he2hb" ];
         }
 
     }

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -428,13 +428,6 @@ void test_hegv_work(Params& params, bool run)
             time = barrier_get_wtime(mpi_comm) - time;
 
             params.ref_time() = time;
-            if (timer_level >= 2) {
-                params.time2() = slate::timers[ "hegv::potrf" ];
-                params.time3() = slate::timers[ "hegv::hegst" ];
-                params.time4() = slate::timers[ "hegv::heev" ];
-                params.time5() = slate::timers[ "hegv::trsm" ];
-                params.time6() = slate::timers[ "hegv::trmm" ];
-            }
 
             if (! ref_only) {
                 // Reference Scalapack was run, check reference eigenvalues

--- a/test/test_hesv.cc
+++ b/test/test_hesv.cc
@@ -209,7 +209,7 @@ void test_hesv_work(Params& params, bool run)
         gflop = lapack::Gflop<scalar_t>::posv(n, nrhs);
     params.time() = time;
     params.gflops() = gflop / time;
-    if (timer_level >=2) {
+    if (timer_level >= 2) {
         params.time2() = slate::timers[ "hesv::hetrf" ];
         params.time3() = slate::timers[ "hesv::hetrs" ];
     }

--- a/test/test_hesv.cc
+++ b/test/test_hesv.cc
@@ -40,6 +40,7 @@ void test_hesv_work(Params& params, bool run)
     int64_t panel_threads = params.panel_threads();
     bool check = params.check() == 'y';
     bool trace = params.trace() == 'y';
+    int timer_level = params.timer_level();
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     params.matrix.mark();
@@ -49,6 +50,12 @@ void test_hesv_work(Params& params, bool run)
     // mark non-standard output values
     params.time();
     params.gflops();
+    if (timer_level >=2) {
+        params.time2();
+        params.time3();
+        params.time2.name( "hetrf (s)" );
+        params.time3.name( "hetrs (s)" );
+    }
 
     if (! run)
         return;
@@ -202,6 +209,11 @@ void test_hesv_work(Params& params, bool run)
         gflop = lapack::Gflop<scalar_t>::posv(n, nrhs);
     params.time() = time;
     params.gflops() = gflop / time;
+    if (timer_level >=2) {
+        params.time2() = slate::timers[ "hesv::hetrf" ];
+        params.time3() = slate::timers[ "hesv::hetrs" ];
+    }
+
 
     if (check) {
         // todo: replace with SLATE code to check error. ScaLAPACK doesn't have hesv.

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -54,7 +54,10 @@ void test_posv_work(Params& params, bool run)
     slate::Method methodHemm = params.method_hemm();
 
     // Currently only posv* supports timer_level >= 2.
-    if (params.routine != "posv")
+    std::vector<std::string> timer_lvl_support{ "posv", "posv_mixed" };
+    bool supported = std::find(timer_lvl_support.begin(), timer_lvl_support.end(), params.routine) != timer_lvl_support.end();
+
+    if (supported == false)
         timer_level = 1;
 
     // mark non-standard output values
@@ -73,11 +76,25 @@ void test_posv_work(Params& params, bool run)
         params.gflops2();
         params.gflops2.name( "trs gflop/s" );
     }
-    if (timer_level >= 2) {
+    if (timer_level >= 2 && params.routine == "posv") {
         params.time2();
         params.time3();
         params.time2.name( "potrf (s)" );
         params.time3.name( "potrs (s)" );
+    }
+    else if (timer_level >=2 && (params.routine == "posv_mixed")) {
+        params.time2();
+        params.time3();
+        params.time4();
+        params.time5();
+        params.time6();
+        params.time7();
+        params.time2.name( "potrf_lo (s)" );
+        params.time3.name( "potrs_lo (s)" );
+        params.time4.name( "hemm_lo (s)" );
+        params.time5.name( "add_lo (s)" );
+        params.time6.name( "potrf_hi (s)" );
+        params.time7.name( "potrs_hi (s)" );
     }
 
     bool is_iterative = params.routine == "posv_mixed"
@@ -275,9 +292,17 @@ void test_posv_work(Params& params, bool run)
         params.time() = time;
         params.gflops() = gflop / time;
 
-        if (timer_level >= 2) {
+        if (timer_level >= 2 && params.routine == "posv") {
             params.time2() = slate::timers[ "posv::potrf" ];
             params.time3() = slate::timers[ "posv::potrs" ];
+        }
+        else if (timer_level >=2 && params.routine == "posv_mixed") {
+            params.time2() = slate::timers[ "posv_mixed::potrf_lo" ];
+            params.time3() = slate::timers[ "posv_mixed::potrs_lo" ];
+            params.time4() = slate::timers[ "posv_mixed::hemm_lo" ];
+            params.time5() = slate::timers[ "posv_mixed::add_lo" ];
+            params.time6() = slate::timers[ "posv_mixed::potrf_hi" ];
+            params.time7() = slate::timers[ "posv_mixed::potrs_hi" ];
         }
 
         //==================================================

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -54,10 +54,13 @@ void test_posv_work(Params& params, bool run)
     slate::Method methodHemm = params.method_hemm();
 
     // Currently only posv* supports timer_level >= 2.
-    std::vector<std::string> timer_lvl_support{ "posv", "posv_mixed", "posv_mixed_gmres" };
-    bool supported = std::find(timer_lvl_support.begin(), timer_lvl_support.end(), params.routine) != timer_lvl_support.end();
+    std::vector<std::string> timer_lvl_support{ "posv", "posv_mixed",
+                                                "posv_mixed_gmres" };
+    bool supported = std::find( timer_lvl_support.begin(),
+                                timer_lvl_support.end(), params.routine )
+                     != timer_lvl_support.end();
 
-    if (supported == false)
+    if (! supported)
         timer_level = 1;
 
     // mark non-standard output values
@@ -82,7 +85,8 @@ void test_posv_work(Params& params, bool run)
         params.time2.name( "potrf (s)" );
         params.time3.name( "potrs (s)" );
     }
-    else if (timer_level >=2 && (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres")) {
+    else if (timer_level >=2 && (params.routine == "posv_mixed"
+                                 || params.routine == "posv_mixed_gmres")) {
         params.time2();
         params.time3();
         params.time4();
@@ -91,8 +95,8 @@ void test_posv_work(Params& params, bool run)
         params.time7();
         params.time2.name( "potrf_lo (s)" );
         params.time3.name( "potrs_lo (s)" );
-        params.time4.name( "hemm_lo (s)" );
-        params.time5.name( "add_lo (s)" );
+        params.time4.name( "hemm_hi (s)" );
+        params.time5.name( "add_hi (s)" );
         params.time6.name( "potrf_hi (s)" );
         params.time7.name( "potrs_hi (s)" );
         if (params.routine == "posv_mixed_gmres") {
@@ -100,8 +104,8 @@ void test_posv_work(Params& params, bool run)
             params.time9();
             params.time10();
             params.time8.name( "rotations (s)" );
-            params.time9.name( "trsm_lo (s)" );
-            params.time10.name( "gemm_lo (s)" );
+            params.time9.name( "trsm_hi (s)" );
+            params.time10.name( "gemm_hi (s)" );
         }
     }
 
@@ -304,24 +308,24 @@ void test_posv_work(Params& params, bool run)
             params.time2() = slate::timers[ "posv::potrf" ];
             params.time3() = slate::timers[ "posv::potrs" ];
         }
-        else if (timer_level >=2 && params.routine == "posv_mixed") {
+        else if (timer_level >= 2 && params.routine == "posv_mixed") {
             params.time2() = slate::timers[ "posv_mixed::potrf_lo" ];
             params.time3() = slate::timers[ "posv_mixed::potrs_lo" ];
-            params.time4() = slate::timers[ "posv_mixed::hemm_lo" ];
-            params.time5() = slate::timers[ "posv_mixed::add_lo" ];
+            params.time4() = slate::timers[ "posv_mixed::hemm_hi" ];
+            params.time5() = slate::timers[ "posv_mixed::add_hi" ];
             params.time6() = slate::timers[ "posv_mixed::potrf_hi" ];
             params.time7() = slate::timers[ "posv_mixed::potrs_hi" ];
         }
-        else if (timer_level >=2 && params.routine == "posv_mixed_gmres") {
+        else if (timer_level >= 2 && params.routine == "posv_mixed_gmres") {
             params.time2() = slate::timers[ "posv_mixed_gmres::potrf_lo" ];
             params.time3() = slate::timers[ "posv_mixed_gmres::potrs_lo" ];
-            params.time4() = slate::timers[ "posv_mixed_gmres::hemm_lo" ];
-            params.time5() = slate::timers[ "posv_mixed_gmres::add_lo" ];
+            params.time4() = slate::timers[ "posv_mixed_gmres::hemm_hi" ];
+            params.time5() = slate::timers[ "posv_mixed_gmres::add_hi" ];
             params.time6() = slate::timers[ "posv_mixed_gmres::potrf_hi" ];
             params.time7() = slate::timers[ "posv_mixed_gmres::potrs_hi" ];
             params.time8() = slate::timers[ "posv_mixed_gmres::rotations" ];
-            params.time9() = slate::timers[ "posv_mixed_gmres::trsm_lo" ];
-            params.time10() = slate::timers[ "posv_mixed_gmres::gemm_lo" ];
+            params.time9() = slate::timers[ "posv_mixed_gmres::trsm_hi" ];
+            params.time10() = slate::timers[ "posv_mixed_gmres::gemm_hi" ];
         }
 
         //==================================================

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -54,7 +54,7 @@ void test_posv_work(Params& params, bool run)
     slate::Method methodHemm = params.method_hemm();
 
     // Currently only posv* supports timer_level >= 2.
-    std::vector<std::string> timer_lvl_support{ "posv", "posv_mixed" };
+    std::vector<std::string> timer_lvl_support{ "posv", "posv_mixed", "posv_mixed_gmres" };
     bool supported = std::find(timer_lvl_support.begin(), timer_lvl_support.end(), params.routine) != timer_lvl_support.end();
 
     if (supported == false)
@@ -82,7 +82,7 @@ void test_posv_work(Params& params, bool run)
         params.time2.name( "potrf (s)" );
         params.time3.name( "potrs (s)" );
     }
-    else if (timer_level >=2 && (params.routine == "posv_mixed")) {
+    else if (timer_level >=2 && (params.routine == "posv_mixed" || params.routine == "posv_mixed_gmres")) {
         params.time2();
         params.time3();
         params.time4();
@@ -95,6 +95,14 @@ void test_posv_work(Params& params, bool run)
         params.time5.name( "add_lo (s)" );
         params.time6.name( "potrf_hi (s)" );
         params.time7.name( "potrs_hi (s)" );
+        if (params.routine == "posv_mixed_gmres") {
+            params.time8();
+            params.time9();
+            params.time10();
+            params.time8.name( "rotations (s)" );
+            params.time9.name( "trsm_lo (s)" );
+            params.time10.name( "gemm_lo (s)" );
+        }
     }
 
     bool is_iterative = params.routine == "posv_mixed"
@@ -303,6 +311,17 @@ void test_posv_work(Params& params, bool run)
             params.time5() = slate::timers[ "posv_mixed::add_lo" ];
             params.time6() = slate::timers[ "posv_mixed::potrf_hi" ];
             params.time7() = slate::timers[ "posv_mixed::potrs_hi" ];
+        }
+        else if (timer_level >=2 && params.routine == "posv_mixed_gmres") {
+            params.time2() = slate::timers[ "posv_mixed_gmres::potrf_lo" ];
+            params.time3() = slate::timers[ "posv_mixed_gmres::potrs_lo" ];
+            params.time4() = slate::timers[ "posv_mixed_gmres::hemm_lo" ];
+            params.time5() = slate::timers[ "posv_mixed_gmres::add_lo" ];
+            params.time6() = slate::timers[ "posv_mixed_gmres::potrf_hi" ];
+            params.time7() = slate::timers[ "posv_mixed_gmres::potrs_hi" ];
+            params.time8() = slate::timers[ "posv_mixed_gmres::rotations" ];
+            params.time9() = slate::timers[ "posv_mixed_gmres::trsm_lo" ];
+            params.time10() = slate::timers[ "posv_mixed_gmres::gemm_lo" ];
         }
 
         //==================================================


### PR DESCRIPTION
This PR will address adding additional internal timers for the following SLATE routines:

- gbsv
- hesv
- gesv_mixed
- gesv_mixed_gmres
- posv_mixed
- posv_mixed_gmres
- gels_cholqr
- hegv

See issue #128.