### PR TITLE
Remove tile life from internal routines and BLAS routines

### DIFF
--- a/src/heev.cc
+++ b/src/heev.cc
@@ -135,6 +135,8 @@ void heev(
 
         // Copy diagonal and super-diagonal to vectors.
         internal::copyhb2st( Aband, Lambda, E );
+
+        Aband.releaseRemoteWorkspace();
     }
 
     // 3. Tri-diagonal eigenvalue solver.

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -55,11 +55,11 @@ void hegst(
     uint8_t* column = column_vector.data();
 
     if (target == Target::Devices) {
-        // The work::trsm (itype=1) and work::trmm (itype=2,3)
-        // routines use 2 queues (queue 0,1). All other
-        // internal::routines here use the default queue (queue 0).
-        // So 2 queues need to be allocated.
-        A.allocateBatchArrays(0, 2+lookahead); // (batch size, num_queues)
+        // The work::trsm (itype=1) routine uses 2 queues (queue 0,1).
+        // The work::trmm (itype=2,3) routine uses 1 queue (queue 0).
+        // All other internal::routines here use the default queue (queue 0).
+        int64_t num_queues = (itype == 1) ? 2 : 1;
+        A.allocateBatchArrays(0, num_queues+lookahead); // (batch size, num_queues)
         A.reserveDeviceWorkspace();
     }
 

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -299,7 +299,7 @@ void hemmA(
                             alpha, A.sub(k+1, A.mt()-1, k, k),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts2 );
                     }
                 }
 

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -37,12 +37,20 @@ void hemmA(
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     const scalar_t one = 1.0;
+    const int priority_0 = 0;
+    const int queue_0 = 0;
 
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
+
+    // Use only TileReleaseStrategy::Slate for hemmA.
+    // Internal routines (hemmA and gemmA) called here won't release
+    // any tiles. This routine will clean up tiles.
+    Options opts2 = opts;
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
 
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
@@ -190,15 +198,24 @@ void hemmA(
                     Side::Left,
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
-                    beta,  C.sub(0, 0, 0, C.nt()-1));
+                    beta,  C.sub(0, 0, 0, C.nt()-1),
+                    priority_0, opts2 );
 
                 if (A.mt()-1 > 0) {
                     internal::gemmA<target>(
                         alpha,  A.sub(1, A.mt()-1, 0, 0),
                                 B.sub(0, 0, 0, B.nt()-1),
                         beta,   C.sub(1, C.mt()-1, 0, C.nt()-1),
-                                layout);
+                        layout, priority_0, queue_0, opts2 );
                 }
+            }
+
+            // Clean up workspace
+            #pragma omp task depend( in:gemm[ 0 ] ) shared( B )
+            {
+                auto B_col_0 = B.sub( 0, 0, 0, B.nt()-1 );
+                B_col_0.releaseRemoteWorkspace();
+                B_col_0.releaseLocalWorkspace();
             }
 
             // Main loop
@@ -268,23 +285,31 @@ void hemmA(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(0, k-1, 0, C.nt()-1),
-                        layout);
+                        layout, priority_0, queue_0, opts2 );
 
                     internal::hemmA<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
-                        one,   C.sub(k, k, 0, C.nt()-1));
+                        one,   C.sub(k, k, 0, C.nt()-1),
+                        priority_0, opts2 );
 
                     if (A.mt()-1 > k) {
                         internal::gemmA<target>(
                             alpha, A.sub(k+1, A.mt()-1, k, k),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                            layout);
+                        layout, priority_0, queue_0, opts2 );
                     }
                 }
 
+                // Clean up workspace
+                #pragma omp task depend( in:gemm[ k ] ) shared( B )
+                {
+                    auto B_col_k = B.sub( k, k, 0, B.nt()-1 );
+                    B_col_k.releaseRemoteWorkspace();
+                    B_col_k.releaseLocalWorkspace();
+                }
             }
 
             #pragma omp task depend(in:gemm[A.nt()-1])
@@ -423,7 +448,8 @@ void hemmA(
                     Side::Left,
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
-                    beta,  C.sub(0, 0, 0, C.nt()-1));
+                    beta,  C.sub(0, 0, 0, C.nt()-1),
+                    priority_0, opts2 );
 
                 if (A.mt()-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, A.nt()-1);
