### PR TITLE
cond: return value instead of output argument

### DIFF
--- a/include/slate/simplified_api.hh
+++ b/include/slate/simplified_api.hh
@@ -363,14 +363,13 @@ void lu_inverse_using_factor_out_of_place(
 
 // gecondest
 template <typename scalar_t>
-void lu_condest_using_factor(
-    Norm norm,
+blas::real_type<scalar_t> lu_rcondest_using_factor(
+    Norm in_norm,
     Matrix<scalar_t>& A,
     blas::real_type<scalar_t> Anorm,
-    blas::real_type<scalar_t> *rcond,
     Options const& opts = Options())
 {
-    gecondest(norm, A, Anorm, rcond, opts);
+    return gecondest( in_norm, A, Anorm, opts );
 }
 
 //-----------------------------------------
@@ -495,14 +494,13 @@ void chol_inverse_using_factor(
 
 // pocondest
 template <typename scalar_t>
-void chol_condest_using_factor(
-    Norm norm,
+blas::real_type<scalar_t> chol_rcondest_using_factor(
+    Norm in_norm,
     HermitianMatrix<scalar_t>& A,
     blas::real_type<scalar_t> Anorm,
-    blas::real_type<scalar_t> *rcond,
     Options const& opts = Options())
 {
-    pocondest(norm, A, Anorm, rcond, opts);
+    return pocondest( in_norm, A, Anorm, opts );
 }
 
 //-----------------------------------------
@@ -684,15 +682,14 @@ void lq_multiply_by_q(
 
 // trcondest
 template <typename scalar_t>
-void triangular_condest(
-    Norm norm,
+blas::real_type<scalar_t> triangular_rcondest(
+    Norm in_norm,
     TriangularMatrix<scalar_t>& A,
-    blas::real_type<scalar_t> *rcond,
+    blas::real_type<scalar_t> Anorm,
     Options const& opts = Options())
 {
-    trcondest(norm, A, rcond, opts);
+    return trcondest( in_norm, A, Anorm, opts );
 }
-
 
 //------------------------------------------------------------------------------
 // Symmetric/Hermitian Eigenvalues

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -1345,15 +1345,14 @@ void steqr2(
 //-----------------------------------------
 // gecondest()
 template <typename scalar_t>
-void gecondest(
-        Norm in_norm,
-        Matrix<scalar_t>& A,
-        blas::real_type<scalar_t> Anorm,
-        blas::real_type<scalar_t> *rcond,
-        Options const& opts = Options());
+blas::real_type<scalar_t> gecondest(
+    Norm in_norm,
+    Matrix<scalar_t>& A,
+    blas::real_type<scalar_t> Anorm,
+    Options const& opts = Options());
 
 template <typename scalar_t>
-[[deprecated( "Pass Anorm by value instead. Will be removed 2024-11." )]]
+[[deprecated( "Use rcond = gecondest(...) and pass Anorm by value instead. Will be removed 2024-11." )]]
 void gecondest(
         Norm in_norm,
         Matrix<scalar_t>& A,
@@ -1361,27 +1360,38 @@ void gecondest(
         blas::real_type<scalar_t> *rcond,
         Options const& opts = Options())
 {
-    gecondest( in_norm, A, *Anorm, rcond, opts );
+    *rcond = gecondest( in_norm, A, *Anorm, opts );
 }
 
 //-----------------------------------------
 // pocondest()
 template <typename scalar_t>
-void pocondest(
-        Norm in_norm,
-        HermitianMatrix<scalar_t>& A,
-        blas::real_type<scalar_t> Anorm,
-        blas::real_type<scalar_t> *rcond,
-        Options const& opts = Options());
+blas::real_type<scalar_t> pocondest(
+    Norm in_norm,
+    HermitianMatrix<scalar_t>& A,
+    blas::real_type<scalar_t> Anorm,
+    Options const& opts = Options());
 
 //-----------------------------------------
 // trcondest()
 template <typename scalar_t>
+blas::real_type<scalar_t> trcondest(
+    Norm in_norm,
+    TriangularMatrix<scalar_t>& A,
+    blas::real_type<scalar_t> Anorm,
+    Options const& opts = Options());
+
+template <typename scalar_t>
+[[deprecated( "Use rcond = trcondest(...) and pass Anorm. Will be removed 2024-11." )]]
 void trcondest(
         Norm in_norm,
         TriangularMatrix<scalar_t>& A,
         blas::real_type<scalar_t> *rcond,
-        Options const& opts = Options());
+        Options const& opts = Options())
+{
+    blas::real_type<scalar_t> Anorm = norm( in_norm, A, opts );
+    *rcond = trcondest( in_norm, A, Anorm, opts );
+}
 
 } // namespace slate
 

--- a/test/test_gecondest.cc
+++ b/test/test_gecondest.cc
@@ -180,7 +180,6 @@ void test_gecondest_work(Params& params, bool run)
         slate_rcond = slate::lu_rcondest_using_factor( norm, A, Anorm, opts );
         // Using traditional BLAS/LAPACK name
         // slate_rcond = slate::gecondest( norm, A, Anorm, opts );
-        // slate::gecondest( norm, A, &Anorm, &slate_rcond, opts );  // deprecated
         time = barrier_get_wtime(MPI_COMM_WORLD) - time;
         // compute and save timing/performance
         params.time() = time;

--- a/test/test_gecondest.cc
+++ b/test/test_gecondest.cc
@@ -176,12 +176,11 @@ void test_gecondest_work(Params& params, bool run)
         params.time2() = time2;
         params.gflops2() = gflop / time2;
 
-
-
         double time = barrier_get_wtime(MPI_COMM_WORLD);
-        slate::lu_condest_using_factor(norm, A, Anorm, &slate_rcond, opts);
+        slate_rcond = slate::lu_rcondest_using_factor( norm, A, Anorm, opts );
         // Using traditional BLAS/LAPACK name
-        // slate::gecondest(norm, A, Anorm, &slate_rcond, opts);
+        // slate_rcond = slate::gecondest( norm, A, Anorm, opts );
+        // slate::gecondest( norm, A, &Anorm, &slate_rcond, opts );  // deprecated
         time = barrier_get_wtime(MPI_COMM_WORLD) - time;
         // compute and save timing/performance
         params.time() = time;

--- a/test/test_pocondest.cc
+++ b/test/test_pocondest.cc
@@ -170,12 +170,10 @@ void test_pocondest_work(Params& params, bool run)
         params.time2() = time2;
         params.gflops2() = gflop / time2;
 
-
-
         double time = barrier_get_wtime(MPI_COMM_WORLD);
-        slate::chol_condest_using_factor(norm, A, Anorm, &slate_rcond, opts);
+        slate_rcond = slate::chol_rcondest_using_factor( norm, A, Anorm, opts );
         // Using traditional BLAS/LAPACK name
-        // slate::pocondest(norm, A, Anorm, &slate_rcond, opts);
+        // slate_rcond = slate::pocondest( norm, A, Anorm, opts );
         time = barrier_get_wtime(MPI_COMM_WORLD) - time;
         // compute and save timing/performance
         params.time() = time;

--- a/test/test_trcondest.cc
+++ b/test/test_trcondest.cc
@@ -157,7 +157,6 @@ void test_trcondest_work(Params& params, bool run)
         slate_rcond = slate::triangular_rcondest( norm, R, Rnorm, opts );
         // Using traditional BLAS/LAPACK name
         // slate_rcond = slate::trcondest( norm, R, Rnorm, opts );
-        // slate::trcondest( norm, R, &slate_rcond, opts );  // deprecated
         time = barrier_get_wtime(MPI_COMM_WORLD) - time;
         // compute and save timing/performance
         params.time() = time;


### PR DESCRIPTION
Returning the rcond seems more native C++, whereas the output argument seemed very Fortran.

For simplified API, uses `rcondest` to clarify that it is the reciprocal cond, so a user does:
```
    rcond = triangular_rcondest( ... );  // Right!
```
instead of:
```
    cond = triangular_condest( ... );  // Wrong! It's rcond, not cond.
```

Also adds Anorm as input argument to `triangular_rcondest( )`, as in other condest routines. In polar (QDWH), we can use this to remove the triangular norm entirely.

Deprecates previous condest routines that had rcond output argument. Since pocondest and the simplified API for condest were added after the last release (2023.11.05), there's no need to deprecate them.