@@ -431,8 +457,16 @@ void hemmA(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, C.mt()-1, 0, C.nt()-1),
-                        layout);
+                        layout, priority_0, queue_0, opts2 );
                 }
+            }
+
+            // Clean up workspace
+            #pragma omp task depend( in:gemm[ 0 ] ) shared( B )
+            {
+                auto B_col_0 = B.sub( 0, 0, 0, B.nt()-1 );
+                B_col_0.releaseRemoteWorkspace();
+                B_col_0.releaseLocalWorkspace();
             }
 
             // Main loop
@@ -500,13 +534,14 @@ void hemmA(
                         alpha, A.sub(0, k-1, k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(0, k-1, 0, C.nt()-1),
-                        layout);
+                        layout, priority_0, queue_0, opts2 );
 
                     internal::hemmA<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
-                        one,   C.sub(k, k, 0, C.nt()-1));
+                        one,   C.sub(k, k, 0, C.nt()-1),
+                        priority_0, opts2 );
 
                     if (A.nt()-1 > k) {
                         auto Arow_k = A.sub(k, k, k+1, A.nt()-1);
@@ -514,8 +549,16 @@ void hemmA(
                             alpha, conj_transpose( Arow_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                            layout);
+                            layout, priority_0, queue_0, opts2 );
                     }
+                }
+
+                // Clean up workspace
+                #pragma omp task depend( in:gemm[ k ] ) shared( B )
+                {
+                    auto B_col_k = B.sub( k, k, 0, B.nt()-1 );
+                    B_col_k.releaseRemoteWorkspace();
+                    B_col_k.releaseLocalWorkspace();
                 }
             }
 

--- a/src/internal/internal_copyhb2st.cc
+++ b/src/internal/internal_copyhb2st.cc
@@ -65,7 +65,6 @@ void copyhb2st(internal::TargetType<Target::HostTask>,
             auto T = A(i-1, i);
             E[E_index] = real( T(T.mb()-1, 0) );
             E_index += 1;
-            A.tileTick(i-1, i);
         }
 
         // Copy main diagonal to D.
@@ -82,7 +81,6 @@ void copyhb2st(internal::TargetType<Target::HostTask>,
             E[E_index + j] = real( T(j, j+1) );
         }
         E_index += len-1;
-        A.tileTick(i, i);
     }
 }
 

--- a/src/internal/internal_copytb2bd.cc
+++ b/src/internal/internal_copytb2bd.cc
@@ -63,7 +63,6 @@ void copytb2bd(internal::TargetType<Target::HostTask>,
             auto T = A(i-1, i);
             E[E_index] = real( T(T.mb()-1, 0) );
             E_index += 1;
-            A.tileTick(i-1, i);
         }
 
         // Copy main diagonal to D.
@@ -80,7 +79,6 @@ void copytb2bd(internal::TargetType<Target::HostTask>,
             E[E_index + j] = real( T(j, j+1) );
         }
         E_index += len-1;
-        A.tileTick(i, i);
     }
 }
 

--- a/src/internal/internal_getrf_tntpiv.cc
+++ b/src/internal/internal_getrf_tntpiv.cc
@@ -608,7 +608,7 @@ void getrf_tntpiv_panel(
                                 aux_pivot[ 0 ], diag_len, A.mt(), mb );
                         }
 
-                        Awork.tileTick( i2, 0 );
+                        Awork.tileRelease( i2, 0 );
                     }
                 }
                 else {

--- a/src/internal/internal_unmtr_hb2st.cc
+++ b/src/internal/internal_unmtr_hb2st.cc
@@ -441,7 +441,6 @@ void unmtr_hb2st( internal::TargetType<target>,
                                     }
                                 }
                             }
-                            V.tileTick(0, r);
                         } // if C(i, k) is local
                     } // inner for loop
 
@@ -451,11 +450,8 @@ void unmtr_hb2st( internal::TargetType<target>,
                             Vr_data[ii + ii*ldv] = tau[ii];
                         }
                     }
-                    if (target == Target::Devices) {
-                        for (int d = 0; d < C.num_devices(); ++d) {
-                            V_.tileRelease(0, r, d);
-                        }
-                    }
+                    V.releaseLocalWorkspaceTile(0, r);
+                    V.releaseRemoteWorkspaceTile(0, r);
                 }
             }
         } // inner loop

--- a/src/svd.cc
+++ b/src/svd.cc
@@ -252,6 +252,8 @@ void svd(
 
         // Copy diagonal and super-diagonal to vectors.
         internal::copytb2bd(Aband, Sigma, E);
+
+        Aband.releaseRemoteWorkspace();
     }
 
     int64_t ncvt = 0, nru = 0, ldvt = 1, ldu = 1;

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -348,9 +348,9 @@ void tbsm(
                         pivots.at(k), layout);
                 }
 
-                #pragma omp task
+                #pragma omp task shared( A, B ) firstprivate( k, k_end, nt )
                 {
-                    auto A_panel = A.sub( k, k, k, k_end );
+                    auto A_panel = A.sub( k, k, k, k_end-1 );
                     A_panel.releaseRemoteWorkspace();
                     A_panel.releaseLocalWorkspace();
 

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -35,11 +35,19 @@ void tbsm(
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     // Assumes column major
-    const int priority_1 = 1;
     const Layout layout = Layout::ColMajor;
+    const int priority_0 = 0;
+    const int priority_1 = 1;
+    const int queue_0 = 0;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
+
+    // Use only TileReleaseStrategy::Slate for gemm.
+    // Internal gemm routine called here won't release
+    // any tiles. This routine will clean up tiles.
+    Options opts2 = opts;
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
 
     // if on right, change to left by (conj)-transposing A and B to get
     // op(B) = op(A)^{-1} * op(B)
@@ -136,7 +144,8 @@ void tbsm(
                     internal::trsm<Target::HostTask>(
                         Side::Left,
                         one, A.sub(k, k),
-                             B.sub(k, k, 0, nt-1), 1);
+                             B.sub(k, k, 0, nt-1),
+                        priority_1, layout, queue_0, opts2 );
 
                     // send A(i=k+1:i_end-1, k) to ranks owning block row B(i, :)
                     BcastList bcast_list_A;
@@ -163,7 +172,7 @@ void tbsm(
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i, i, 0, nt-1),
-                            layout, 1);
+                            layout, priority_1, queue_0, opts2 );
                     }
                 }
 
@@ -181,8 +190,23 @@ void tbsm(
                             -one, A.sub(k+1+lookahead, i_end-1, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(k+1+lookahead, i_end-1, 0, nt-1),
-                            layout);
+                            layout, priority_0, queue_0, opts2 );
                     }
+                }
+
+                #pragma omp task depend(inout:row[k])
+                {
+                    auto A_panel = A.sub(k, i_end-1, k, k);
+                    A_panel.releaseRemoteWorkspace();
+                    A_panel.releaseLocalWorkspace();
+
+                    auto B_panel = B.sub(k, k, 0, nt-1);
+                    B_panel.releaseRemoteWorkspace();
+
+                    // Copy back modifications to tiles in the B panel
+                    // before they are erased.
+                    B_panel.tileUpdateAllOrigin();
+                    B_panel.releaseLocalWorkspace();
                 }
             }
         }
@@ -204,7 +228,8 @@ void tbsm(
                     internal::trsm<Target::HostTask>(
                         Side::Left,
                         one, A.sub(k, k),
-                             B.sub(k, k, 0, nt-1), 1);
+                             B.sub(k, k, 0, nt-1),
+                        priority_1, layout, queue_0, opts2 );
 
                     // send A(i=k-kdt:k-1, k) to ranks owning block row B(i, :)
                     BcastList bcast_list_A;
@@ -228,7 +253,7 @@ void tbsm(
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i, i, 0, nt-1),
-                            layout, 1);
+                            layout, priority_1, queue_0, opts2 );
                     }
                 }
 
@@ -245,8 +270,23 @@ void tbsm(
                             -one, A.sub(i_begin, k-1-lookahead, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i_begin, k-1-lookahead, 0, nt-1),
-                            layout);
+                            layout, priority_0, queue_0, opts2 );
                     }
+                }
+
+                #pragma omp task depend(inout:row[k])
+                {
+                    auto A_panel = A.sub(i_begin, k, k, k);
+                    A_panel.releaseRemoteWorkspace();
+                    A_panel.releaseLocalWorkspace();
+
+                    auto B_panel = B.sub(k, k, 0, nt-1);
+                    B_panel.releaseRemoteWorkspace();
+
+                    // Copy back modifications to tiles in the B panel
+                    // before they are erased.
+                    B_panel.tileUpdateAllOrigin();
+                    B_panel.releaseLocalWorkspace();
                 }
             }
         }
@@ -259,15 +299,15 @@ void tbsm(
             // A = L^T, the RHS updates are organized differently than in
             // the no-pivoting case above. Due to dependencies, there is no
             // lookahead or top-level tasks, only the nested tasks inside
-            // internal routines.
+            // internal routines and a tile-release task.
             for (int64_t k = mt-1; k >= 0; --k) {
+                // A( k, k : k_end-1 ) is k-th row
+                // Typically, A is L^T, so the k-th row is the
+                // k-th panel (transposed) from gbtrf.
+                int64_t k_end = min(k + kdt + 1, A.nt());
+
                 // update RHS
                 {
-                    // A( k, k : k_end-1 ) is k-th row
-                    // Typically, A is L^T, so the k-th row is the
-                    // k-th panel (transposed) from gbtrf.
-                    int64_t k_end = min(k + kdt + 1, A.nt());
-
                     for (int64_t i = k+1; i < k_end; ++i) {
                         // send A(k, i) across to ranks owning B(k, :)
                         A.template tileBcast<target>(k, i, B.sub(k, k, 0, nt-1), layout);
@@ -284,7 +324,7 @@ void tbsm(
                                     -one, A.sub(k, k, i, i),
                                           B.sub(i, i, 0, nt-1),
                                     one,  B.sub(k, k, 0, nt-1),
-                                    layout, priority_1 );
+                                    layout, priority_1, queue_0, opts2 );
                     }
                 }
 
@@ -297,7 +337,8 @@ void tbsm(
                     internal::trsm<Target::HostTask>(
                         Side::Left,
                         one, A.sub(k, k),
-                             B.sub(k, k, 0, nt-1), 1);
+                             B.sub(k, k, 0, nt-1),
+                        priority_1, layout, queue_0, opts2 );
                 }
 
                 // swap rows in B(k:mt-1, 0:nt-1)
@@ -305,6 +346,21 @@ void tbsm(
                     internal::permuteRows<Target::HostTask>(
                         Direction::Backward, B.sub(k, B.mt()-1, 0, B.nt()-1),
                         pivots.at(k), layout);
+                }
+
+                #pragma omp task
+                {
+                    auto A_panel = A.sub( k, k, k, k_end );
+                    A_panel.releaseRemoteWorkspace();
+                    A_panel.releaseLocalWorkspace();
+
+                    auto B_panel = B.sub( k, k, 0, nt-1 );
+                    B_panel.releaseRemoteWorkspace();
+
+                    // Copy back modifications to tiles in the B panel
+                    // before they are erased.
+                    B_panel.tileUpdateAllOrigin();
+                    B_panel.releaseLocalWorkspace();
                 }
             }
         }

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -43,8 +43,8 @@ void tbsm(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for gemm.
-    // Internal gemm routine called here won't release
+    // Use only TileReleaseStrategy::Slate for tbsmPivots.
+    // Internal tbsmPivots routine called here won't release
     // any tiles. This routine will clean up tiles.
     Options opts2 = opts;
     opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -354,13 +354,15 @@ void tbsm(
                     A_panel.releaseRemoteWorkspace();
                     A_panel.releaseLocalWorkspace();
 
-                    auto B_panel = B.sub( k, k, 0, nt-1 );
-                    B_panel.releaseRemoteWorkspace();
+                    if (k + kdt + 1 <= A.nt()) {
+                        auto B_panel = B.sub( k_end-1, k_end-1, 0, nt-1 );
+                        B_panel.releaseRemoteWorkspace();
 
-                    // Copy back modifications to tiles in the B panel
-                    // before they are erased.
-                    B_panel.tileUpdateAllOrigin();
-                    B_panel.releaseLocalWorkspace();
+                        // Copy back modifications to tiles in the B panel
+                        // before they are erased.
+                        B_panel.tileUpdateAllOrigin();
+                        B_panel.releaseLocalWorkspace();
+                    }
                 }
             }
         }

--- a/src/trmm.cc
+++ b/src/trmm.cc
@@ -28,7 +28,7 @@ void trmm(
 
     if (target == Target::Devices) {
         const int64_t batch_size_default = 0; // use default batch size
-        const int num_queues = 2; // Number of kernels without lookahead
+        const int num_queues = 1; // Number of kernels without lookahead
         B.allocateBatchArrays( batch_size_default, num_queues );
         B.reserveDeviceWorkspace();
     }

--- a/src/work/work_trmm.cc
+++ b/src/work/work_trmm.cc
@@ -73,8 +73,8 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
-    // Use only TileReleaseStrategy::Slate for trsm.
-    // Internal routines (trsm and gemm) called here won't release
+    // Use only TileReleaseStrategy::Slate for trmm.
+    // Internal routines (trmm and gemm) called here won't release
     // any tiles. Trsm will clean up tiles.
     Options opts2 = {{Option::TileReleaseStrategy, TileReleaseStrategy::Slate}};
 

--- a/src/work/work_trmm.cc
+++ b/src/work/work_trmm.cc
@@ -70,7 +70,6 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     const int priority_0 = 0;
     const int priority_1 = 1;
     const int queue_0 = 0;
-    const int queue_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -100,9 +99,9 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    // Requires at least 2 queues
+    // Requires at least 1 queues
     if (target == Target::Devices)
-        assert(B.numComputeQueues() >= 2);
+        assert(B.numComputeQueues() >= 1);
 
     if (A.uplo() == Uplo::Upper) {
         // ----------------------------------------
@@ -148,7 +147,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 Side::Left,
                 alpha, A.sub(0, 0),
                        B.sub(0, 0, 0, nt-1),
-                priority_1, queue_1, opts2 );
+                priority_1, queue_0, opts2 );
         }
 
         #pragma omp task depend(in:gemm[0])
@@ -202,7 +201,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alpha, A.sub(k, k),
                            B.sub(k, k, 0, nt-1),
-                    priority_0, queue_1, opts2 );
+                    priority_0, queue_0, opts2 );
             }
 
             #pragma omp task depend(in:gemm[k])
@@ -262,7 +261,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 Side::Left,
                 alpha, A.sub(mt-1, mt-1),
                        B.sub(mt-1, mt-1, 0, nt-1),
-                priority_1, queue_1, opts2 );
+                priority_1, queue_0, opts2 );
         }
 
         #pragma omp task depend(in:gemm[mt-1])
@@ -316,7 +315,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alpha, A.sub(k, k),
                            B.sub(k, k, 0, nt-1),
-                    priority_0, queue_1, opts2 );
+                    priority_0, queue_0, opts2 );
             }
 
             #pragma omp task depend(in:gemm[k])

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -90,17 +90,15 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
+    // Use only TileReleaseStrategy::Slate for trsm.
+    // Internal routines (trsm and gemm) called here won't release
+    // any tiles. Trsm will clean up tiles.
     Options opts2 = opts;
+    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
 
     // Requires 2+lookahead queues
     if (target == Target::Devices) {
         assert(B.numComputeQueues() >= 2+lookahead);
-
-        // Use only TileReleaseStrategy::Slate for trsm.
-        // Internal routines (trsm and gemm) called here
-        // won't release any tiles. Trsm will
-        // clean up tiles.
-        opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
     }
 
     if (A.uplo() == Uplo::Lower) {


### PR DESCRIPTION
This addresses tile life in everywhere except 10 LAPACK routines.  (N.B., #143 removes tile life from `getrf`, `getrf_tntpiv`, and `getrf_nopiv`, so it's really just 7 that are left.)