### PR TITLE
Remove tile life infrastructure

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -434,14 +434,14 @@ public:
     void tileUpdateAllOrigin();
 
     /// Returns life counter of tile {i, j} of op(A).
-    [[deprecated( "Tile life has been removed. Will be removed 2024-12." )]]
+    [[deprecated( "Tile life has been removed. Accessor stubs will be removed 2024-12." )]]
     int64_t tileLife(int64_t i, int64_t j) const
     {
         return 1;
     }
 
     /// Set life counter of tile {i, j} of op(A).
-    [[deprecated( "Tile life has been removed. Will be removed 2024-12." )]]
+    [[deprecated( "Tile life has been removed. Accessor stubs will be removed 2024-12." )]]
     void tileLife(int64_t i, int64_t j, int64_t life)
     {
     }
@@ -449,7 +449,7 @@ public:
     /// Decrements life counter of workspace tile {i, j} of op(A).
     /// Then, if life reaches 0, deletes tile on all devices.
     /// For local, non-workspace tiles, does nothing.
-    [[deprecated( "Tile life has been removed. Will be removed 2024-12." )]]
+    [[deprecated( "Tile life has been removed. Accessor stubs will be removed 2024-12." )]]
     void tileTick(int64_t i, int64_t j)
     {
     }

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -504,24 +504,36 @@ public:
     template <Target target = Target::Host>
     [[deprecated( "Tile life has been removed. The 6 argument tileBcast will be removed 2024-12." )]]
     void tileBcast(int64_t i, int64_t j, BaseMatrix const& B,
-                   Layout layout, int tag, int64_t life_factor) {
+                   Layout layout, int tag, int64_t life_factor)
+    {
         tileBcast( i, j, B, layout, tag );
     }
 
-    // TODO add deprecation warnings
     template <Target target = Target::Host>
+    void listBcast( BcastList& bcast_list, Layout layout, int tag = 0, bool is_shared = false );
+
+    template <Target target = Target::Host>
+    [[deprecated( "Tile life has been removed. The 5 argument listBcast will be removed 2024-12." )]]
     void listBcast(
-        BcastList& bcast_list, Layout layout,
-        int tag = 0, int64_t life_factor = 1,
-        bool is_shared = false);
+        BcastList& bcast_list, Layout layout, int tag,
+        int64_t life_factor, bool is_shared = false)
+    {
+        listBcast( bcast_list, layout, tag, is_shared );
+    }
 
     // This variant takes a BcastListTag where each <i,j> tile has
     // its own message tag
     template <Target target = Target::Host>
+    void listBcastMT( BcastListTag& bcast_list, Layout layout, bool is_shared = false );
+
+    template <Target target = Target::Host>
+    [[deprecated( "Tile life has been removed. The 4 argument listBcastMT will be removed 2024-12." )]]
     void listBcastMT(
         BcastListTag& bcast_list, Layout layout,
-        int64_t life_factor = 1,
-        bool is_shared = false);
+        int64_t life_factor, bool is_shared = false)
+    {
+        listBcastMT( bcast_list, layout, is_shared );
+    }
 
     template <Target target = Target::Host>
     void listReduce(ReduceList& reduce_list, Layout layout, int tag = 0);
@@ -1940,9 +1952,6 @@ void BaseMatrix<scalar_t>::tileBcast(
 /// @param[in] tag
 ///     MPI tag, default 0.
 ///
-/// @param[in] life_factor
-///     A unused argument from tile life
-///
 /// @param[in] is_shared
 ///     A flag to get and hold the broadcasted (prefetched) tiles on the
 ///     devices. This flag prevents any subsequent calls of tileRelease()
@@ -1953,8 +1962,7 @@ void BaseMatrix<scalar_t>::tileBcast(
 template <typename scalar_t>
 template <Target target>
 void BaseMatrix<scalar_t>::listBcast(
-    BcastList& bcast_list, Layout layout,
-    int tag, int64_t life_factor, bool is_shared)
+    BcastList& bcast_list, Layout layout, int tag, bool is_shared )
 {
     if (target == Target::Devices) {
         assert(num_devices() > 0);
@@ -2071,9 +2079,6 @@ void BaseMatrix<scalar_t>::listBcast(
 ///     Indicates the Layout (ColMajor/RowMajor) of the broadcasted data.
 ///     WARNING: must match the layout of the tile in the sender MPI rank.
 ///
-/// @param[in] life_factor
-///     An unused argument from tile life
-///
 /// @param[in] is_shared
 ///     A flag to get and hold the broadcasted (prefetched) tiles on the
 ///     devices. This flag prevents any subsequent calls of tileRelease()
@@ -2084,8 +2089,7 @@ void BaseMatrix<scalar_t>::listBcast(
 template <typename scalar_t>
 template <Target target>
 void BaseMatrix<scalar_t>::listBcastMT(
-    BcastListTag& bcast_list, Layout layout,
-    int64_t life_factor, bool is_shared)
+    BcastListTag& bcast_list, Layout layout, bool is_shared )
 {
     if (target == Target::Devices) {
         assert(num_devices() > 0);
@@ -2111,8 +2115,7 @@ void BaseMatrix<scalar_t>::listBcastMT(
 
     #if defined( SLATE_HAVE_MT_BCAST )
         #pragma omp taskloop slate_omp_default_none \
-            shared( bcast_list ) \
-            firstprivate(layout, mpi_size, is_shared)
+            shared( bcast_list ) firstprivate( layout, mpi_size, is_shared )
     #endif
     for (size_t bcastnum = 0; bcastnum < bcast_list.size(); ++bcastnum) {
 

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -553,7 +553,7 @@ void swap(BaseTrapezoidMatrix<scalar_t>& A, BaseTrapezoidMatrix<scalar_t>& B)
 
 //------------------------------------------------------------------------------
 /// Returns number of local tiles of the matrix on this rank.
-// todo: numLocalTiles? use for life as well?
+// todo: numLocalTiles?
 template <typename scalar_t>
 int64_t BaseTrapezoidMatrix<scalar_t>::getMaxHostTiles()
 {

--- a/include/slate/HermitianBandMatrix.hh
+++ b/include/slate/HermitianBandMatrix.hh
@@ -55,7 +55,12 @@ public:
     template <typename T>
     friend void swap(HermitianBandMatrix<T>& A, HermitianBandMatrix<T>& B);
 
-    void    gatherAll(std::set<int>& rank_set, int tag = 0, int64_t life_factor = 1);
+    void    gatherAll(std::set<int>& rank_set, int tag = 0);
+    [[deprecated( "Tile life has been removed. The 3 argument gatherAll will be removed 2024-12." )]]
+    void    gatherAll(std::set<int>& rank_set, int tag, int64_t life_factor) {
+        gatherAll( rank_set, tag );
+    }
+
     void    he2hbGather(HermitianMatrix<scalar_t>& A);
 };
 
@@ -265,7 +270,7 @@ void swap(HermitianBandMatrix<scalar_t>& A, HermitianBandMatrix<scalar_t>& B)
 // avoid if possible.
 //
 template <typename scalar_t>
-void HermitianBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag, int64_t life_factor)
+void HermitianBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag)
 {
     trace::Block trace_block("slate::gatherAll");
 
@@ -286,7 +291,7 @@ void HermitianBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag, 
 
             // If receiving the tile.
             this->storage_->tilePrepareToReceive( this->globalIndex( i, j ),
-                                                 life_factor, this->layout_ );
+                                                  this->layout_ );
 
             // Send across MPI ranks.
             // Previous used MPI bcast: tileBcastToSet(i, j, rank_set);

--- a/include/slate/Matrix.hh
+++ b/include/slate/Matrix.hh
@@ -678,7 +678,7 @@ void swap(Matrix<scalar_t>& A, Matrix<scalar_t>& B)
 //------------------------------------------------------------------------------
 /// Returns number of local tiles of the matrix on this rank.
 //
-// todo: numLocalTiles? use for life as well?
+// todo: numLocalTiles?
 template <typename scalar_t>
 int64_t Matrix<scalar_t>::getMaxHostTiles()
 {

--- a/include/slate/TriangularBandMatrix.hh
+++ b/include/slate/TriangularBandMatrix.hh
@@ -59,7 +59,12 @@ public:
     template <typename T>
     friend void swap(TriangularBandMatrix<T>& A, TriangularBandMatrix<T>& B);
 
-    void    gatherAll(std::set<int>& rank_set, int tag = 0, int64_t life_factor = 1);
+    void    gatherAll(std::set<int>& rank_set, int tag = 0);
+    [[deprecated( "Tile life has been removed. The 3 argument gatherAll will be removed 2024-12." )]]
+    void    gatherAll(std::set<int>& rank_set, int tag, int64_t life_factor) {
+        gatherAll( rank_set, tag );
+    }
+
     void    ge2tbGather(Matrix<scalar_t>& A);
 
     Diag diag() { return diag_; }
@@ -281,7 +286,7 @@ void swap(TriangularBandMatrix<scalar_t>& A, TriangularBandMatrix<scalar_t>& B)
 // avoid if possible.
 //
 template <typename scalar_t>
-void TriangularBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag, int64_t life_factor)
+void TriangularBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag)
 {
     trace::Block trace_block("slate::gatherAll");
 
@@ -302,7 +307,7 @@ void TriangularBandMatrix<scalar_t>::gatherAll(std::set<int>& rank_set, int tag,
 
             // If receiving the tile.
             this->storage_->tilePrepareToReceive( this->globalIndex( i, j ),
-                                                 life_factor, this->layout_ );
+                                                  this->layout_ );
 
             // Send across MPI ranks.
             // Previous used MPI bcast: tileBcastToSet(i, j, rank_set);

--- a/include/slate/c_api/types.h
+++ b/include/slate/c_api/types.h
@@ -32,13 +32,6 @@ const slate_Target slate_Target_HostBatch   = 'B'; ///< slate::Target::HostBatch
 const slate_Target slate_Target_Devices     = 'D'; ///< slate::Target::Devices
 // end slate_Target
 
-typedef char slate_TileReleaseStrategy; /* enum */                        ///< slate::TileReleaseStrategy
-const slate_TileReleaseStrategy slate_TileReleaseStrategy_None     = 'N'; ///< slate::TileReleaseStrategy::None
-const slate_TileReleaseStrategy slate_TileReleaseStrategy_Internal = 'I'; ///< slate::TileReleaseStrategy::Internal
-const slate_TileReleaseStrategy slate_TileReleaseStrategy_Slate    = 'S'; ///< slate::TileReleaseStrategy::Slate
-const slate_TileReleaseStrategy slate_TileReleaseStrategy_All      = 'A'; ///< slate::TileReleaseStrategy::All
-// end slate_TileReleaseStrategy
-
 typedef char slate_MethodEig; /* enum */        ///< slate::MethodEig
 const slate_MethodEig slate_MethodEig_QR = 'Q'; ///< slate::MethodEig::QR
 const slate_MethodEig slate_MethodEig_DC = 'D'; ///< slate::MethodEig::DC
@@ -53,12 +46,11 @@ const slate_Option slate_Option_InnerBlocking        =  3; ///< slate::Option::I
 const slate_Option slate_Option_MaxPanelThreads      =  4; ///< slate::Option::MaxPanelThreads
 const slate_Option slate_Option_Tolerance            =  5; ///< slate::Option::Tolerance
 const slate_Option slate_Option_Target               =  6; ///< slate::Option::Target
-const slate_Option slate_Option_TileReleaseStrategy  =  7; ///< slate::Option::TileReleaseStrategy
-const slate_Option slate_Option_HoldLocalWorkspace   =  8; ///< slate::Option::HoldLocalWorkspace
-const slate_Option slate_Option_Depth                =  9; ///< slate::Option::HoldLocalWorkspace
-const slate_Option slate_Option_MaxIterations        = 10; ///< slate::Option::HoldLocalWorkspace
-const slate_Option slate_Option_UseFallbackSolver    = 11; ///< slate::Option::HoldLocalWorkspace
-const slate_Option slate_Option_PivotThreshold       = 12; ///< slate::Option::PivotThreshold
+const slate_Option slate_Option_HoldLocalWorkspace   =  7; ///< slate::Option::HoldLocalWorkspace
+const slate_Option slate_Option_Depth                =  8; ///< slate::Option::HoldLocalWorkspace
+const slate_Option slate_Option_MaxIterations        =  9; ///< slate::Option::HoldLocalWorkspace
+const slate_Option slate_Option_UseFallbackSolver    = 10; ///< slate::Option::HoldLocalWorkspace
+const slate_Option slate_Option_PivotThreshold       = 11; ///< slate::Option::PivotThreshold
 const slate_Option slate_Option_PrintVerbose         = 50; ///< slate::Option::PrintVerbose
 const slate_Option slate_Option_PrintEdgeItems       = 51; ///< slate::Option::PrintEdgeItems
 const slate_Option slate_Option_PrintWidth           = 52; ///< slate::Option::PrintWidth
@@ -86,7 +78,6 @@ typedef union slate_OptionValue {
     int64_t       max_panel_threads;
     double        tolerance;
     slate_Target  target;
-    slate_TileReleaseStrategy tile_release_strategy;
 } slate_OptionValue;                  ///< slate::OptionValue
 
 typedef struct slate_Options {

--- a/include/slate/enums.hh
+++ b/include/slate/enums.hh
@@ -39,13 +39,6 @@ enum class Target : char {
     Devices   = 'D',    ///< computation using batch BLAS on devices (cuBLAS)
 };
 
-enum class TileReleaseStrategy : char {
-    None      = 'N',    ///< tiles are not release at all
-    Internal  = 'I',    ///< tiles are released by routines in slate::internal namespace
-    Slate     = 'S',    ///< tiles are released by routines directly in slate namespace
-    All       = 'A',    ///< tiles are released by routines in all namespaces
-};
-
 namespace internal {
 
 /// TargetType is used to overload functions, since there is no C++
@@ -75,7 +68,6 @@ enum class Option : char {
     MaxPanelThreads,    ///< max number of threads for panel, >= 1
     Tolerance,          ///< tolerance for iterative methods, default epsilon
     Target,             ///< computation method (@see Target)
-    TileReleaseStrategy,///< tile releasing strategy used by routines
     HoldLocalWorkspace, ///< do not erase local workspace tiles for enabling
                         ///< resue of the tiles by the next routine
     Depth,              ///< depth for the RBT solver

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -344,8 +344,6 @@ public:
     void tileMakeTransposable(Tile<scalar_t>* tile);
     void tileLayoutReset(Tile<scalar_t>* tile);
 
-    void tileTick(ij_tuple ij);
-
     //--------------------------------------------------------------------------
     /// @return tile's receive counter.
     int64_t tileReceiveCount(ij_tuple ij)

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -37,7 +37,6 @@ private:
     /// vector of tile instances indexed by device id.
     std::vector< Tile<scalar_t>* > tiles_;
     int num_instances_;
-    int64_t life_;
     /// number of times a tile is received.
     /// This variable is used for only MPI communications.
     int64_t receive_count_;
@@ -49,7 +48,6 @@ public:
     /// Constructor for TileNode class
     TileNode(int num_devices)
         : num_instances_(0),
-          life_(0),
           receive_count_(0)
     {
         slate_assert(num_devices >= 0);
@@ -131,11 +129,6 @@ public:
     {
         slate_assert(dev >= -1 && dev+1 < int(tiles_.size()));
         return tiles_[dev+1];
-    }
-
-    int64_t& lives()
-    {
-        return life_;
     }
 
     int64_t& receiveCount()
@@ -354,22 +347,6 @@ public:
     void tileTick(ij_tuple ij);
 
     //--------------------------------------------------------------------------
-    /// @return tile's life counter.
-    int64_t tileLife(ij_tuple ij)
-    {
-        LockGuard guard( getTilesMapLock() );
-        return tiles_.at( ij )->lives();
-    }
-
-    //--------------------------------------------------------------------------
-    /// Set tile's life counter.
-    void tileLife(ij_tuple ij, int64_t life)
-    {
-        LockGuard guard( getTilesMapLock() );
-        tiles_.at( ij )->lives() = life;
-    }
-
-    //--------------------------------------------------------------------------
     /// @return tile's receive counter.
     int64_t tileReceiveCount(ij_tuple ij)
     {
@@ -393,14 +370,11 @@ public:
         tiles_.at( ij )->receiveCount() -= release_count;
     }
 
-    /// Ensures the tile node exists and increments both the tile life and
-    /// recieve count
-    void tilePrepareToReceive(ij_tuple ij, int life, Layout layout)
+    /// Ensures the tile node exists and increments the recieve count
+    void tilePrepareToReceive(ij_tuple ij, Layout layout)
     {
         if (! tileIsLocal(ij)) {
-            // Create tile to receive data, with life span.
-            // If tile already exists, add to its life span.
-            //
+            // Create tile to receive data.
             LockGuard guard( getTilesMapLock() );
             int64_t i  = std::get<0>( ij );
             int64_t j  = std::get<1>( ij );
@@ -409,9 +383,6 @@ public:
 
             if (iter == end())
                 tileInsert( {i, j, HostNum}, TileKind::Workspace, layout );
-            else
-                life += tileLife( ij );
-            tileLife( ij, life );
             tileIncrementReceiveCount( ij );
         }
     }
@@ -1038,7 +1009,7 @@ void MatrixStorage<scalar_t>::releaseWorkspaceBuffer(scalar_t* data, int device)
 //------------------------------------------------------------------------------
 /// Inserts tile {i, j} on given device, which can be host,
 /// allocating new memory for it.
-/// Creates TileNode(i, j) if not already exists (Tile's life is set 0).
+/// Creates TileNode(i, j) if not already exists.
 /// Tile kind should be either TileKind::Workspace or TileKind::SlateOwned.
 ///
 /// @return Pointer to newly inserted Tile.
@@ -1153,23 +1124,6 @@ void MatrixStorage<scalar_t>::tileLayoutReset(Tile<scalar_t>* tile)
     if (tile->extended()) {
         memory_.free(tile->extData(), tile->device());
         tile->layoutReset();
-    }
-}
-
-//------------------------------------------------------------------------------
-/// If tile {i, j} is a workspace tile (i.e., not local),
-/// decrement its life counter by 1;
-/// if life reaches 0, erase tile on the host and all devices.
-///
-template <typename scalar_t>
-void MatrixStorage<scalar_t>::tileTick(ij_tuple ij)
-{
-    if (! tileIsLocal(ij)) {
-        LockGuard guard(getTilesMapLock());
-        int64_t life = --(tiles_.at(ij)->lives());
-        if (life == 0) {
-            erase(ij);
-        }
     }
 }
 

--- a/include/slate/types.hh
+++ b/include/slate/types.hh
@@ -46,9 +46,6 @@ public:
     OptionValue(Target t) : i_(int(t))
     {}
 
-    OptionValue(TileReleaseStrategy t) : i_(int(t))
-    {}
-
     OptionValue(MethodEig m) : i_(int(m))
     {}
 

--- a/src/add.cc
+++ b/src/add.cc
@@ -34,17 +34,14 @@ void add(
         B.reserveDeviceWorkspace();
     }
 
-    Options opts2 = Options( opts );
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     bool hold_local_workspace = get_option<bool>(
-            opts2, Option::HoldLocalWorkspace, 0 );
+            opts, Option::HoldLocalWorkspace, 0 );
 
     #pragma omp parallel
     #pragma omp master
     {
         internal::add<target>(alpha, std::move(A),
-                                beta, std::move(B), priority_0, queue_0, opts2);
+                                beta, std::move(B), priority_0, queue_0, opts );
         #pragma omp taskwait
         B.tileUpdateAllOrigin();
     }
@@ -175,17 +172,14 @@ void add(
         B.reserveDeviceWorkspace();
     }
 
-    Options opts2 = Options( opts );
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     bool hold_local_workspace = get_option<bool>(
-            opts2, Option::HoldLocalWorkspace, 0 );
+            opts, Option::HoldLocalWorkspace, 0 );
 
     #pragma omp parallel
     #pragma omp master
     {
         internal::add<target>(alpha, std::move(A),
-                              beta, std::move(B), priority_0, queue_0, opts2);
+                              beta, std::move(B), priority_0, queue_0, opts );
         #pragma omp taskwait
         B.tileUpdateAllOrigin();
     }

--- a/src/add.cc
+++ b/src/add.cc
@@ -25,10 +25,6 @@ void add(
     scalar_t beta,  Matrix<scalar_t>& B,
     Options const& opts )
 {
-    // Constants
-    const int priority_0 = 0;
-    const int queue_0 = 0;
-
     if (target == Target::Devices) {
         B.allocateBatchArrays();
         B.reserveDeviceWorkspace();
@@ -41,7 +37,7 @@ void add(
     #pragma omp master
     {
         internal::add<target>(alpha, std::move(A),
-                                beta, std::move(B), priority_0, queue_0, opts );
+                                beta, std::move(B) );
         #pragma omp taskwait
         B.tileUpdateAllOrigin();
     }
@@ -165,8 +161,6 @@ void add(
     Options const& opts )
 {
     // Constants
-    const int priority_0 = 0;
-    const int queue_0 = 0;
     if (target == Target::Devices) {
         B.allocateBatchArrays();
         B.reserveDeviceWorkspace();
@@ -179,7 +173,7 @@ void add(
     #pragma omp master
     {
         internal::add<target>(alpha, std::move(A),
-                              beta, std::move(B), priority_0, queue_0, opts );
+                              beta, std::move(B) );
         #pragma omp taskwait
         B.tileUpdateAllOrigin();
     }

--- a/src/auxiliary/Debug.hh
+++ b/src/auxiliary/Debug.hh
@@ -20,7 +20,6 @@ enum Fields {
     Field_MOSI   = 0x02,
     Field_Layout = 0x04,
     Field_Buffer = 0x08,
-    Field_Life   = 0x10,
 };
 
 // -----------------------------------------------------------------------------

--- a/src/gbmm.cc
+++ b/src/gbmm.cc
@@ -48,12 +48,6 @@ void gbmm(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for gbmm.
-    // Internal gbmm routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector(A.nt());
     std::vector<uint8_t>  gemm_vector(A.nt());
@@ -132,7 +126,7 @@ void gbmm(
                     alpha, A.sub(i_begin, i_end-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  C.sub(i_begin, i_end-1, 0, C.nt()-1),
-                    layout, priority_0, queue_0, opts2 );
+                    layout, priority_0, queue_0, opts );
 
             if (beta != one) {
                 // Scale block rows of C below the bandwidth of A:
@@ -197,7 +191,7 @@ void gbmm(
                         alpha, A.sub(i_begin, i_end-1, k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(i_begin, i_end-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
 
                 #pragma omp task depend(in:gemm[k])

--- a/src/gbmm.cc
+++ b/src/gbmm.cc
@@ -42,8 +42,6 @@ void gbmm(
     const Layout layout = Layout::ColMajor;
 
     const scalar_t one = 1.0;
-    const int64_t priority_0 = 0;
-    const int64_t queue_0 = 0;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
@@ -126,7 +124,7 @@ void gbmm(
                     alpha, A.sub(i_begin, i_end-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  C.sub(i_begin, i_end-1, 0, C.nt()-1),
-                    layout, priority_0, queue_0, opts );
+                    layout );
 
             if (beta != one) {
                 // Scale block rows of C below the bandwidth of A:
@@ -191,7 +189,7 @@ void gbmm(
                         alpha, A.sub(i_begin, i_end-1, k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(i_begin, i_end-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
                 }
 
                 #pragma omp task depend(in:gemm[k])

--- a/src/gbtrf.cc
+++ b/src/gbtrf.cc
@@ -35,7 +35,6 @@ int64_t gbtrf(
     const int priority_0 = 0;
     const int priority_1 = 1;
     const int tag_0 = 0;
-    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -148,7 +147,7 @@ int64_t gbtrf(
                     internal::trsm<Target::HostTask>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_1, layout, queue_0, opts );
+                        priority_1, layout );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     A.tileBcast(k, j, A.sub(k+1, i_end-1, j, j), layout, tag_j);
@@ -158,7 +157,7 @@ int64_t gbtrf(
                         -one, A.sub(k+1, i_end-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, i_end-1, j, j),
-                        layout, priority_1, queue_0, opts );
+                        layout, priority_1 );
                 }
             }
             // Update trailing submatrix, normal priority.
@@ -184,7 +183,7 @@ int64_t gbtrf(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, j_end-1),
-                        priority_0, layout, queue_0, opts );
+                        priority_0, layout );
 
                     // send A(k, kl+1:j_end-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastList bcast_list_A;
@@ -199,7 +198,7 @@ int64_t gbtrf(
                         -one, A.sub(k+1, i_end-1, k, k),
                               A.sub(k, k, k+1+lookahead, j_end-1),
                         one,  A.sub(k+1, i_end-1, k+1+lookahead, j_end-1),
-                        layout, priority_0, queue_0, opts );
+                        layout, priority_0 );
                 }
             }
 

--- a/src/gbtrf.cc
+++ b/src/gbtrf.cc
@@ -48,12 +48,6 @@ int64_t gbtrf(
     max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads,
                                              max_panel_threads );
 
-    // Use only TileReleaseStrategy::Slate for gbtrf
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     int64_t info = 0;
     int64_t A_nt = A.nt();
     int64_t A_mt = A.mt();
@@ -154,7 +148,7 @@ int64_t gbtrf(
                     internal::trsm<Target::HostTask>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_1, layout, queue_0, opts2 );
+                        priority_1, layout, queue_0, opts );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     A.tileBcast(k, j, A.sub(k+1, i_end-1, j, j), layout, tag_j);
@@ -164,7 +158,7 @@ int64_t gbtrf(
                         -one, A.sub(k+1, i_end-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, i_end-1, j, j),
-                        layout, priority_1, queue_0, opts2 );
+                        layout, priority_1, queue_0, opts );
                 }
             }
             // Update trailing submatrix, normal priority.
@@ -190,7 +184,7 @@ int64_t gbtrf(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, j_end-1),
-                        priority_0, layout, queue_0, opts2 );
+                        priority_0, layout, queue_0, opts );
 
                     // send A(k, kl+1:j_end-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastList bcast_list_A;
@@ -205,7 +199,7 @@ int64_t gbtrf(
                         -one, A.sub(k+1, i_end-1, k, k),
                               A.sub(k, k, k+1+lookahead, j_end-1),
                         one,  A.sub(k+1, i_end-1, k+1+lookahead, j_end-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
             }
 

--- a/src/ge2tb.cc
+++ b/src/ge2tb.cc
@@ -36,7 +36,6 @@ void ge2tb(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const int queue_0 = 0;
-    const int priority_0 = 0;
 
     // Options
     int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
@@ -208,7 +207,7 @@ void ge2tb(
             // ttqrt handles tile transfers internally
             internal::ttqrt<Target::HostTask>(
                             std::move(U_panel),
-                            std::move(TUr_panel), opts );
+                            std::move(TUr_panel) );
 
             //--------------------
             // QR update trailing submatrix.
@@ -258,8 +257,7 @@ void ge2tb(
                                 std::move(U_panel),
                                 std::move(TUl_panel),
                                 std::move(A_trail_j),
-                                W.sub(k, A_mt-1, j, A_nt-1),
-                                priority_0, queue_0, opts );
+                                W.sub(k, A_mt-1, j, A_nt-1) );
 
                 // Apply triangle-triangle reduction reflectors
                 // ttmqr handles the tile broadcasting internally
@@ -268,7 +266,7 @@ void ge2tb(
                                 std::move(U_panel),
                                 std::move(TUr_panel),
                                 std::move(A_trail_j),
-                                j, opts );
+                                j );
             }
 
             // Can release tiles parallel to the main execution
@@ -359,8 +357,7 @@ void ge2tb(
                 // ttlqt handles tile transfers internally
                 internal::ttlqt<Target::HostTask>(
                                 std::move(V_panel),
-                                std::move(TVr_panel),
-                                opts );
+                                std::move(TVr_panel) );
 
                 //--------------------
                 // LQ update trailing submatrix
@@ -409,8 +406,7 @@ void ge2tb(
                                     std::move(V_panel),
                                     std::move(TVl_panel),
                                     std::move(A_trail_i),
-                                    W.sub(i, A_mt-1, k+1, A_nt-1),
-                                    priority_0, queue_0, opts );
+                                    W.sub(i, A_mt-1, k+1, A_nt-1) );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -419,7 +415,7 @@ void ge2tb(
                                     std::move(V_panel),
                                     std::move(TVr_panel),
                                     std::move(A_trail_i),
-                                    i, opts );
+                                    i );
                 }
 
                 // Can release tiles parallel to the main execution

--- a/src/ge2tb.cc
+++ b/src/ge2tb.cc
@@ -44,12 +44,6 @@ void ge2tb(
     max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads,
                                              max_panel_threads );
 
-    // Use only TileReleaseStrategy::Slate for gemm.
-    // Internal gemm routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     int64_t A_mt = A.mt();
     int64_t A_nt = A.nt();
     int64_t A_min_mtnt = std::min(A_mt, A_nt);
@@ -214,7 +208,7 @@ void ge2tb(
             // ttqrt handles tile transfers internally
             internal::ttqrt<Target::HostTask>(
                             std::move(U_panel),
-                            std::move(TUr_panel), opts2 );
+                            std::move(TUr_panel), opts );
 
             //--------------------
             // QR update trailing submatrix.
@@ -265,7 +259,7 @@ void ge2tb(
                                 std::move(TUl_panel),
                                 std::move(A_trail_j),
                                 W.sub(k, A_mt-1, j, A_nt-1),
-                                priority_0, queue_0, opts2 );
+                                priority_0, queue_0, opts );
 
                 // Apply triangle-triangle reduction reflectors
                 // ttmqr handles the tile broadcasting internally
@@ -274,7 +268,7 @@ void ge2tb(
                                 std::move(U_panel),
                                 std::move(TUr_panel),
                                 std::move(A_trail_j),
-                                j, opts2 );
+                                j, opts );
             }
 
             // Can release tiles parallel to the main execution
@@ -366,7 +360,7 @@ void ge2tb(
                 internal::ttlqt<Target::HostTask>(
                                 std::move(V_panel),
                                 std::move(TVr_panel),
-                                opts2 );
+                                opts );
 
                 //--------------------
                 // LQ update trailing submatrix
@@ -416,7 +410,7 @@ void ge2tb(
                                     std::move(TVl_panel),
                                     std::move(A_trail_i),
                                     W.sub(i, A_mt-1, k+1, A_nt-1),
-                                    priority_0, queue_0, opts2 );
+                                    priority_0, queue_0, opts );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -425,7 +419,7 @@ void ge2tb(
                                     std::move(V_panel),
                                     std::move(TVr_panel),
                                     std::move(A_trail_i),
-                                    i, opts2 );
+                                    i, opts );
                 }
 
                 // Can release tiles parallel to the main execution

--- a/src/gecondest.cc
+++ b/src/gecondest.cc
@@ -114,7 +114,7 @@ blas::real_type<scalar_t> gecondest(
 
     // initial and final value of kase is 0
     kase = 0;
-    internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
+    internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave );
 
     MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
     MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
@@ -137,7 +137,7 @@ blas::real_type<scalar_t> gecondest(
             slate::trsm( Side::Left, alpha, LH, X, opts );
         }
 
-        internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
+        internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave );
         MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
         MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
     } // while (kase != 0)

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -207,8 +207,7 @@ void gelqf(
                 // ttlqt handles tile transfers internally
                 internal::ttlqt<Target::HostTask>(
                                 std::move(A_panel),
-                                std::move(Tr_panel),
-                                opts );
+                                std::move(Tr_panel) );
 
                 // if a trailing matrix exists
                 if (k < A_mt-1) {
@@ -260,7 +259,7 @@ void gelqf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_i),
                                     W.sub(i, i, k, A_nt-1),
-                                    priority_1, queue_ik1, opts );
+                                    priority_1, queue_ik1 );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -270,7 +269,7 @@ void gelqf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_i),
-                                    tag_i, opts );
+                                    tag_i );
                 }
             }
 
@@ -291,7 +290,7 @@ void gelqf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_i),
                                     W.sub(i, A_mt-1, k, A_nt-1),
-                                    priority_0, queue_ik1, opts );
+                                    priority_0, queue_ik1 );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -301,7 +300,7 @@ void gelqf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_i),
-                                    tag_i, opts );
+                                    tag_i );
                 }
             }
 

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -32,12 +32,6 @@ void gelqf(
     using lapack::device_info_int;
     using blas::real;
 
-    // Use only TileReleaseStrategy::Slate for geqrf
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // Constants
     const int priority_0 = 0;
     const int priority_1 = 1;
@@ -214,7 +208,7 @@ void gelqf(
                 internal::ttlqt<Target::HostTask>(
                                 std::move(A_panel),
                                 std::move(Tr_panel),
-                                opts2);
+                                opts );
 
                 // if a trailing matrix exists
                 if (k < A_mt-1) {
@@ -266,7 +260,7 @@ void gelqf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_i),
                                     W.sub(i, i, k, A_nt-1),
-                                    priority_1, queue_ik1, opts2);
+                                    priority_1, queue_ik1, opts );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -276,7 +270,7 @@ void gelqf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_i),
-                                    tag_i, opts2);
+                                    tag_i, opts );
                 }
             }
 
@@ -297,7 +291,7 @@ void gelqf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_i),
                                     W.sub(i, A_mt-1, k, A_nt-1),
-                                    priority_0, queue_ik1, opts2 );
+                                    priority_0, queue_ik1, opts );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmlq handles the tile broadcasting internally
@@ -307,7 +301,7 @@ void gelqf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_i),
-                                    tag_i, opts2 );
+                                    tag_i, opts );
                 }
             }
 

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -53,9 +53,6 @@ void gemmA(
     SLATE_UNUSED( bcast ); // Used only by OpenMP
     SLATE_UNUSED( gemmA ); // Used only by OpenMP
 
-    const int priority_0 = 0;
-    const int queue_0 = 0;
-
     if (target == Target::Devices) {
         if (A.num_devices() > 1)
             slate_not_implemented( "gemmA doesn't support multiple GPUs" );
@@ -109,7 +106,7 @@ void gemmA(
                 alpha, std::move(A),
                        B.sub( 0, B.mt()-1, 0, 0 ),
                 beta,  C.sub( 0, C.mt()-1, 0, 0 ),
-                layout, priority_0, queue_0, opts );
+                layout );
 
             // reduce C(:, 0)
             using ReduceList = typename Matrix<scalar_t>::ReduceList;
@@ -171,7 +168,7 @@ void gemmA(
                     alpha, std::move(A),
                            B.sub( 0, B.mt()-1, k, k ),
                     beta,  C.sub( 0, C.mt()-1, k, k ),
-                    layout, priority_0, queue_0, opts );
+                    layout );
 
                 // reduce C(:, k)
                 using ReduceList = typename Matrix<scalar_t>::ReduceList;

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -44,14 +44,6 @@ void gemmA(
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
-    auto tileStrategy = get_option<TileReleaseStrategy>(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::Slate );
-
-    Options local_opts = opts;
-    local_opts[ Option::Lookahead ] = lookahead;
-
-    // XXX This should be removed later, based on Kadir's comment.
-    local_opts[ Option::TileReleaseStrategy ] = tileStrategy;
 
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector( A.nt() );
@@ -117,7 +109,7 @@ void gemmA(
                 alpha, std::move(A),
                        B.sub( 0, B.mt()-1, 0, 0 ),
                 beta,  C.sub( 0, C.mt()-1, 0, 0 ),
-                layout, priority_0, queue_0, local_opts );
+                layout, priority_0, queue_0, opts );
 
             // reduce C(:, 0)
             using ReduceList = typename Matrix<scalar_t>::ReduceList;
@@ -179,7 +171,7 @@ void gemmA(
                     alpha, std::move(A),
                            B.sub( 0, B.mt()-1, k, k ),
                     beta,  C.sub( 0, C.mt()-1, k, k ),
-                    layout, priority_0, queue_0, local_opts );
+                    layout, priority_0, queue_0, opts );
 
                 // reduce C(:, k)
                 using ReduceList = typename Matrix<scalar_t>::ReduceList;

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -38,8 +38,6 @@ void gemmC(
 
     // Constants
     const scalar_t one = 1.0;
-    const int priority_0 = 0;
-    const int queue_0 = 0;
     const Layout layout = Layout::ColMajor;
 
     // Options
@@ -120,7 +118,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  std::move(C),
-                    layout, priority_0, queue_0, opts );
+                    layout );
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
@@ -169,7 +167,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, k, k),
                            B.sub(k, k, 0, B.nt()-1),
                     one,   std::move( C ),
-                    layout, priority_0, queue_0, opts );
+                    layout );
             }
 
             #pragma omp task depend(in:gemm[k])

--- a/src/gemmC.cc
+++ b/src/gemmC.cc
@@ -45,12 +45,6 @@ void gemmC(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for gemm.
-    // Internal gemm routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector(A.nt());
     std::vector<uint8_t> gemm_vector(A.nt());
@@ -126,7 +120,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, 0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  std::move(C),
-                    layout, priority_0, queue_0, opts2 );
+                    layout, priority_0, queue_0, opts );
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
             auto B_rowblock = B.sub(0, 0, 0, B.nt()-1);
@@ -175,7 +169,7 @@ void gemmC(
                     alpha, A.sub(0, A.mt()-1, k, k),
                            B.sub(k, k, 0, B.nt()-1),
                     one,   std::move( C ),
-                    layout, priority_0, queue_0, opts2 );
+                    layout, priority_0, queue_0, opts );
             }
 
             #pragma omp task depend(in:gemm[k])

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -160,8 +160,7 @@ void geqrf(
                 // ttqrt handles tile transfers internally
                 internal::ttqrt<Target::HostTask>(
                                 std::move(A_panel),
-                                std::move(Tr_panel),
-                                opts );
+                                std::move(Tr_panel) );
 
                 // if a trailing matrix exists
                 if (k < A_nt-1) {
@@ -213,7 +212,7 @@ void geqrf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_j),
                                     W.sub(k, A_mt-1, j, j),
-                                    priority_1, queue_jk1, opts );
+                                    priority_1, queue_jk1 );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmqr handles the tile broadcasting internally
@@ -223,7 +222,7 @@ void geqrf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_j),
-                                    tag_j, opts );
+                                    tag_j );
                 }
             }
 
@@ -244,7 +243,7 @@ void geqrf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_j),
                                     W.sub(k, A_mt-1, j, A_nt-1),
-                                    priority_0, queue_jk1, opts );
+                                    priority_0, queue_jk1 );
 
                     // Apply triangle-triangle reduction reflectors.
                     // ttmqr handles the tile broadcasting internally.
@@ -254,7 +253,7 @@ void geqrf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_j),
-                                    tag_j, opts );
+                                    tag_j );
                 }
             }
 

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -32,13 +32,6 @@ void geqrf(
     using lapack::device_info_int;
     using blas::real;
 
-    // Use only TileReleaseStrategy::Slate for geqrf
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
-
     // Constants
     const int priority_0 = 0;
     const int priority_1 = 1;
@@ -168,7 +161,7 @@ void geqrf(
                 internal::ttqrt<Target::HostTask>(
                                 std::move(A_panel),
                                 std::move(Tr_panel),
-                                opts2);
+                                opts );
 
                 // if a trailing matrix exists
                 if (k < A_nt-1) {
@@ -220,7 +213,7 @@ void geqrf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_j),
                                     W.sub(k, A_mt-1, j, j),
-                                    priority_1, queue_jk1, opts2);
+                                    priority_1, queue_jk1, opts );
 
                     // Apply triangle-triangle reduction reflectors
                     // ttmqr handles the tile broadcasting internally
@@ -230,7 +223,7 @@ void geqrf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_j),
-                                    tag_j, opts2);
+                                    tag_j, opts );
                 }
             }
 
@@ -251,7 +244,7 @@ void geqrf(
                                     std::move(Tl_panel),
                                     std::move(A_trail_j),
                                     W.sub(k, A_mt-1, j, A_nt-1),
-                                    priority_0, queue_jk1, opts2 );
+                                    priority_0, queue_jk1, opts );
 
                     // Apply triangle-triangle reduction reflectors.
                     // ttmqr handles the tile broadcasting internally.
@@ -261,7 +254,7 @@ void geqrf(
                                     std::move(A_panel),
                                     std::move(Tr_panel),
                                     std::move(A_trail_j),
-                                    tag_j, opts2 );
+                                    tag_j, opts );
                 }
             }
 

--- a/src/gerbt.cc
+++ b/src/gerbt.cc
@@ -206,7 +206,6 @@ void gerbt(Matrix<scalar_t>& U_in,
             });
 
         #pragma omp taskwait
-        // Manage U and V life here
         U.releaseRemoteWorkspace();
         U.releaseLocalWorkspace();
         V.releaseRemoteWorkspace();
@@ -315,7 +314,6 @@ void gerbt(Matrix<scalar_t>& Uin,
                 });
 
         #pragma omp taskwait
-        // Manage U life here
         U.releaseRemoteWorkspace();
         U.releaseLocalWorkspace();
 

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -139,7 +139,7 @@ int64_t getrf(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_1, Layout::ColMajor, queue_jk1, opts );
+                        priority_1, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -150,7 +150,7 @@ int64_t getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        target_layout, priority_1, queue_jk1, opts );
+                        target_layout, priority_1, queue_jk1 );
                 }
             }
             // pivot to the left
@@ -196,7 +196,7 @@ int64_t getrf(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, A_nt-1),
-                        priority_0, Layout::ColMajor, queue_1, opts );
+                        priority_0, Layout::ColMajor, queue_1 );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastList bcast_list_A;
@@ -213,7 +213,7 @@ int64_t getrf(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, k+1+lookahead, A_nt-1),
                         one,  A.sub(k+1, A_mt-1, k+1+lookahead, A_nt-1),
-                        target_layout, priority_0, queue_1, opts );
+                        target_layout, priority_0, queue_1 );
                 }
             }
             #pragma omp task depend(inout:column[k])

--- a/src/getrf_nopiv.cc
+++ b/src/getrf_nopiv.cc
@@ -107,7 +107,7 @@ int64_t getrf_nopiv(
                 internal::trsm<target>(
                     Side::Right,
                     one, std::move( Tkk ), A.sub(k+1, A_mt-1, k, k),
-                    priority_1, layout, queue_0, opts );
+                    priority_1, layout, queue_0 );
 
 
                 BcastListTag bcast_list;
@@ -136,7 +136,7 @@ int64_t getrf_nopiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_1, layout, queue_jk1, opts );
+                        priority_1, layout, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     A.tileBcast(k, j, A.sub(k+1, A_mt-1, j, j), layout, tag_j);
@@ -152,7 +152,7 @@ int64_t getrf_nopiv(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        layout, priority_1, queue_jk1, opts );
+                        layout, priority_1, queue_jk1 );
                 }
             }
             // update trailing submatrix, normal priority
@@ -171,7 +171,7 @@ int64_t getrf_nopiv(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, A_nt-1),
-                        priority_0, layout, queue_1, opts );
+                        priority_0, layout, queue_1 );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastListTag bcast_list;
@@ -195,7 +195,7 @@ int64_t getrf_nopiv(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, k+1+lookahead, A_nt-1),
                         one,  A.sub(k+1, A_mt-1, k+1+lookahead, A_nt-1),
-                        layout, priority_0, queue_1, opts );
+                        layout, priority_0, queue_1 );
                 }
             }
             #pragma omp task depend(inout:column[k])

--- a/src/getrf_nopiv.cc
+++ b/src/getrf_nopiv.cc
@@ -40,12 +40,6 @@ int64_t getrf_nopiv(
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
     int64_t ib = get_option<int64_t>( opts, Option::InnerBlocking, 16 );
 
-    // Use only TileReleaseStrategy::Slate for getrf_nopiv.
-    // Internal routines won't release any tiles.
-    // getrf_nopiv will clean up tiles.
-    Options opts2 = Options( opts );
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     if (target == Target::Devices) {
         // two batch arrays plus one for each lookahead
         // batch array size will be set as needed
@@ -113,7 +107,7 @@ int64_t getrf_nopiv(
                 internal::trsm<target>(
                     Side::Right,
                     one, std::move( Tkk ), A.sub(k+1, A_mt-1, k, k),
-                    priority_1, layout, queue_0, opts2 );
+                    priority_1, layout, queue_0, opts );
 
 
                 BcastListTag bcast_list;
@@ -142,7 +136,7 @@ int64_t getrf_nopiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub(k, k, j, j),
-                        priority_1, layout, queue_jk1, opts2 );
+                        priority_1, layout, queue_jk1, opts );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     A.tileBcast(k, j, A.sub(k+1, A_mt-1, j, j), layout, tag_j);
@@ -158,7 +152,7 @@ int64_t getrf_nopiv(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, j, j),
                         one,  A.sub(k+1, A_mt-1, j, j),
-                        layout, priority_1, queue_jk1, opts2 );
+                        layout, priority_1, queue_jk1, opts );
                 }
             }
             // update trailing submatrix, normal priority
@@ -177,7 +171,7 @@ int64_t getrf_nopiv(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub(k, k, k+1+lookahead, A_nt-1),
-                        priority_0, layout, queue_1, opts2 );
+                        priority_0, layout, queue_1, opts );
 
                     // send A(k, kl+1:A_nt-1) across A(k+1:mt-1, kl+1:nt-1)
                     BcastListTag bcast_list;
@@ -201,7 +195,7 @@ int64_t getrf_nopiv(
                         -one, A.sub(k+1, A_mt-1, k, k),
                               A.sub(k, k, k+1+lookahead, A_nt-1),
                         one,  A.sub(k+1, A_mt-1, k+1+lookahead, A_nt-1),
-                        layout, priority_0, queue_1, opts2 );
+                        layout, priority_0, queue_1, opts );
                 }
             }
             #pragma omp task depend(inout:column[k])

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -45,12 +45,6 @@ int64_t getrf_tntpiv(
     max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads,
                                              max_panel_threads );
 
-    // Use only TileReleaseStrategy::Slate for getrf_tntpiv.
-    // Internal routines won't release any tiles.
-    // getrf_tntpiv will clean up tiles.
-    Options opts2 = Options( opts );
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // Host can use Col/RowMajor for row swapping,
     // RowMajor is slightly more efficient.
     // Layout host_layout = Layout::RowMajor;
@@ -229,7 +223,7 @@ int64_t getrf_tntpiv(
                     Side::Right,
                     one, std::move(Tkk),
                          A.sub( k+1, A_mt-1, k, k ),
-                    priority_1, Layout::ColMajor, queue_0, opts2 );
+                    priority_1, Layout::ColMajor, queue_0, opts );
             }
 
             #pragma omp task depend(inout:column[k]) \
@@ -268,7 +262,7 @@ int64_t getrf_tntpiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub( k, k, j, j ),
-                        priority_1, Layout::ColMajor, queue_jk1, opts2 );
+                        priority_1, Layout::ColMajor, queue_jk1, opts );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -287,7 +281,7 @@ int64_t getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, j, j ),
                         one,  A.sub( k+1, A_mt-1, j, j ),
-                        host_layout, priority_1, queue_jk1, opts2 );
+                        host_layout, priority_1, queue_jk1, opts );
                 }
             }
 
@@ -312,7 +306,7 @@ int64_t getrf_tntpiv(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub( k, k, k+1+lookahead, A_nt-1 ),
-                        priority_0, Layout::ColMajor, queue_1, opts2 );
+                        priority_0, Layout::ColMajor, queue_1, opts );
                 }
 
                 #pragma omp task depend(inout:column[k+1+lookahead]) \
@@ -341,7 +335,7 @@ int64_t getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, k+1+lookahead, A_nt-1 ),
                         one,  A.sub( k+1, A_mt-1, k+1+lookahead, A_nt-1 ),
-                        host_layout, priority_0, queue_1, opts2 );
+                        host_layout, priority_0, queue_1, opts );
                 }
             }
             // pivot to the left

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -223,7 +223,7 @@ int64_t getrf_tntpiv(
                     Side::Right,
                     one, std::move(Tkk),
                          A.sub( k+1, A_mt-1, k, k ),
-                    priority_1, Layout::ColMajor, queue_0, opts );
+                    priority_1, Layout::ColMajor, queue_0 );
             }
 
             #pragma omp task depend(inout:column[k]) \
@@ -262,7 +262,7 @@ int64_t getrf_tntpiv(
                     internal::trsm<target>(
                         Side::Left,
                         one, std::move( Tkk ), A.sub( k, k, j, j ),
-                        priority_1, Layout::ColMajor, queue_jk1, opts );
+                        priority_1, Layout::ColMajor, queue_jk1 );
 
                     // send A(k, j) across column A(k+1:mt-1, j)
                     // todo: trsm still operates in ColMajor
@@ -281,7 +281,7 @@ int64_t getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, j, j ),
                         one,  A.sub( k+1, A_mt-1, j, j ),
-                        host_layout, priority_1, queue_jk1, opts );
+                        host_layout, priority_1, queue_jk1 );
                 }
             }
 
@@ -306,7 +306,7 @@ int64_t getrf_tntpiv(
                         Side::Left,
                         one, std::move( Tkk ),
                              A.sub( k, k, k+1+lookahead, A_nt-1 ),
-                        priority_0, Layout::ColMajor, queue_1, opts );
+                        priority_0, Layout::ColMajor, queue_1 );
                 }
 
                 #pragma omp task depend(inout:column[k+1+lookahead]) \
@@ -335,7 +335,7 @@ int64_t getrf_tntpiv(
                         -one, A.sub( k+1, A_mt-1, k, k ),
                               A.sub( k, k, k+1+lookahead, A_nt-1 ),
                         one,  A.sub( k+1, A_mt-1, k+1+lookahead, A_nt-1 ),
-                        host_layout, priority_0, queue_1, opts );
+                        host_layout, priority_0, queue_1 );
                 }
             }
             // pivot to the left

--- a/src/getri.cc
+++ b/src/getri.cc
@@ -43,12 +43,6 @@ void getri(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
-    // Use only TileReleaseStrategy::Slate for getri
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // auto U = TriangularMatrix<scalar_t>(Uplo::Upper, Diag::NonUnit, A);
     auto L = TriangularMatrix<scalar_t>(Uplo::Lower, Diag::Unit, A);
 
@@ -79,7 +73,7 @@ void getri(
             internal::trsm<Target::HostTask>(
                 Side::Right,
                 one, std::move( Wkk ), A.sub(0, A.nt()-1, k, k),
-                priority_0, layout, queue_0, opts2);
+                priority_0, layout, queue_0, opts );
 
             // W is deleted here, releasing its tiles
         }
@@ -120,7 +114,7 @@ void getri(
                 -one, A.sub(0, A.nt()-1, k+1, A.nt()-1),
                       W.sub(1, W.mt()-1, 0, 0),
                 one,  A.sub(0, A.nt()-1, k, k),
-                layout, priority_0, queue_0, opts2 );
+                layout, priority_0, queue_0, opts );
 
             // reduce A(0:nt-1, k)
             ReduceList reduce_list_A;
@@ -144,7 +138,7 @@ void getri(
             internal::trsm<Target::HostTask>(
                 Side::Right,
                 one, std::move( Tkk ), A.sub(0, A.nt()-1, k, k),
-                priority_0, layout, queue_0, opts2);
+                priority_0, layout, queue_0, opts );
 
             // W is deleted here, releasing its tiles
         }

--- a/src/getri.cc
+++ b/src/getri.cc
@@ -38,7 +38,6 @@ void getri(
     const scalar_t zero = 0.0;
     const scalar_t one  = 1.0;
     const int priority_0 = 0;
-    const int queue_0 = 0;
 
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -73,7 +72,7 @@ void getri(
             internal::trsm<Target::HostTask>(
                 Side::Right,
                 one, std::move( Wkk ), A.sub(0, A.nt()-1, k, k),
-                priority_0, layout, queue_0, opts );
+                priority_0, layout );
 
             // W is deleted here, releasing its tiles
         }
@@ -114,7 +113,7 @@ void getri(
                 -one, A.sub(0, A.nt()-1, k+1, A.nt()-1),
                       W.sub(1, W.mt()-1, 0, 0),
                 one,  A.sub(0, A.nt()-1, k, k),
-                layout, priority_0, queue_0, opts );
+                layout );
 
             // reduce A(0:nt-1, k)
             ReduceList reduce_list_A;
@@ -138,7 +137,7 @@ void getri(
             internal::trsm<Target::HostTask>(
                 Side::Right,
                 one, std::move( Tkk ), A.sub(0, A.nt()-1, k, k),
-                priority_0, layout, queue_0, opts );
+                priority_0, layout );
 
             // W is deleted here, releasing its tiles
         }

--- a/src/hbmm.cc
+++ b/src/hbmm.cc
@@ -54,12 +54,6 @@ void hbmm(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for hbmm.
-    // Internal hbmm routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
@@ -162,7 +156,7 @@ void hbmm(
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts2 );
+                    priority_0, opts );
 
                 int64_t i_end = min(0 + kdt + 1, A.mt());
 
@@ -171,7 +165,7 @@ void hbmm(
                         alpha, A.sub(1, i_end-1, 0, 0),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, i_end-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
 
                 if (beta != one) {
@@ -262,14 +256,14 @@ void hbmm(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(i_begin, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
 
                     internal::hemm<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts2 );
+                        priority_0, opts );
 
                     if (i_end-1 > k) {
                         auto Acol_k = A.sub( k+1, i_end-1, k, k );
@@ -277,7 +271,7 @@ void hbmm(
                             alpha, std::move( Acol_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, i_end-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
 
@@ -359,7 +353,7 @@ void hbmm(
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts2 );
+                    priority_0, opts );
 
                 int64_t i_end = min(0 + kdt + 1, A.mt());
 
@@ -369,7 +363,7 @@ void hbmm(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, i_end-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
 
                 if (beta != one) {
@@ -456,14 +450,14 @@ void hbmm(
                         alpha, std::move( Acol_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(i_begin, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
 
                     internal::hemm<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts2 );
+                        priority_0, opts );
 
                     if (i_end-1 > k) {
                         auto Arow_k = A.sub(k, k, k+1, i_end-1);
@@ -471,7 +465,7 @@ void hbmm(
                             alpha, conj_transpose( Arow_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, i_end-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
 

--- a/src/hbmm.cc
+++ b/src/hbmm.cc
@@ -45,8 +45,6 @@ void hbmm(
     using blas::min;
     using BcastList = typename Matrix<scalar_t>::BcastList;
     const scalar_t one = 1.0;
-    const int64_t priority_0 = 0;
-    const int64_t queue_0 = 0;
 
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -155,8 +153,7 @@ void hbmm(
                     Side::Left,
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
-                    beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts );
+                    beta,  C.sub(0, 0, 0, C.nt()-1) );
 
                 int64_t i_end = min(0 + kdt + 1, A.mt());
 
@@ -165,7 +162,7 @@ void hbmm(
                         alpha, A.sub(1, i_end-1, 0, 0),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, i_end-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
                 }
 
                 if (beta != one) {
@@ -256,14 +253,13 @@ void hbmm(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(i_begin, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     internal::hemm<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
-                        one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts );
+                        one,   C.sub(k, k, 0, C.nt()-1) );
 
                     if (i_end-1 > k) {
                         auto Acol_k = A.sub( k+1, i_end-1, k, k );
@@ -271,7 +267,7 @@ void hbmm(
                             alpha, std::move( Acol_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, i_end-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts );
+                            layout );
                     }
                 }
 
@@ -352,8 +348,7 @@ void hbmm(
                     Side::Left,
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
-                    beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts );
+                    beta,  C.sub(0, 0, 0, C.nt()-1) );
 
                 int64_t i_end = min(0 + kdt + 1, A.mt());
 
@@ -363,7 +358,7 @@ void hbmm(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, i_end-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
                 }
 
                 if (beta != one) {
@@ -450,14 +445,13 @@ void hbmm(
                         alpha, std::move( Acol_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(i_begin, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     internal::hemm<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
-                        one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts );
+                        one,   C.sub(k, k, 0, C.nt()-1) );
 
                     if (i_end-1 > k) {
                         auto Arow_k = A.sub(k, k, k+1, i_end-1);
@@ -465,7 +459,7 @@ void hbmm(
                             alpha, conj_transpose( Arow_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, i_end-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts );
+                            layout );
                     }
                 }
 

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -56,12 +56,6 @@ void he2hb(
     max_panel_threads = get_option<int64_t>( opts, Option::MaxPanelThreads,
                                              max_panel_threads );
 
-    // Use only TileReleaseStrategy::Slate for gemm.
-    // Internal gemm routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     int64_t nt = A.nt();
     int mpi_rank = A.mpiRank();
 
@@ -200,7 +194,7 @@ void he2hb(
                 depend( inout:block[ k ] ) \
                 shared( dwork_array ) \
                 firstprivate(  A_panel, Tlocal_panel, Treduce_panel, ib, \
-                               max_panel_threads, work_size, priority_1, opts2 )
+                               max_panel_threads, work_size, priority_1, opts )
             {
                 internal::geqrf<target>(
                     std::move( A_panel ),
@@ -213,7 +207,7 @@ void he2hb(
                 internal::ttqrt<Target::HostTask>(
                     std::move( A_panel ),
                     std::move( Treduce_panel ),
-                    opts2 );
+                    opts );
             }
 
             // if trailing matrix exists.
@@ -400,7 +394,7 @@ void he2hb(
                         firstprivate( zero, half, one, r_one, i0, k, nt, \
                                       panel_rank, panel_rank_rows, \
                                       panel_rank_rows_sub, mpi_rank, \
-                                      layout, layoutc, priority_0, queue_0, opts2 )
+                                      layout, layoutc, priority_0, queue_0, opts )
                     {
                         // Compute W = A V T.
                         // 1a. Wi_part = sum_j Aij Vj, local partial sum,
@@ -410,7 +404,7 @@ void he2hb(
                             A.sub( k+1, nt-1, k, k ),
                             W.sub( k+1, nt-1, k, k ),
                             panel_rank_rows_sub,
-                            priority_0, queue_0, opts2 );
+                            priority_0, queue_0, opts );
 
                         // 1b. Wi = Wi_part1 + Wi_part2.
                         // At most 2 ranks contribute to each Wi; if I am one,
@@ -466,7 +460,7 @@ void he2hb(
                             A.sub( k+1, nt-1 ), // Needed to get the rank
                             Tlocal.sub( i0, i0, k, k ),
                             W.sub( k+1, nt-1, k, k ),
-                            panel_rank_rows_sub, priority_0, queue_0, opts2 );
+                            panel_rank_rows_sub, priority_0, queue_0, opts );
 
                         if (A.tileIsLocal( i0, i0 )) {
                             //--------------------
@@ -486,7 +480,7 @@ void he2hb(
                                 one,  conj_transpose( A.sub( k+1, nt-1, k, k ) ),
                                       W.sub( k+1, nt-1, k, k ),
                                 zero, std::move( TVAVT ),
-                                panel_rank, priority_0, queue_0, opts2 );
+                                panel_rank, priority_0, queue_0, opts );
 
                             // 1e. TVAVT = T^H (V^H A V T).
                             auto T0     = Tlocal.sub( i0, i0, k, k );
@@ -516,7 +510,7 @@ void he2hb(
                                 -half, A.sub( k+1, nt-1, k, k ),
                                        std::move( TVAVT ),
                                 one,   W.sub( k+1, nt-1, k, k ),
-                                panel_rank, priority_0, queue_0, opts2 );
+                                panel_rank, priority_0, queue_0, opts );
 
                             // 2. Update trailing matrix.
                             // A = A - V Y^H - Y V^H, with Y in W.
@@ -524,7 +518,7 @@ void he2hb(
                                 -one,  A.sub( k+1, nt-1, k, k ),
                                        W.sub( k+1, nt-1, k, k ),
                                 r_one, A.sub( k+1, nt-1 ),
-                                priority_0, queue_0, layout, opts2 );
+                                priority_0, queue_0, layout, opts );
                         }
                         else { // off-diag
                             //--------------------
@@ -546,7 +540,7 @@ void he2hb(
                                 -one, A.sub( k+1, nt-1, k, k ),
                                       W.sub( k+1, nt-1, k, k ),
                                 one,  A.sub( k+1, nt-1 ),
-                                panel_rank_rows_sub, priority_0, queue_0, opts2 );
+                                panel_rank_rows_sub, priority_0, queue_0, opts );
                         }
                     }
 
@@ -572,7 +566,7 @@ void he2hb(
                     depend( inout:block[ nt-1 ] ) \
                     depend( inout:fetch_trailing[ 0 ] ) \
                     shared( A ) \
-                    firstprivate( A_panel, Treduce_panel, k, nt, opts2 )
+                    firstprivate( A_panel, Treduce_panel, k, nt, opts )
                 {
                     int tag_base = A.mt()*A.mt();
                     // Do 2-sided Hermitian update:
@@ -582,7 +576,7 @@ void he2hb(
                         std::move( A_panel ),
                         std::move( Treduce_panel ),
                         A.sub( k+1, nt-1 ),
-                        tag_base, opts2 );
+                        tag_base, opts );
                 }
             }
 

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -194,7 +194,7 @@ void he2hb(
                 depend( inout:block[ k ] ) \
                 shared( dwork_array ) \
                 firstprivate(  A_panel, Tlocal_panel, Treduce_panel, ib, \
-                               max_panel_threads, work_size, priority_1, opts )
+                               max_panel_threads, work_size, priority_1 )
             {
                 internal::geqrf<target>(
                     std::move( A_panel ),
@@ -206,8 +206,7 @@ void he2hb(
                 // ttqrt handles tile transfers internally
                 internal::ttqrt<Target::HostTask>(
                     std::move( A_panel ),
-                    std::move( Treduce_panel ),
-                    opts );
+                    std::move( Treduce_panel ) );
             }
 
             // if trailing matrix exists.
@@ -394,7 +393,7 @@ void he2hb(
                         firstprivate( zero, half, one, r_one, i0, k, nt, \
                                       panel_rank, panel_rank_rows, \
                                       panel_rank_rows_sub, mpi_rank, \
-                                      layout, layoutc, priority_0, queue_0, opts )
+                                      layout, layoutc, priority_0, queue_0 )
                     {
                         // Compute W = A V T.
                         // 1a. Wi_part = sum_j Aij Vj, local partial sum,
@@ -403,8 +402,7 @@ void he2hb(
                             A.sub( k+1, nt-1 ),
                             A.sub( k+1, nt-1, k, k ),
                             W.sub( k+1, nt-1, k, k ),
-                            panel_rank_rows_sub,
-                            priority_0, queue_0, opts );
+                            panel_rank_rows_sub );
 
                         // 1b. Wi = Wi_part1 + Wi_part2.
                         // At most 2 ranks contribute to each Wi; if I am one,
@@ -460,7 +458,7 @@ void he2hb(
                             A.sub( k+1, nt-1 ), // Needed to get the rank
                             Tlocal.sub( i0, i0, k, k ),
                             W.sub( k+1, nt-1, k, k ),
-                            panel_rank_rows_sub, priority_0, queue_0, opts );
+                            panel_rank_rows_sub );
 
                         if (A.tileIsLocal( i0, i0 )) {
                             //--------------------
@@ -480,7 +478,7 @@ void he2hb(
                                 one,  conj_transpose( A.sub( k+1, nt-1, k, k ) ),
                                       W.sub( k+1, nt-1, k, k ),
                                 zero, std::move( TVAVT ),
-                                panel_rank, priority_0, queue_0, opts );
+                                panel_rank );
 
                             // 1e. TVAVT = T^H (V^H A V T).
                             auto T0     = Tlocal.sub( i0, i0, k, k );
@@ -510,7 +508,7 @@ void he2hb(
                                 -half, A.sub( k+1, nt-1, k, k ),
                                        std::move( TVAVT ),
                                 one,   W.sub( k+1, nt-1, k, k ),
-                                panel_rank, priority_0, queue_0, opts );
+                                panel_rank );
 
                             // 2. Update trailing matrix.
                             // A = A - V Y^H - Y V^H, with Y in W.
@@ -518,7 +516,7 @@ void he2hb(
                                 -one,  A.sub( k+1, nt-1, k, k ),
                                        W.sub( k+1, nt-1, k, k ),
                                 r_one, A.sub( k+1, nt-1 ),
-                                priority_0, queue_0, layout, opts );
+                                priority_0, queue_0, layout );
                         }
                         else { // off-diag
                             //--------------------
@@ -540,7 +538,7 @@ void he2hb(
                                 -one, A.sub( k+1, nt-1, k, k ),
                                       W.sub( k+1, nt-1, k, k ),
                                 one,  A.sub( k+1, nt-1 ),
-                                panel_rank_rows_sub, priority_0, queue_0, opts );
+                                panel_rank_rows_sub );
                         }
                     }
 
@@ -566,7 +564,7 @@ void he2hb(
                     depend( inout:block[ nt-1 ] ) \
                     depend( inout:fetch_trailing[ 0 ] ) \
                     shared( A ) \
-                    firstprivate( A_panel, Treduce_panel, k, nt, opts )
+                    firstprivate( A_panel, Treduce_panel, k, nt )
                 {
                     int tag_base = A.mt()*A.mt();
                     // Do 2-sided Hermitian update:
@@ -576,7 +574,7 @@ void he2hb(
                         std::move( A_panel ),
                         std::move( Treduce_panel ),
                         A.sub( k+1, nt-1 ),
-                        tag_base, opts );
+                        tag_base );
                 }
             }
 

--- a/src/hegst.cc
+++ b/src/hegst.cc
@@ -93,7 +93,7 @@ void hegst(
                         internal::trsm<target>(
                             Side::Right,  one,  conj_transpose( TBkk ),
                                                 std::move(Asub),
-                            priority_0, layout, queue_0, opts );
+                            priority_0, layout );
                     }
 
                     #pragma omp task depend(inout:column[k])
@@ -115,8 +115,7 @@ void hegst(
                         internal::hemm<Target::HostTask>(
                             Side::Right, -half, std::move(Akk),
                                                 std::move(Bsub),
-                                          one,  std::move(Asub),
-                            priority_0, opts );
+                                          one,  std::move(Asub) );
 
                         BcastList bcast_list;
                         for (int64_t i = k+1; i < nt; ++i) {
@@ -129,14 +128,13 @@ void hegst(
                             -one,  std::move( Asub ),
                                    std::move( Bsub ),
                             r_one, A.sub(k+1, nt-1),
-                            priority_0, queue_0, layout, opts );
+                            priority_0, queue_0, layout );
 
                         internal::hemm<Target::HostTask>(
                             Side::Right,
                             -half, std::move( Akk  ),
                                    std::move( Bsub ),
-                            one,   std::move( Asub ),
-                            priority_0, opts );
+                            one,   std::move( Asub ) );
 
                         auto Bk1  = B.sub(k+1, nt-1);
                         auto TBk1 = TriangularMatrix<scalar_t>(Diag::NonUnit, Bk1);
@@ -176,8 +174,7 @@ void hegst(
                         internal::hemm<Target::HostTask>(
                             Side::Left,  half, std::move(Akk),
                                                std::move(Bsub),
-                                         one,  std::move(Asub),
-                            priority_0, opts );
+                                         one,  std::move(Asub) );
 
                         BcastList bcast_list;
                         for (int64_t i = 0; i < k; ++i) {
@@ -190,18 +187,16 @@ void hegst(
                             one,   conj_transpose( Asub ),
                                    conj_transpose( Bsub ),
                             r_one, A.sub(0, k-1),
-                            priority_0, queue_0, layout, opts );
+                            priority_0, queue_0, layout );
 
                         internal::hemm<Target::HostTask>(
                             Side::Left, half, std::move(Akk),
                                               std::move(Bsub),
-                                        one,  std::move(Asub),
-                            priority_0, opts );
+                                        one,  std::move(Asub) );
 
                         internal::trmm<Target::HostTask>(
                             Side::Left, one,  conj_transpose( TBkk ),
-                                              std::move(Asub),
-                            priority_0, queue_0, opts );
+                                              std::move(Asub) );
                     }
                 }
 

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -46,12 +46,6 @@ void hemmA(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for hemmA.
-    // Internal routines (hemmA and gemmA) called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if on right, change to left by transposing A, B, C to get
     // op(C) = op(A)*op(B)
     if (side == Side::Right) {
@@ -199,14 +193,14 @@ void hemmA(
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts2 );
+                    priority_0, opts );
 
                 if (A.mt()-1 > 0) {
                     internal::gemmA<target>(
                         alpha,  A.sub(1, A.mt()-1, 0, 0),
                                 B.sub(0, 0, 0, B.nt()-1),
                         beta,   C.sub(1, C.mt()-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
             }
 
@@ -285,21 +279,21 @@ void hemmA(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(0, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
 
                     internal::hemmA<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts2 );
+                        priority_0, opts );
 
                     if (A.mt()-1 > k) {
                         internal::gemmA<target>(
                             alpha, A.sub(k+1, A.mt()-1, k, k),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
 
@@ -449,7 +443,7 @@ void hemmA(
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
                     beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts2 );
+                    priority_0, opts );
 
                 if (A.mt()-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, A.nt()-1);
@@ -457,7 +451,7 @@ void hemmA(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, C.mt()-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
             }
 
@@ -534,14 +528,14 @@ void hemmA(
                         alpha, A.sub(0, k-1, k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(0, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
 
                     internal::hemmA<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts2 );
+                        priority_0, opts );
 
                     if (A.nt()-1 > k) {
                         auto Arow_k = A.sub(k, k, k+1, A.nt()-1);
@@ -549,7 +543,7 @@ void hemmA(
                             alpha, conj_transpose( Arow_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
 

--- a/src/hemmA.cc
+++ b/src/hemmA.cc
@@ -37,8 +37,6 @@ void hemmA(
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
     const scalar_t one = 1.0;
-    const int priority_0 = 0;
-    const int queue_0 = 0;
 
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -192,15 +190,14 @@ void hemmA(
                     Side::Left,
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
-                    beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts );
+                    beta,  C.sub(0, 0, 0, C.nt()-1) );
 
                 if (A.mt()-1 > 0) {
                     internal::gemmA<target>(
                         alpha,  A.sub(1, A.mt()-1, 0, 0),
                                 B.sub(0, 0, 0, B.nt()-1),
                         beta,   C.sub(1, C.mt()-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
                 }
             }
 
@@ -279,21 +276,20 @@ void hemmA(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(0, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     internal::hemmA<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
-                        one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts );
+                        one,   C.sub(k, k, 0, C.nt()-1) );
 
                     if (A.mt()-1 > k) {
                         internal::gemmA<target>(
                             alpha, A.sub(k+1, A.mt()-1, k, k),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts );
+                            layout );
                     }
                 }
 
@@ -442,8 +438,7 @@ void hemmA(
                     Side::Left,
                     alpha, A.sub(0, 0),
                            B.sub(0, 0, 0, B.nt()-1),
-                    beta,  C.sub(0, 0, 0, C.nt()-1),
-                    priority_0, opts );
+                    beta,  C.sub(0, 0, 0, C.nt()-1) );
 
                 if (A.mt()-1 > 0) {
                     auto Arow_k = A.sub(0, 0, 1, A.nt()-1);
@@ -451,7 +446,7 @@ void hemmA(
                         alpha, conj_transpose( Arow_k ),
                                B.sub(0, 0, 0, B.nt()-1),
                         beta,  C.sub(1, C.mt()-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
                 }
             }
 
@@ -528,14 +523,13 @@ void hemmA(
                         alpha, A.sub(0, k-1, k, k),
                                B.sub(k, k, 0, B.nt()-1),
                         one,   C.sub(0, k-1, 0, C.nt()-1),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     internal::hemmA<Target::HostTask>(
                         Side::Left,
                         alpha, A.sub(k, k),
                                B.sub(k, k, 0, B.nt()-1),
-                        one,   C.sub(k, k, 0, C.nt()-1),
-                        priority_0, opts );
+                        one,   C.sub(k, k, 0, C.nt()-1) );
 
                     if (A.nt()-1 > k) {
                         auto Arow_k = A.sub(k, k, k+1, A.nt()-1);
@@ -543,7 +537,7 @@ void hemmA(
                             alpha, conj_transpose( Arow_k ),
                                    B.sub(k, k, 0, B.nt()-1),
                             one,   C.sub(k+1, C.mt()-1, 0, C.nt()-1),
-                            layout, priority_0, queue_0, opts );
+                            layout );
                     }
                 }
 

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -47,8 +47,6 @@ void hemmC(
 
     // Constants
     const scalar_t one = 1.0;
-    const int priority_0 = 0;
-    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -150,8 +148,7 @@ void hemmC(
                     Side::Left,
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
-                    beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts );
+                    beta,  C.sub( 0, 0, 0, C.nt()-1 ) );
 
                 // Erase local & remote tile on all devices including host.
                 A.releaseRemoteWorkspaceTile( 0, 0 );
@@ -163,7 +160,7 @@ void hemmC(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     // Don't release local Acol_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -236,7 +233,7 @@ void hemmC(
                         alpha,  conj_transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     Arow_k.releaseRemoteWorkspace();
                     Arow_k.releaseLocalWorkspace();
@@ -245,8 +242,7 @@ void hemmC(
                         Side::Left,
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
-                        one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts );
+                        one,    C.sub( k, k, 0, C.nt()-1 ) );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -257,7 +253,7 @@ void hemmC(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts );
+                            layout );
 
                         // Don't release local Acol_k here, because it may be
                         // bcast again, creating a race condition.
@@ -343,8 +339,7 @@ void hemmC(
                     Side::Left,
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
-                    beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts );
+                    beta,  C.sub( 0, 0, 0, C.nt()-1 ) );
 
                 A.releaseRemoteWorkspaceTile( 0, 0 );
                 A.releaseLocalWorkspaceTile( 0, 0 );
@@ -355,7 +350,7 @@ void hemmC(
                         alpha, conj_transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     // Don't release local Arow_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -426,7 +421,7 @@ void hemmC(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     Acol_k.releaseRemoteWorkspace();
                     Acol_k.releaseLocalWorkspace();
@@ -435,8 +430,7 @@ void hemmC(
                         Side::Left,
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
-                        one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts );
+                        one,    C.sub( k, k, 0, C.nt()-1 ) );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -447,7 +441,7 @@ void hemmC(
                             alpha,  conj_transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts );
+                            layout );
 
                         // Don't release local Arow_k here, because it may be
                         // bcast again, creating a race condition.

--- a/src/hemmC.cc
+++ b/src/hemmC.cc
@@ -68,13 +68,7 @@ void hemmC(
     assert( B.mt() == C.mt() );
     assert( B.nt() == C.nt() );
 
-    // Use only TileReleaseStrategy::Slate for hemm.
-    // Internal hemm and gemm routines called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts_local = opts;
-    opts_local[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
-    int64_t lookahead = get_option<int64_t>( opts_local, Option::Lookahead, 1 );
+    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector( A.nt() );
@@ -157,7 +151,7 @@ void hemmC(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts_local );
+                    priority_0, opts );
 
                 // Erase local & remote tile on all devices including host.
                 A.releaseRemoteWorkspaceTile( 0, 0 );
@@ -169,7 +163,7 @@ void hemmC(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     // Don't release local Acol_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -242,7 +236,7 @@ void hemmC(
                         alpha,  conj_transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     Arow_k.releaseRemoteWorkspace();
                     Arow_k.releaseLocalWorkspace();
@@ -252,7 +246,7 @@ void hemmC(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts_local );
+                        priority_0, opts );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -263,7 +257,7 @@ void hemmC(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts );
 
                         // Don't release local Acol_k here, because it may be
                         // bcast again, creating a race condition.
@@ -350,7 +344,7 @@ void hemmC(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts_local );
+                    priority_0, opts );
 
                 A.releaseRemoteWorkspaceTile( 0, 0 );
                 A.releaseLocalWorkspaceTile( 0, 0 );
@@ -361,7 +355,7 @@ void hemmC(
                         alpha, conj_transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     // Don't release local Arow_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -432,7 +426,7 @@ void hemmC(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     Acol_k.releaseRemoteWorkspace();
                     Acol_k.releaseLocalWorkspace();
@@ -442,7 +436,7 @@ void hemmC(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts_local );
+                        priority_0, opts );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -453,7 +447,7 @@ void hemmC(
                             alpha,  conj_transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts );
 
                         // Don't release local Arow_k here, because it may be
                         // bcast again, creating a race condition.

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -119,7 +119,7 @@ void her2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                priority_0, queue_0, layout, opts );
+                priority_0, queue_0, layout );
 
             // Erase remote tiles on all devices including host
             A_col0.releaseRemoteWorkspace();
@@ -166,7 +166,7 @@ void her2k(
                     alpha,         std::move( A_colk ),
                                    std::move( B_colk ),
                     real_t( 1.0 ), std::move( C ),
-                    priority_0, queue_0, layout, opts );
+                    priority_0, queue_0, layout );
 
                 // Erase remote tiles on all devices including host
                 A_colk.releaseRemoteWorkspace();

--- a/src/her2k.cc
+++ b/src/her2k.cc
@@ -47,12 +47,6 @@ void her2k(
     assert(B.mt() == C.mt());
     assert(A.nt() == B.nt());
 
-    // Use only TileReleaseStrategy::Slate for her2k.
-    // Internal her2k routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options const opts_local =  {
-        {slate::Option::TileReleaseStrategy, TileReleaseStrategy::Slate}};
-
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector(A.nt());
     std::vector<uint8_t>  gemm_vector(A.nt());
@@ -125,7 +119,7 @@ void her2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                priority_0, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts );
 
             // Erase remote tiles on all devices including host
             A_col0.releaseRemoteWorkspace();
@@ -172,7 +166,7 @@ void her2k(
                     alpha,         std::move( A_colk ),
                                    std::move( B_colk ),
                     real_t( 1.0 ), std::move( C ),
-                    priority_0, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts );
 
                 // Erase remote tiles on all devices including host
                 A_colk.releaseRemoteWorkspace();

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -103,7 +103,7 @@ void herk(
             internal::herk<target>(
                 alpha, A.sub(0, A.mt()-1, 0, 0),
                 beta,  std::move(C),
-                priority_0, queue_0, layout, opts );
+                priority_0, queue_0, layout );
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
@@ -142,7 +142,7 @@ void herk(
                 internal::herk<target>(
                     alpha,       A.sub(0, A.mt()-1, k, k),
                     real_t(1.0), std::move(C),
-                    priority_0, queue_0, layout, opts );
+                    priority_0, queue_0, layout );
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 

--- a/src/herk.cc
+++ b/src/herk.cc
@@ -37,12 +37,6 @@ void herk(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for herk.
-    // Internal herk routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if upper, change to lower
     if (C.uplo() == Uplo::Upper)
         C = conj_transpose( C );
@@ -109,7 +103,7 @@ void herk(
             internal::herk<target>(
                 alpha, A.sub(0, A.mt()-1, 0, 0),
                 beta,  std::move(C),
-                priority_0, queue_0, layout, opts2);
+                priority_0, queue_0, layout, opts );
 
             auto A_colblock = A.sub(0, A.mt()-1, 0, 0);
 
@@ -148,7 +142,7 @@ void herk(
                 internal::herk<target>(
                     alpha,       A.sub(0, A.mt()-1, k, k),
                     real_t(1.0), std::move(C),
-                    priority_0, queue_0, layout, opts2);
+                    priority_0, queue_0, layout, opts );
 
                 auto A_colblock = A.sub(0, A.mt()-1, k, k);
 

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -43,7 +43,6 @@ int64_t hetrf(
     const int priority_0 = 0;
     const int priority_1 = 1;
     const int tag_0 = 0;
-    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -173,7 +172,7 @@ int64_t hetrf(
                     -one, A.sub(k, k,   0, k-2),
                           Hj.sub(0, k-2, 0, 0),
                     one,  T.sub(k, k,   k, k),
-                    layout, priority_0, queue_0, opts );
+                    layout, priority_0 );
                 #endif
 
                 ReduceList reduce_list;
@@ -301,7 +300,7 @@ int64_t hetrf(
                                     -one, A.sub(k+1, A_mt-1, 0, k-2),
                                           Hj.sub(0, k-2, 0, 0),
                                     one,  A.sub(k+1, A_mt-1, k, k),
-                                    layout, priority_0, queue_0, opts );
+                                    layout, priority_0 );
                             #else
                                 if (A_mt - (k+1) > max_panel_threads) {
                                     slate::internal::gemmA<Target::HostTask>(
@@ -341,7 +340,7 @@ int64_t hetrf(
                                     -one, A.sub(k+1, A_mt-1, j, j),
                                           Hj.sub(0, 0, 0, 0),
                                     one,  A.sub(k+1, A_mt-1, k, k),
-                                    layout, priority_1, queue_0, opts );
+                                    layout, priority_1 );
                             }
                         }
                     }
@@ -362,7 +361,7 @@ int64_t hetrf(
                         -one, A.sub(k+1, A_mt-1, k-1, k-1),
                               Hj.sub(0,   0,     0, 0),
                         one,  A.sub(k+1, A_mt-1, k, k),
-                        layout, priority_1, queue_0, opts );
+                        layout, priority_1 );
                 }
             }
 

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -47,12 +47,6 @@ int64_t hetrf(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
-    // Use only TileReleaseStrategy::Slate for hetrf
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // Options
     real_t pivot_threshold
         = get_option<double>( opts, Option::PivotThreshold, 1.0 );
@@ -179,7 +173,7 @@ int64_t hetrf(
                     -one, A.sub(k, k,   0, k-2),
                           Hj.sub(0, k-2, 0, 0),
                     one,  T.sub(k, k,   k, k),
-                    layout, priority_0, queue_0, opts2 );
+                    layout, priority_0, queue_0, opts );
                 #endif
 
                 ReduceList reduce_list;
@@ -307,7 +301,7 @@ int64_t hetrf(
                                     -one, A.sub(k+1, A_mt-1, 0, k-2),
                                           Hj.sub(0, k-2, 0, 0),
                                     one,  A.sub(k+1, A_mt-1, k, k),
-                                    layout, priority_0, queue_0, opts2 );
+                                    layout, priority_0, queue_0, opts );
                             #else
                                 if (A_mt - (k+1) > max_panel_threads) {
                                     slate::internal::gemmA<Target::HostTask>(
@@ -347,7 +341,7 @@ int64_t hetrf(
                                     -one, A.sub(k+1, A_mt-1, j, j),
                                           Hj.sub(0, 0, 0, 0),
                                     one,  A.sub(k+1, A_mt-1, k, k),
-                                    layout, priority_1, queue_0, opts2 );
+                                    layout, priority_1, queue_0, opts );
                             }
                         }
                     }
@@ -368,7 +362,7 @@ int64_t hetrf(
                         -one, A.sub(k+1, A_mt-1, k-1, k-1),
                               Hj.sub(0,   0,     0, 0),
                         one,  A.sub(k+1, A_mt-1, k, k),
-                        layout, priority_1, queue_0, opts2 );
+                        layout, priority_1, queue_0, opts );
                 }
             }
 

--- a/src/internal/internal.hh
+++ b/src/internal/internal.hh
@@ -112,15 +112,13 @@ template <Target target=Target::HostTask,
           typename src_scalar_t, typename dst_scalar_t>
 void copy(Matrix<src_scalar_t>&& A,
           Matrix<dst_scalar_t>&& B,
-          int priority=0, int queue_index=0,
-          Options const& opts = Options());
+          int priority=0, int queue_index=0 );
 
 template <Target target=Target::HostTask,
           typename src_scalar_t, typename dst_scalar_t>
 void copy(BaseTrapezoidMatrix<src_scalar_t>&& A,
           BaseTrapezoidMatrix<dst_scalar_t>&& B,
-          int priority=0, int queue_index=0,
-          Options const& opts = Options());
+          int priority=0, int queue_index=0 );
 
 //-----------------------------------------
 // scale()
@@ -176,8 +174,7 @@ template <Target target=Target::HostTask, typename scalar_t>
 void gemm(scalar_t alpha, Matrix<scalar_t>&& A,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
-          Layout layout, int priority=0, int64_t queue_index=0,
-          Options const& opts = Options());
+          Layout layout, int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // gemmA()
@@ -185,8 +182,7 @@ template <Target target=Target::HostTask, typename scalar_t>
 void gemmA(scalar_t alpha, Matrix<scalar_t>&& A,
                            Matrix<scalar_t>&& B,
            scalar_t beta,  Matrix<scalar_t>&& C,
-           Layout layout, int priority=0, int64_t queue_index=0,
-           Options const& opts = Options());
+           Layout layout, int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // hemm()
@@ -195,8 +191,7 @@ void hemm(Side side,
           scalar_t alpha, HermitianMatrix<scalar_t>&& A,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
-          int priority=0,
-          Options const& opts = Options());
+          int priority=0 );
 
 // forward real-symmetric matrices to hemm;
 // disabled for complex
@@ -206,11 +201,10 @@ void hemm(Side side,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
           int priority=0,
-          Options const& opts = Options(),
           enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
     hemm<target>(side, alpha, std::move(A),
-                 beta, HermitianMatrix<scalar_t>(C), priority, opts);
+                 beta, HermitianMatrix<scalar_t>(C), priority );
 }
 
 //-----------------------------------------
@@ -220,15 +214,14 @@ void hemmA(Side side,
            scalar_t alpha, HermitianMatrix<scalar_t>&& A,
                            Matrix<scalar_t>&& B,
            scalar_t beta,  Matrix<scalar_t>&& C,
-           int priority=0, Options const& opts = Options());
+           int priority=0 );
 
 //-----------------------------------------
 // herk()
 template <Target target=Target::HostTask, typename scalar_t>
 void herk(blas::real_type<scalar_t> alpha, Matrix<scalar_t>&& A,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>&& C,
-          int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-          Options const& opts = Options());
+          int priority=0, int queue_index=0, Layout layout=Layout::ColMajor );
 
 // forward real-symmetric matrices to herk;
 // disabled for complex
@@ -236,12 +229,11 @@ template <Target target=Target::HostTask, typename scalar_t>
 void herk(blas::real_type<scalar_t> alpha, Matrix<scalar_t>&& A,
           blas::real_type<scalar_t> beta,  SymmetricMatrix<scalar_t>&& C,
           int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-          Options const& opts = Options(),
           enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
     herk<target>(alpha, std::move(A),
                  beta, HermitianMatrix<scalar_t>(C),
-                 priority, queue_index, layout, opts);
+                 priority, queue_index, layout );
 }
 
 //-----------------------------------------
@@ -250,8 +242,7 @@ template <Target target=Target::HostTask, typename scalar_t>
 void her2k(scalar_t alpha,                 Matrix<scalar_t>&& A,
                                            Matrix<scalar_t>&& B,
            blas::real_type<scalar_t> beta, HermitianMatrix<scalar_t>&& C,
-           int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-           Options const& opts = Options());
+           int priority=0, int queue_index=0, Layout layout=Layout::ColMajor );
 
 // forward real-symmetric matrices to her2k;
 // disabled for complex
@@ -260,12 +251,11 @@ void her2k(scalar_t alpha,                  Matrix<scalar_t>&& A,
                                             Matrix<scalar_t>&& B,
            blas::real_type<scalar_t> beta,  SymmetricMatrix<scalar_t>&& C,
            int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-           Options const& opts = Options(),
            enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
     her2k<target>(alpha, std::move(A),
                   beta, HermitianMatrix<scalar_t>(C),
-                  priority, queue_index, layout, opts);
+                  priority, queue_index, layout );
 }
 
 //-----------------------------------------
@@ -275,8 +265,7 @@ void symm(Side side,
           scalar_t alpha, SymmetricMatrix<scalar_t>&& A,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
-          int priority=0,
-          Options const& opts = Options());
+          int priority=0 );
 
 // forward real-Hermitian matrices to symm;
 // disabled for complex
@@ -286,11 +275,10 @@ void symm(Side side,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
           int priority=0,
-          Options const& opts = Options(),
           enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
     symm<target>(side, alpha, std::move(A),
-                 beta, SymmetricMatrix<scalar_t>(C), priority, opts);
+                 beta, SymmetricMatrix<scalar_t>(C), priority );
 }
 
 //-----------------------------------------
@@ -298,8 +286,7 @@ void symm(Side side,
 template <Target target=Target::HostTask, typename scalar_t>
 void syrk(scalar_t alpha, Matrix<scalar_t>&& A,
           scalar_t beta,  SymmetricMatrix<scalar_t>&& C,
-          int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-          Options const& opts = Options());
+          int priority=0, int queue_index=0, Layout layout=Layout::ColMajor );
 
 // forward real-Hermitian matrices to syrk;
 // disabled for complex
@@ -307,7 +294,6 @@ template <Target target=Target::HostTask, typename scalar_t>
 void syrk(scalar_t alpha, Matrix<scalar_t>&& A,
           scalar_t beta,  HermitianMatrix<scalar_t>&& C,
           int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-          Options const& opts = Options(),
           enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
     syrk<target>(alpha, std::move(A),
@@ -321,8 +307,7 @@ template <Target target=Target::HostTask, typename scalar_t>
 void syr2k(scalar_t alpha, Matrix<scalar_t>&& A,
                            Matrix<scalar_t>&& B,
            scalar_t beta,  SymmetricMatrix<scalar_t>&& C,
-           int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-           Options const& opts = Options());
+           int priority=0, int queue_index=0, Layout layout=Layout::ColMajor );
 
 // forward real-Hermitian matrices to syr2k;
 // disabled for complex
@@ -331,12 +316,11 @@ void syr2k(scalar_t alpha, Matrix<scalar_t>&& A,
                            Matrix<scalar_t>&& B,
            scalar_t beta,  HermitianMatrix<scalar_t>&& C,
            int priority=0, int queue_index=0, Layout layout=Layout::ColMajor,
-           Options const& opts = Options(),
            enable_if_t< ! is_complex<scalar_t>::value >* = nullptr)
 {
     syr2k<target>(alpha, std::move(A), std::move(B),
                   beta, SymmetricMatrix<scalar_t>(C),
-                  priority, queue_index, layout, opts);
+                  priority, queue_index, layout );
 }
 
 //-----------------------------------------
@@ -345,8 +329,7 @@ template <Target target=Target::HostTask, typename scalar_t>
 void trmm(Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
-          int priority=0, int64_t queue_index=0,
-          Options const& opts = Options());
+          int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // trsm()
@@ -355,7 +338,7 @@ void trsm(Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
           int priority=0, Layout layout=Layout::ColMajor,
-          int64_t queue_index=0, Options const& opts = Options());
+          int64_t queue_index=0 );
 
 //-----------------------------------------
 // trsmA()
@@ -364,7 +347,7 @@ void trsmA(Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
           int priority=0, Layout layout=Layout::ColMajor,
-          int64_t queue_index=0, Options const& opts = Options());
+          int64_t queue_index=0 );
 
 //-----------------------------------------
 // trtri()
@@ -397,14 +380,12 @@ void permuteRowsCols(
 template <Target target=Target::HostTask, typename scalar_t>
 void add(scalar_t alpha, Matrix<scalar_t>&& A,
          scalar_t beta,  Matrix<scalar_t>&& B,
-         int priority=0, int queue_index=0,
-         Options const& opts = Options());
+         int priority=0, int queue_index=0 );
 
 template <Target target=Target::HostTask, typename scalar_t>
 void add(scalar_t alpha, BaseTrapezoidMatrix<scalar_t>&& A,
          scalar_t beta,  BaseTrapezoidMatrix<scalar_t>&& B,
-         int priority=0, int queue_index=0,
-         Options const& opts = Options());
+         int priority=0, int queue_index=0 );
 
 template<typename scalar_t>
 void gerbt(Matrix<scalar_t> A11,
@@ -560,8 +541,7 @@ void he2hb_hemm(HermitianMatrix<scalar_t>&& A,
             Matrix<scalar_t>&& B,
             Matrix<scalar_t>&& C,
             std::vector<int64_t>& panel_rank_rows,
-            int priority=0, int64_t queue_index=0,
-            Options const& opts = Options());
+            int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // he2hb_trmm()
@@ -570,8 +550,7 @@ void he2hb_trmm(HermitianMatrix<scalar_t>&& AH,
             Matrix<scalar_t>&& A,
             Matrix<scalar_t>&& B,
             std::vector<int64_t>& panel_rank_rows,
-            int priority=0, int64_t queue_index=0,
-            Options const& opts = Options());
+            int priority=0, int64_t queue_index=0 );
 
 
 //-----------------------------------------
@@ -581,8 +560,7 @@ void he2hb_gemm(scalar_t alpha, Matrix<scalar_t>&& A,
                                 Matrix<scalar_t>&& B,
                 scalar_t beta,  Matrix<scalar_t>&& T,
                 int panel_rank,
-                int priority=0, int64_t queue_index=0,
-                Options const& opts = Options());
+                int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // he2hb_her2k_offdiag_ranks()
@@ -592,21 +570,18 @@ void he2hb_her2k_offdiag_ranks(
                         Matrix<scalar_t>&& B,
         scalar_t beta,  HermitianMatrix<scalar_t>&& C,
         std::vector<int64_t>& panel_rank_rows,
-        int priority=0, int64_t queue_index=0,
-        Options const& opts = Options());
+        int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // ttqrt()
 template <Target target=Target::HostTask, typename scalar_t>
 void ttqrt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T,
-           Options const& opts = Options());
+           Matrix<scalar_t>&& T );
 
 // ttlqt()
 template <Target target=Target::HostTask, typename scalar_t>
 void ttlqt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T,
-           Options const& opts = Options());
+           Matrix<scalar_t>&& T );
 
 //-----------------------------------------
 // ttmqr()
@@ -615,8 +590,7 @@ void ttmqr(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag=0,
-           Options const& opts = Options());
+           int tag=0 );
 
 // ttmlq()
 template <Target target=Target::HostTask, typename scalar_t>
@@ -624,8 +598,7 @@ void ttmlq(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag=0,
-           Options const& opts = Options());
+           int tag=0 );
 
 // hettmqr()
 template <Target target=Target::HostTask, typename scalar_t>
@@ -633,7 +606,7 @@ void hettmqr(Op op,
              Matrix<scalar_t>&& A,
              Matrix<scalar_t>&& T,
              HermitianMatrix<scalar_t>&& C,
-             int tag=0, Options const& opts = Options());
+             int tag=0 );
 
 //-----------------------------------------
 // unmqr()
@@ -643,8 +616,7 @@ void unmqr(Side side, Op op,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
            Matrix<scalar_t>&& W,
-           int priority=0, int64_t queue_index=0,
-           Options const& opts = Options());
+           int priority=0, int64_t queue_index=0 );
 
 // unmlq()
 template <Target target=Target::HostTask, typename scalar_t>
@@ -653,24 +625,21 @@ void unmlq(Side side, Op op,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
            Matrix<scalar_t>&& W,
-           int priority=0, int64_t queue_index=0,
-           Options const& opts = Options());
+           int priority=0, int64_t queue_index=0 );
 
 //-----------------------------------------
 // unmtr_hb2st()
 template <Target target=Target::HostTask, typename scalar_t>
 void unmtr_hb2st(Side side, Op op,
                  Matrix<scalar_t>& V,
-                 Matrix<scalar_t>& C,
-                 const std::map<Option, Value>& opts);
+                 Matrix<scalar_t>& C );
 
 //-----------------------------------------
 // unmbr_tb2bd()
 template <Target target=Target::HostTask, typename scalar_t>
 void unmbr_tb2bd(Side side, Op op,
                  Matrix<scalar_t>& V,
-                 Matrix<scalar_t>& C,
-                 const std::map<Option, Value>& opts);
+                 Matrix<scalar_t>& C );
 
 //-----------------------------------------
 // potrf()
@@ -695,8 +664,7 @@ void norm1est(
     Matrix<int64_t>& S,
     blas::real_type<scalar_t>* one_normest,
     int* kase,
-    std::vector<int64_t>& isave,
-    Options const& opts = Options());
+    std::vector<int64_t>& isave );
 
 //------------------------------------------------------------------------------
 // MPI reduce info, used in getrf, hetrf, etc.

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -52,29 +52,19 @@ void add(internal::TargetType<Target::HostTask>,
     assert(A_mt == B.mt());
     assert(A_nt == B.nt());
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     #pragma omp taskgroup
     for (int64_t i = 0; i < A_mt; ++i) {
         for (int64_t j = 0; j < A_nt; ++j) {
             if (B.tileIsLocal(i, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B ) \
-                    firstprivate( i, j, alpha, beta, call_tile_tick )  priority(priority)
+                    firstprivate( i, j, alpha, beta )  priority(priority)
                 {
                     A.tileGetForReading(i, j, LayoutConvert::None);
                     B.tileGetForWriting(i, j, LayoutConvert::None);
                     tile::add(
                         alpha, A(i, j),
                         beta,  B(i, j) );
-
-                    if (call_tile_tick) {
-                        A.tileTick(i, j);
-                    }
                 }
             }
         }
@@ -119,17 +109,11 @@ void add(internal::TargetType<Target::Devices>,
 {
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     #pragma omp taskgroup
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none priority( priority ) \
             shared( A, B ) \
-            firstprivate( device, queue_index, beta, alpha, call_tile_tick )
+            firstprivate( device, queue_index, beta, alpha )
         {
             // temporarily, convert both into same layout
             // todo: this is in-efficient, because both matrices may have same layout already
@@ -193,19 +177,6 @@ void add(internal::TargetType<Target::Devices>,
             }
 
             queue->sync();
-
-            if (call_tile_tick) {
-                for (int64_t i = 0; i < B.mt(); ++i) {
-                    for (int64_t j = 0; j < B.nt(); ++j) {
-                        if (B.tileIsLocal(i, j) && device == B.tileDevice(i, j)) {
-                            // erase tmp local and remote device tiles;
-                            A.tileRelease(i, j, device);
-                            // decrement life for remote tiles
-                            A.tileTick(i, j);
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -23,12 +23,12 @@ namespace internal {
 template <Target target, typename scalar_t>
 void add(scalar_t alpha, Matrix<scalar_t>&& A,
          scalar_t beta, Matrix<scalar_t>&& B,
-         int priority, int queue_index, Options const& opts)
+         int priority, int queue_index )
 {
     add(internal::TargetType<target>(),
         alpha, A,
         beta,  B,
-        priority, queue_index, opts);
+        priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -43,7 +43,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostTask>,
          scalar_t alpha, Matrix<scalar_t>& A,
          scalar_t beta, Matrix<scalar_t>& B,
-         int priority, int queue_index, Options const& opts)
+         int priority, int queue_index )
 {
     // trace::Block trace_block("add");
 
@@ -77,7 +77,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostNest>,
          scalar_t alpha, Matrix<scalar_t>& A,
          scalar_t beta, Matrix<scalar_t>& B,
-         int priority, int queue_index, Options const& opts)
+         int priority, int queue_index )
 {
     slate_not_implemented("Target::HostNest isn't yet supported.");
 }
@@ -88,7 +88,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostBatch>,
          scalar_t alpha, Matrix<scalar_t>& A,
          scalar_t beta, Matrix<scalar_t>& B,
-         int priority, int queue_index, Options const& opts)
+         int priority, int queue_index )
 {
     slate_not_implemented("Target::HostBatch isn't yet supported.");
 }
@@ -105,7 +105,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::Devices>,
          scalar_t alpha, Matrix<scalar_t>& A,
          scalar_t beta, Matrix<scalar_t>& B,
-         int priority, int queue_index, Options const& opts)
+         int priority, int queue_index )
 {
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
 
@@ -189,100 +189,100 @@ template
 void add<Target::HostTask, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostNest, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostBatch, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::Devices, float>(
      float alpha, Matrix<float>&& A,
      float beta, Matrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 // ----------------------------------------
 template
 void add<Target::HostTask, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostNest, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostBatch, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::Devices, double>(
      double alpha, Matrix<double>&& A,
      double beta, Matrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 // ----------------------------------------
 template
 void add< Target::HostTask, std::complex<float> >(
      std::complex<float> alpha, Matrix< std::complex<float> >&& A,
      std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostNest, std::complex<float> >(
      std::complex<float> alpha, Matrix< std::complex<float> >&& A,
      std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostBatch, std::complex<float> >(
      std::complex<float> alpha, Matrix< std::complex<float> >&& A,
      std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
     std::complex<float>  beta, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts);
+    int priority, int queue_index );
 
 // ----------------------------------------
 template
 void add< Target::HostTask, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostNest, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostBatch, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::Devices, std::complex<double> >(
      std::complex<double> alpha, Matrix< std::complex<double> >&& A,
      std::complex<double> beta, Matrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -44,12 +44,11 @@ namespace internal {
 template <Target target, typename src_scalar_t, typename dst_scalar_t>
 void copy( Matrix<src_scalar_t>&& A,
            Matrix<dst_scalar_t>&& B,
-           int priority, int queue_index,
-           Options const& opts )
+           int priority, int queue_index )
 {
     copy(internal::TargetType<target>(),
          A, B,
-         priority, queue_index, opts);
+         priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -63,8 +62,7 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::HostTask>,
           Matrix<src_scalar_t>& A,
           Matrix<dst_scalar_t>& B,
-          int priority, int queue_index,
-          Options const& opts )
+          int priority, int queue_index )
 {
     // trace::Block trace_block("copy");
 
@@ -97,8 +95,7 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::HostNest>,
           Matrix<src_scalar_t>& A,
           Matrix<dst_scalar_t>& B,
-          int priority, int queue_index,
-          Options const& opts )
+          int priority, int queue_index )
 {
     slate_not_implemented("Target::HostNest isn't yet supported.");
 }
@@ -108,8 +105,7 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::HostBatch>,
           Matrix<src_scalar_t>& A,
           Matrix<dst_scalar_t>& B,
-          int priority, int queue_index,
-          Options const& opts )
+          int priority, int queue_index )
 {
     slate_not_implemented("Target::HostBatch isn't yet supported.");
 }
@@ -125,8 +121,7 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::Devices>,
           Matrix<src_scalar_t>& A,
           Matrix<dst_scalar_t>& B,
-          int priority, int queue_index,
-          Options const& opts )
+          int priority, int queue_index )
 {
     using ij_tuple = typename BaseMatrix<src_scalar_t>::ij_tuple;
 
@@ -241,220 +236,220 @@ void copy(internal::TargetType<Target::Devices>,
 template
 void copy<Target::HostTask, float, float>(
     Matrix<float>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostNest, float, float>(
     Matrix<float>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostBatch, float, float>(
     Matrix<float>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, float, float>(
     Matrix<float>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // float => double
 template
 void copy<Target::HostTask, float, double>(
     Matrix<float>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostNest, float, double>(
     Matrix<float>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostBatch, float, double>(
     Matrix<float>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, float, double>(
     Matrix<float>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // double => double
 template
 void copy<Target::HostTask, double, double>(
     Matrix<double>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostNest, double, double>(
     Matrix<double>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostBatch, double, double>(
     Matrix<double>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, double, double>(
     Matrix<double>&& A, Matrix<double>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // double => float
 template
 void copy<Target::HostTask, double, float>(
     Matrix<double>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostNest, double, float>(
     Matrix<double>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::HostBatch, double, float>(
     Matrix<double>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, double, float>(
     Matrix<double>&& A, Matrix<float>&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // complex-float => complex-float
 template
 void copy< Target::HostTask, std::complex<float>, std::complex<float> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostNest, std::complex<float>, std::complex<float> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostBatch, std::complex<float>, std::complex<float> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<float>, std::complex<float> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // complex-float => complex-double
 template
 void copy< Target::HostTask, std::complex<float>, std::complex<double> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostNest, std::complex<float>, std::complex<double> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostBatch, std::complex<float>, std::complex<double> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<float>, std::complex<double> >(
     Matrix< std::complex<float> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // complex-double => complex-double
 template
 void copy< Target::HostTask, std::complex<double>, std::complex<double> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostNest, std::complex<double>, std::complex<double> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostBatch, std::complex<double>, std::complex<double> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<double>, std::complex<double> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // complex-double => complex-float
 template
 void copy< Target::HostTask, std::complex<double>, std::complex<float> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<double>, std::complex<float> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostNest, std::complex<double>, std::complex<float> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostBatch, std::complex<double>, std::complex<float> >(
     Matrix< std::complex<double> >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // float => complex-float
 template
 void copy< Target::HostTask, float, std::complex<float> >(
     Matrix< float >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, float, std::complex<float> >(
     Matrix< float >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostNest, float, std::complex<float> >(
     Matrix< float >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostBatch, float, std::complex<float> >(
     Matrix< float >&& A, Matrix< std::complex<float> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 //-----------------------------------------
 // double => complex-double
 template
 void copy< Target::HostTask, double, std::complex<double> >(
     Matrix< double >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, double, std::complex<double> >(
     Matrix< double >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostNest, double, std::complex<double> >(
     Matrix< double >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 template
 void copy< Target::HostBatch, double, std::complex<double> >(
     Matrix< double >&& A, Matrix< std::complex<double> >&& B,
-    int priority, int queue_index, Options const& opts );
+    int priority, int queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -73,18 +73,12 @@ void copy(internal::TargetType<Target::HostTask>,
     assert(A_mt == B.mt());
     assert(A_nt == B.nt());
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     #pragma omp taskgroup
     for (int64_t i = 0; i < A_mt; ++i) {
         for (int64_t j = 0; j < A_nt; ++j) {
             if (B.tileIsLocal(i, j)) {
                 #pragma omp task slate_omp_default_none \
-                    shared( A, B ) firstprivate( i, j, HostNum, call_tile_tick ) \
+                    shared( A, B ) firstprivate( i, j, HostNum ) \
                     priority(priority)
                 {
                     A.tileGetForReading(i, j, LayoutConvert::None);
@@ -92,9 +86,6 @@ void copy(internal::TargetType<Target::HostTask>,
                     B.tileAcquire(i, j, A.tileLayout(i, j));
                     B.tileModified(i, j, HostNum, true);
                     tile::gecopy( A(i, j), B(i, j) );
-                    if (call_tile_tick) {
-                        A.tileTick(i, j);
-                    }
                 }
             }
         }
@@ -139,16 +130,10 @@ void copy(internal::TargetType<Target::Devices>,
 {
     using ij_tuple = typename BaseMatrix<src_scalar_t>::ij_tuple;
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     #pragma omp taskgroup
     for (int device = 0; device < B.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none priority( priority ) \
-            shared( A, B ) firstprivate( device, queue_index, call_tile_tick )
+            shared( A, B ) firstprivate( device, queue_index )
         {
             std::set<ij_tuple> A_tiles_set;
             for (int64_t i = 0; i < B.mt(); ++i) {
@@ -245,19 +230,6 @@ void copy(internal::TargetType<Target::Devices>,
             }
 
             queue->sync();
-
-            if (call_tile_tick) {
-                for (int64_t i = 0; i < B.mt(); ++i) {
-                    for (int64_t j = 0; j < B.nt(); ++j) {
-                        if (B.tileIsLocal(i, j) && device == B.tileDevice(i, j)) {
-                            // erase tmp local and remote device tiles;
-                            A.tileRelease(i, j, device);
-                            // decrement life for remote tiles
-                            A.tileTick(i, j);
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/src/internal/internal_gemm.cc
+++ b/src/internal/internal_gemm.cc
@@ -31,8 +31,7 @@ template <Target target, typename scalar_t>
 void gemm(scalar_t alpha, Matrix<scalar_t>&& A,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
-          Layout layout, int priority, int64_t queue_index,
-          Options const& opts )
+          Layout layout, int priority, int64_t queue_index )
 {
     if (C.is_complex &&
         ((C.op() == Op::Trans &&
@@ -47,7 +46,7 @@ void gemm(scalar_t alpha, Matrix<scalar_t>&& A,
          alpha, A,
                 B,
          beta,  C,
-         layout, priority, queue_index, opts);
+         layout, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -61,8 +60,7 @@ void gemm(internal::TargetType<Target::HostTask>,
           scalar_t alpha, Matrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          Layout layout, int priority, int64_t queue_index,
-          Options const& opts )
+          Layout layout, int priority, int64_t queue_index )
 {
     // todo: optimize for the number of layout conversions,
     //       by watching 'layout' and 'C(i, j).layout()'
@@ -127,8 +125,7 @@ void gemm(internal::TargetType<Target::HostNest>,
           scalar_t alpha, Matrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          Layout layout, int priority, int64_t queue_index,
-          Options const& opts )
+          Layout layout, int priority, int64_t queue_index )
 {
 #if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
@@ -184,8 +181,7 @@ void gemm(internal::TargetType<Target::HostBatch>,
           scalar_t alpha, Matrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          Layout layout, int priority, int64_t queue_index,
-          Options const& opts )
+          Layout layout, int priority, int64_t queue_index )
 {
 #ifdef BLAS_HAVE_MKL
     using blas::conj;
@@ -360,9 +356,7 @@ void gemm(internal::TargetType<Target::Devices>,
           scalar_t alpha, Matrix< scalar_t >& A,
                           Matrix< scalar_t >& B,
           scalar_t beta,  Matrix< scalar_t >& C,
-          Layout layout, int priority, int64_t queue_index,
-          Options const& opts
-          )
+          Layout layout, int priority, int64_t queue_index )
 {
     using blas::conj;
     using std::swap;
@@ -531,32 +525,28 @@ void gemm<Target::HostTask, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm<Target::HostNest, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm<Target::HostBatch, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm<Target::Devices, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -564,32 +554,28 @@ void gemm<Target::HostTask, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm<Target::HostNest, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm<Target::HostBatch, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm<Target::Devices, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -597,32 +583,28 @@ void gemm< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm< Target::HostBatch, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -630,32 +612,28 @@ void gemm< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm< Target::HostBatch, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemm< Target::Devices, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts );
+    Layout layout, int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_gemmA.cc
+++ b/src/internal/internal_gemmA.cc
@@ -28,8 +28,7 @@ template <Target target, typename scalar_t>
 void gemmA(scalar_t alpha, Matrix<scalar_t>&& A,
                            Matrix<scalar_t>&& B,
            scalar_t beta,  Matrix<scalar_t>&& C,
-           Layout layout, int priority, int64_t queue_index,
-           Options const& opts)
+           Layout layout, int priority, int64_t queue_index )
 {
     if (C.is_complex &&
         ((C.op() == Op::Trans &&
@@ -44,7 +43,7 @@ void gemmA(scalar_t alpha, Matrix<scalar_t>&& A,
           alpha, A,
                  B,
           beta,  C,
-          layout, priority, queue_index, opts );
+          layout, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -74,8 +73,7 @@ void gemmA(internal::TargetType<Target::HostTask>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  Matrix<scalar_t>& C,
-           Layout layout, int priority, int queue_index,
-           Options const& opts)
+           Layout layout, int priority, int queue_index )
 {
     // check dimensions
     assert( A.nt() == B.mt() );
@@ -199,11 +197,10 @@ void gemmA(internal::TargetType<Target::HostNest>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  Matrix<scalar_t>& C,
-           Layout layout, int priority, int queue_index,
-           Options const& opts)
+           Layout layout, int priority, int queue_index )
 {
     gemmA( internal::TargetType<Target::HostTask>(),
-            alpha, A, B, beta, C, layout, priority, queue_index, opts );
+            alpha, A, B, beta, C, layout, priority, queue_index );
 }
 
 template <typename scalar_t>
@@ -211,11 +208,10 @@ void gemmA(internal::TargetType<Target::HostBatch>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  Matrix<scalar_t>& C,
-           Layout layout, int priority, int queue_index,
-           Options const& opts)
+           Layout layout, int priority, int queue_index )
 {
     gemmA( internal::TargetType<Target::HostTask>(),
-            alpha, A, B, beta, C, layout, priority, queue_index, opts );
+            alpha, A, B, beta, C, layout, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -230,8 +226,7 @@ void gemmA(internal::TargetType<Target::Devices>,
           scalar_t alpha, Matrix< scalar_t >& A,
                           Matrix< scalar_t >& B,
           scalar_t beta,  Matrix< scalar_t >& C,
-          Layout layout, int priority, int64_t queue_index,
-          Options const& opts)
+          Layout layout, int priority, int64_t queue_index )
 {
     using blas::conj;
     using std::swap;
@@ -496,32 +491,28 @@ void gemmA<Target::HostTask, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA<Target::HostTask, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -529,32 +520,28 @@ void gemmA<Target::HostNest, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA<Target::HostNest, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -562,32 +549,28 @@ void gemmA<Target::HostBatch, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA<Target::HostBatch, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::HostBatch, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::HostBatch, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -595,32 +578,28 @@ void gemmA<Target::Devices, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA<Target::Devices, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 template
 void gemmA< Target::Devices, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    Layout layout, int priority, int64_t queue_index,
-    Options const& opts);
+    Layout layout, int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_he2hb_gemm.cc
+++ b/src/internal/internal_he2hb_gemm.cc
@@ -28,12 +28,11 @@ void he2hb_gemm(
     scalar_t alpha, Matrix<scalar_t>&& A, Matrix<scalar_t>&& B,
     scalar_t beta,  Matrix<scalar_t>&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     he2hb_gemm( internal::TargetType<target>(),
                 alpha, A, B, beta, C,
-                panel_rank, priority, queue_index, opts );
+                panel_rank, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -47,8 +46,7 @@ void he2hb_gemm(
     scalar_t alpha, Matrix<scalar_t>& A, Matrix<scalar_t>& B,
     scalar_t beta,  Matrix<scalar_t>& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -102,8 +100,7 @@ void he2hb_gemm(
     scalar_t alpha, Matrix<scalar_t>& A, Matrix<scalar_t>& B,
     scalar_t beta,  Matrix<scalar_t>& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -293,8 +290,7 @@ void he2hb_gemm<Target::HostTask, float>(
     float alpha, Matrix<float>&& A, Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -302,8 +298,7 @@ void he2hb_gemm<Target::HostTask, double>(
     double alpha, Matrix<double>&& A, Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -312,8 +307,7 @@ void he2hb_gemm< Target::HostTask, std::complex<float> >(
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -322,8 +316,7 @@ void he2hb_gemm< Target::HostTask, std::complex<double> >(
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -331,8 +324,7 @@ void he2hb_gemm<Target::Devices, float>(
     float alpha, Matrix<float>&& A, Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -340,8 +332,7 @@ void he2hb_gemm<Target::Devices, double>(
     double alpha, Matrix<double>&& A, Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -350,8 +341,7 @@ void he2hb_gemm< Target::Devices, std::complex<float> >(
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -360,8 +350,7 @@ void he2hb_gemm< Target::Devices, std::complex<double> >(
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
     int panel_rank,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -28,11 +28,10 @@ void he2hb_hemm(
     Matrix<scalar_t>&& B,
     Matrix<scalar_t>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     he2hb_hemm( internal::TargetType<target>(),
-                A, B, C, panel_rank_rows, priority, queue_index, opts );
+                A, B, C, panel_rank_rows, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -47,8 +46,7 @@ void he2hb_hemm(
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     int64_t mt = A.mt();
     const scalar_t one  = 1;
@@ -109,8 +107,7 @@ void he2hb_hemm(
     Matrix<scalar_t>& B,
     Matrix<scalar_t>& C,
     std::vector<int64_t> panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     int64_t mt = A.mt();
     const scalar_t one  = 1;
@@ -730,8 +727,7 @@ void he2hb_hemm<Target::HostTask, float>(
     Matrix<float>&& B,
     Matrix<float>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -740,8 +736,7 @@ void he2hb_hemm<Target::HostTask, double>(
     Matrix<double>&& B,
     Matrix<double>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -750,8 +745,7 @@ void he2hb_hemm< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& B,
     Matrix< std::complex<float> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -760,8 +754,7 @@ void he2hb_hemm< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& B,
     Matrix< std::complex<double> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -770,8 +763,7 @@ void he2hb_hemm<Target::Devices, float>(
     Matrix<float>&& B,
     Matrix<float>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -780,8 +772,7 @@ void he2hb_hemm<Target::Devices, double>(
     Matrix<double>&& B,
     Matrix<double>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -790,8 +781,7 @@ void he2hb_hemm< Target::Devices, std::complex<float> >(
     Matrix< std::complex<float> >&& B,
     Matrix< std::complex<float> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -800,8 +790,7 @@ void he2hb_hemm< Target::Devices, std::complex<double> >(
     Matrix< std::complex<double> >&& B,
     Matrix< std::complex<double> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_he2hb_hemm.cc
+++ b/src/internal/internal_he2hb_hemm.cc
@@ -57,16 +57,10 @@ void he2hb_hemm(
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layoutc = LayoutConvert( layout );
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     #pragma omp taskgroup
     for (int64_t i = 0; i < mt; ++i) {
         #pragma omp task slate_omp_default_none \
-            shared( A, B, C, panel_rank_rows, call_tile_tick ) \
+            shared( A, B, C, panel_rank_rows ) \
             firstprivate( one, i, layoutc )
         {
             for (int64_t j : panel_rank_rows) {
@@ -85,10 +79,6 @@ void he2hb_hemm(
                             tile::gemm( one, A( i, j ), B( j, 0 ),
                                         one, C( i, 0 ) );
                         }
-                        if (call_tile_tick) {
-                            A.tileTick( i, j );
-                            B.tileTick( j, 0 );
-                        }
                     }
                 }
                 else { // upper
@@ -98,10 +88,6 @@ void he2hb_hemm(
                         C.tileGetForWriting( i, 0, layoutc );
                         tile::gemm( one, conj_transpose( A( j, i ) ), B( j, 0 ),
                                     one, C( i, 0 ) );
-                        if (call_tile_tick) {
-                            A.tileTick( j, i );
-                            B.tileTick( j, 0 );
-                        }
                     }
                 }
             }
@@ -133,12 +119,6 @@ void he2hb_hemm(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const LayoutConvert layoutc = LayoutConvert( layout );
-
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
 
     #pragma omp taskgroup
     for (int device = 0; device < C.num_devices(); ++device) {
@@ -202,7 +182,7 @@ void he2hb_hemm(
     for (int device = 0; device < C.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( one, device, mt, num_queues, layout, call_tile_tick ) \
+            firstprivate( one, device, mt, num_queues, layout ) \
             priority( priority )
         {
             trace::Block trace_block( "blas::batch::he2hb_hemm" );
@@ -275,34 +255,6 @@ void he2hb_hemm(
                 blas::Queue* queue = C.compute_queue( device, i );
                 queue->sync();
             }
-
-            if (call_tile_tick) {
-                // todo: release tiles in top-level routine.
-                // for (int64_t j : panel_rank_rows) {
-                //     for (int64_t i = 0; i < mt; ++i) {
-                //         if (i >= j) { // lower or diagonal
-                //             if (A.tileIsLocal( i, j )
-                //                 && device == C.tileDevice( i, 0 )) {
-                //                 C.tileModified( i, 0, device );
-                //                 A.tileRelease( i, j, device );
-                //                 B.tileRelease( j, 0, device );
-                //                 A.tileTick( i, j );
-                //                 B.tileTick( j, 0 );
-                //             }
-                //         }
-                //         else { // upper
-                //             if (A.tileIsLocal( j, i )
-                //                 && device == C.tileDevice( i, 0 )) {
-                //                 C.tileModified( i, 0, device );
-                //                 A.tileRelease( j, i, device );
-                //                 B.tileRelease( j, 0, device );
-                //                 A.tileTick( j, i );
-                //                 B.tileTick( j, 0 );
-                //             }
-                //         }
-                //     } //i loop
-                // } // j loop
-            }
         } // pragma
     } // devices
 }
@@ -333,13 +285,6 @@ void he2hb_hemm(internal::TargetType<Target::Devices>,
     assert( C.num_devices() > 0 );
     scalar_t alpha = 1.;
     scalar_t beta = 1.;
-
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
 
     // check if there is a cleanup tile
     int64_t i_interior = mt;
@@ -766,32 +711,6 @@ void he2hb_hemm(internal::TargetType<Target::Devices>,
                 }
 
                 queue->sync();
-
-                if (call_tile_tick) {
-                    // todo: release tiles in top-level routine.
-                    // for (int64_t i = 0; i < mt; ++i) {
-                    //     if (i >= j) { // lower or diagonal
-                    //         if (A.tileIsLocal( i, j )) {
-                    //             if (device == C.tileDevice( i, 0 )) {
-                    //                 A.tileRelease( i, j, device );
-                    //                 B.tileRelease( j, 0, device );
-                    //                 A.tileTick( i, j );
-                    //                 B.tileTick( j, 0 );
-                    //             }
-                    //         }
-                    //     }
-                    //     else { // upper
-                    //         if (A.tileIsLocal( j, i )) {
-                    //             if (device == C.tileDevice( i, 0 )) {
-                    //                 A.tileRelease( j, i, device );
-                    //                 B.tileRelease( j, 0, device );
-                    //                 A.tileTick( j, i );
-                    //                 B.tileTick( j, 0 );
-                    //             }
-                    //         }
-                    //     }
-                    // }
-                }
             } // j = panel_rank_rows
         } // task
     } // device

--- a/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
+++ b/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
@@ -56,18 +56,12 @@ void he2hb_her2k_offdiag_ranks(
 
     int64_t nt = C.nt();
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     // try to loop over one tile and do two gemm, similar to her2k
     #pragma omp taskgroup
     for (int64_t j = 0; j < nt; ++j) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, panel_rank_rows ) \
-            firstprivate( alpha, beta, j, layoutc, call_tile_tick )
+            firstprivate( alpha, beta, j, layoutc )
         {
             for (int64_t i : panel_rank_rows) {
                 // todo: if HermitianMatrix returned conjTrans
@@ -80,11 +74,6 @@ void he2hb_her2k_offdiag_ranks(
                         // Aij -= Vik Wjk^H
                         tile::gemm( alpha, A( i, 0 ), conj_transpose( B( j, 0 ) ),
                                     beta, C( i, j ) );
-
-                        if (call_tile_tick) {
-                            A.tileTick( i, 0 );
-                            B.tileTick( j, 0 );
-                        }
                     }
                 }
                 else if (i < j) {  // upper
@@ -95,10 +84,6 @@ void he2hb_her2k_offdiag_ranks(
                         // Aji -= Wjk Vik^H
                         tile::gemm( alpha, B( j, 0 ), conj_transpose( A( i, 0 ) ),
                                     beta, C( j, i ) );
-                        if (call_tile_tick) {
-                            B.tileTick( j, 0 );
-                            A.tileTick( i, 0 );
-                        }
                     }
                 }
                 else { // i == j
@@ -143,19 +128,12 @@ void he2hb_her2k_offdiag_ranks(
 
     assert( C.num_devices() > 0 );
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     int err = 0;
     #pragma omp taskgroup
     for (int device = 0; device < C.num_devices(); ++device) {
         #pragma omp task slate_omp_default_none \
             shared( A, B, C, err, panel_rank_rows ) \
             firstprivate( alpha, beta, device, nt, layout, layoutc, queue_index ) \
-            firstprivate( call_tile_tick ) \
             priority( priority )
         {
             Op opA = A.op();
@@ -372,36 +350,6 @@ void he2hb_her2k_offdiag_ranks(
                     c_array_host += group_count;
                 }
                 queue->sync();
-            }
-
-            if (call_tile_tick) {
-                // todo: release tiles in top-level routine.
-                //for (int64_t j = 0; j < nt; ++j) {
-                //    for (int64_t i : panel_rank_rows) {
-                //        if (i > j) {
-                //            if (C.tileIsLocal( i, j )
-                //                && device == C.tileDevice( i, j )) {
-                //                // erase tmp local and remote device tiles;
-                //                A.tileRelease( i, 0, device );
-                //                B.tileRelease( j, 0, device );
-                //                // decrement life for remote tiles
-                //                A.tileTick( i, 0 );
-                //                B.tileTick( j, 0 );
-                //            }
-                //        }
-                //        else if (i < j) {
-                //            if (C.tileIsLocal( j, i )
-                //                && device == C.tileDevice( j, i )) {
-                //                // erase tmp local and remote device tiles;
-                //                A.tileRelease( i, 0, device );
-                //                B.tileRelease( j, 0, device );
-                //                // decrement life for remote tiles
-                //                A.tileTick( i, 0 );
-                //                B.tileTick( j, 0 );
-                //            }
-                //        }
-                //    }
-                //}
             }
         }
     }

--- a/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
+++ b/src/internal/internal_he2hb_her2k_offdiag_ranks.cc
@@ -26,13 +26,12 @@ void he2hb_her2k_offdiag_ranks(
                     Matrix<scalar_t>&& B,
     scalar_t beta,  HermitianMatrix<scalar_t>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     he2hb_her2k_offdiag_ranks(
         internal::TargetType<target>(),
         alpha, A, B, beta, C,
-        panel_rank_rows, priority, queue_index, opts );
+        panel_rank_rows, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -47,8 +46,7 @@ void he2hb_her2k_offdiag_ranks(
                     Matrix<scalar_t>& B,
     scalar_t beta,  HermitianMatrix<scalar_t>& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -109,8 +107,7 @@ void he2hb_her2k_offdiag_ranks(
                     Matrix<scalar_t>& B,
     scalar_t beta,  HermitianMatrix<scalar_t>& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -367,8 +364,7 @@ void he2hb_her2k_offdiag_ranks<Target::HostTask, float>(
                  Matrix<float>&& B,
     float beta,  HermitianMatrix<float>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -377,8 +373,7 @@ void he2hb_her2k_offdiag_ranks<Target::HostTask, double>(
                   Matrix<double>&& B,
     double beta,  HermitianMatrix<double>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -387,8 +382,7 @@ void he2hb_her2k_offdiag_ranks< Target::HostTask, std::complex<float> >(
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  HermitianMatrix< std::complex<float> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -397,8 +391,7 @@ void he2hb_her2k_offdiag_ranks< Target::HostTask, std::complex<double> >(
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  HermitianMatrix< std::complex<double> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -407,8 +400,7 @@ void he2hb_her2k_offdiag_ranks<Target::Devices, float>(
                  Matrix<float>&& B,
     float beta,  HermitianMatrix<float>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -417,8 +409,7 @@ void he2hb_her2k_offdiag_ranks<Target::Devices, double>(
                   Matrix<double>&& B,
     double beta,  HermitianMatrix<double>&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -427,8 +418,7 @@ void he2hb_her2k_offdiag_ranks< Target::Devices, std::complex<float> >(
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  HermitianMatrix< std::complex<float> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -437,8 +427,7 @@ void he2hb_her2k_offdiag_ranks< Target::Devices, std::complex<double> >(
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  HermitianMatrix< std::complex<double> >&& C,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_he2hb_trmm.cc
+++ b/src/internal/internal_he2hb_trmm.cc
@@ -60,12 +60,11 @@ void he2hb_trmm(
     HermitianMatrix<scalar_t>&& AH, Matrix<scalar_t>&& A,
     Matrix<scalar_t>&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     he2hb_trmm( internal::TargetType<target>(),
                 AH, A, B,
-                panel_rank_rows, priority, queue_index, opts );
+                panel_rank_rows, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -80,8 +79,7 @@ void he2hb_trmm(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     const scalar_t one  = 1;
     int mpi_rank = AH.mpiRank();
@@ -140,8 +138,7 @@ void he2hb_trmm(
     Matrix<scalar_t>& A,
     Matrix<scalar_t>& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts )
+    int priority, int64_t queue_index )
 {
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
 
@@ -304,8 +301,7 @@ void he2hb_trmm<Target::HostTask, float>(
     Matrix<float>&& A,
     Matrix<float>&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -314,8 +310,7 @@ void he2hb_trmm<Target::HostTask, double>(
     Matrix<double>&& A,
     Matrix<double>&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -324,8 +319,7 @@ void he2hb_trmm< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
     Matrix< std::complex<float> >&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -334,8 +328,7 @@ void he2hb_trmm< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
     Matrix< std::complex<double> >&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -344,8 +337,7 @@ void he2hb_trmm<Target::Devices, float>(
     Matrix<float>&& A,
     Matrix<float>&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -354,8 +346,7 @@ void he2hb_trmm<Target::Devices, double>(
     Matrix<double>&& A,
     Matrix<double>&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -364,8 +355,7 @@ void he2hb_trmm< Target::Devices, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
     Matrix< std::complex<float> >&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -374,8 +364,7 @@ void he2hb_trmm< Target::Devices, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
     Matrix< std::complex<double> >&& B,
     std::vector<int64_t>& panel_rank_rows,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_hemm.cc
+++ b/src/internal/internal_hemm.cc
@@ -27,7 +27,7 @@ void hemm(Side side,
           scalar_t alpha, HermitianMatrix<scalar_t>&& A,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
-          int priority, Options const& opts)
+          int priority )
 {
     // check dimensions
     assert(A.mt() == 1);
@@ -48,7 +48,7 @@ void hemm(Side side,
          side,
          alpha, A, B,
          beta,  C,
-         priority, opts);
+         priority );
 }
 
 //------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ void hemm(internal::TargetType<Target::HostTask>,
           scalar_t alpha, HermitianMatrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          int priority, Options const& opts)
+          int priority )
 {
     // CPU uses ColMajor
     // todo: relax this assumption, by allowing Tile_blas.hh::hemm() to take layout param
@@ -137,7 +137,7 @@ void hemm(internal::TargetType<Target::HostNest>,
           scalar_t alpha, HermitianMatrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          int priority, Options const& opts)
+          int priority )
 {
     // CPU uses ColMajor
     // todo: relax this assumption, by allowing Tile_blas.hh::hemm() to take layout param
@@ -201,7 +201,7 @@ void hemm< Target::HostTask, float >(
     float alpha, HermitianMatrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemm<Target::HostNest, float>(
@@ -209,7 +209,7 @@ void hemm<Target::HostNest, float>(
     float alpha, HermitianMatrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -218,7 +218,7 @@ void hemm<Target::HostTask, double>(
     double alpha, HermitianMatrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemm<Target::HostNest, double>(
@@ -226,7 +226,7 @@ void hemm<Target::HostNest, double>(
     double alpha, HermitianMatrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -235,7 +235,7 @@ void hemm< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, HermitianMatrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemm< Target::HostNest, std::complex<float> >(
@@ -243,7 +243,7 @@ void hemm< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, HermitianMatrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -252,7 +252,7 @@ void hemm< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, HermitianMatrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemm< Target::HostNest, std::complex<double> >(
@@ -260,7 +260,7 @@ void hemm< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, HermitianMatrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_hemmA.cc
+++ b/src/internal/internal_hemmA.cc
@@ -28,7 +28,7 @@ void hemmA(Side side,
            scalar_t alpha, HermitianMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
            scalar_t beta,  Matrix<scalar_t>&& C,
-           int priority, Options const& opts)
+           int priority )
 {
     // check dimensions
     assert(A.mt() == 1);
@@ -50,7 +50,7 @@ void hemmA(Side side,
           alpha, A,
                  B,
           beta,  C,
-          priority, opts);
+          priority );
 }
 
 //------------------------------------------------------------------------------
@@ -64,7 +64,7 @@ void hemmA(internal::TargetType<Target::HostTask>,
            scalar_t alpha, HermitianMatrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  Matrix<scalar_t>& C,
-           int priority, Options const& opts)
+           int priority )
 {
     // CPU uses ColMajor
     // todo: relax this assumption, by allowing Tile_blas.hh::hemm() to take layout param
@@ -120,7 +120,7 @@ void hemmA(internal::TargetType<Target::HostNest>,
            scalar_t alpha, HermitianMatrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  Matrix<scalar_t>& C,
-           int priority, Options const& opts)
+           int priority )
 {
     // CPU uses ColMajor
     // todo: relax this assumption, by allowing Tile_blas.hh::hemm() to take layout param
@@ -184,7 +184,7 @@ void hemmA< Target::HostTask, float >(
     float alpha, HermitianMatrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemmA<Target::HostNest, float>(
@@ -192,7 +192,7 @@ void hemmA<Target::HostNest, float>(
     float alpha, HermitianMatrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -201,7 +201,7 @@ void hemmA<Target::HostTask, double>(
     double alpha, HermitianMatrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemmA<Target::HostNest, double>(
@@ -209,7 +209,7 @@ void hemmA<Target::HostNest, double>(
     double alpha, HermitianMatrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -218,7 +218,7 @@ void hemmA< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, HermitianMatrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemmA< Target::HostNest, std::complex<float> >(
@@ -226,7 +226,7 @@ void hemmA< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, HermitianMatrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -235,7 +235,7 @@ void hemmA< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, HermitianMatrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void hemmA< Target::HostNest, std::complex<double> >(
@@ -243,7 +243,7 @@ void hemmA< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, HermitianMatrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_her2k.cc
+++ b/src/internal/internal_her2k.cc
@@ -25,7 +25,7 @@ template <Target target, typename scalar_t>
 void her2k(scalar_t alpha,                  Matrix<scalar_t>&& A,
                                             Matrix<scalar_t>&& B,
            blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>&& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     if (! ((C.uplo() == Uplo::Lower)
            &&
@@ -39,7 +39,7 @@ void her2k(scalar_t alpha,                  Matrix<scalar_t>&& A,
           alpha, A,
                  B,
           beta,  C,
-          priority, queue_index, layout, opts);
+          priority, queue_index, layout );
 }
 
 //------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ void her2k(internal::TargetType<Target::HostTask>,
            scalar_t alpha,                 Matrix<scalar_t>& A,
                                            Matrix<scalar_t>& B,
            blas::real_type<scalar_t> beta, HermitianMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     using blas::conj;
 
@@ -137,7 +137,7 @@ void her2k(internal::TargetType<Target::HostNest>,
            scalar_t alpha,                 Matrix<scalar_t>& A,
                                            Matrix<scalar_t>& B,
            blas::real_type<scalar_t> beta, HermitianMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     using blas::conj;
 
@@ -225,7 +225,7 @@ void her2k(internal::TargetType<Target::HostBatch>,
            scalar_t alpha,                 Matrix<scalar_t>& A,
                                            Matrix<scalar_t>& B,
            blas::real_type<scalar_t> beta, HermitianMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
 #ifdef BLAS_HAVE_MKL
     using blas::conj;
@@ -410,7 +410,7 @@ void her2k(internal::TargetType<Target::Devices>,
            scalar_t alpha,                 Matrix<scalar_t>& A,
                                            Matrix<scalar_t>& B,
            blas::real_type<scalar_t> beta, HermitianMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     trace::Block trace_block_her2k("internal::her2k");
     using std::swap;
@@ -647,28 +647,28 @@ void her2k<Target::HostTask, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k<Target::HostNest, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k<Target::HostBatch, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k<Target::Devices, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
@@ -676,28 +676,28 @@ void her2k<Target::HostTask, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k<Target::HostNest, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k<Target::HostBatch, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k<Target::Devices, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
@@ -705,28 +705,28 @@ void her2k< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     float beta,                HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     float beta,                HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k< Target::HostBatch, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     float beta,                HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     float beta,                HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
@@ -734,28 +734,28 @@ void her2k< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     double beta,                HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     double beta,                HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k< Target::HostBatch, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     double beta,                HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void her2k< Target::Devices, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     double beta,                HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_herk.cc
+++ b/src/internal/internal_herk.cc
@@ -23,7 +23,7 @@ namespace internal {
 template <Target target, typename scalar_t>
 void herk(blas::real_type<scalar_t> alpha, Matrix<scalar_t>&& A,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>&& C,
-          int priority, int queue_index, Layout layout, Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
     if (! ((C.uplo() == Uplo::Lower)
            &&
@@ -34,7 +34,7 @@ void herk(blas::real_type<scalar_t> alpha, Matrix<scalar_t>&& A,
     herk(internal::TargetType<target>(),
          alpha, A,
          beta,  C,
-         priority, queue_index, layout, opts);
+         priority, queue_index, layout );
 }
 
 //------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ template <typename scalar_t>
 void herk(internal::TargetType<Target::HostTask>,
           blas::real_type<scalar_t> alpha, Matrix<scalar_t>& A,
           blas::real_type<scalar_t> beta,  HermitianMatrix< scalar_t >& C,
-          int priority, int queue_index, Layout layout, Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
     scalar_t alpha_ = scalar_t(alpha);
     scalar_t beta_  = scalar_t(beta);
@@ -119,7 +119,7 @@ template <typename scalar_t>
 void herk(internal::TargetType<Target::HostNest>,
           blas::real_type<scalar_t> alpha, Matrix<scalar_t>& A,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout, Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
 #if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
@@ -200,7 +200,7 @@ template <typename scalar_t>
 void herk(internal::TargetType<Target::HostBatch>,
           blas::real_type<scalar_t> alpha, Matrix<scalar_t>& A,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout, Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
 #ifdef BLAS_HAVE_MKL
     // CPU assumes column major
@@ -351,7 +351,7 @@ template <typename scalar_t>
 void herk(internal::TargetType<Target::Devices>,
           blas::real_type<scalar_t> alpha, Matrix<scalar_t>& A,
           blas::real_type<scalar_t> beta,  HermitianMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout, Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
     int err = 0;
     using std::swap;
@@ -541,100 +541,100 @@ template
 void herk<Target::HostTask, float>(
     float alpha, Matrix<float>&& A,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk<Target::HostNest, float>(
     float alpha, Matrix<float>&& A,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk<Target::HostBatch, float>(
     float alpha, Matrix<float>&& A,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk<Target::Devices, float>(
     float alpha, Matrix<float>&& A,
     float beta,  HermitianMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
 void herk<Target::HostTask, double>(
     double alpha, Matrix<double>&& A,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk<Target::HostNest, double>(
     double alpha, Matrix<double>&& A,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk<Target::HostBatch, double>(
     double alpha, Matrix<double>&& A,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk<Target::Devices, double>(
     double alpha, Matrix<double>&& A,
     double beta,  HermitianMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
 void herk< Target::HostTask, std::complex<float> >(
     float alpha, Matrix< std::complex<float> >&& A,
     float beta,  HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk< Target::HostNest, std::complex<float> >(
     float alpha, Matrix< std::complex<float> >&& A,
     float beta,  HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk< Target::HostBatch, std::complex<float> >(
     float alpha, Matrix< std::complex<float> >&& A,
     float beta,  HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk< Target::Devices, std::complex<float> >(
     float alpha, Matrix< std::complex<float> >&& A,
     float beta,  HermitianMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
 void herk< Target::HostTask, std::complex<double> >(
     double alpha, Matrix< std::complex<double> >&& A,
     double beta,  HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk< Target::HostNest, std::complex<double> >(
     double alpha, Matrix< std::complex<double> >&& A,
     double beta,  HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk< Target::HostBatch, std::complex<double> >(
     double alpha, Matrix< std::complex<double> >&& A,
     double beta,  HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void herk< Target::Devices, std::complex<double> >(
     double alpha, Matrix< std::complex<double> >&& A,
     double beta,  HermitianMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_hettmqr.cc
+++ b/src/internal/internal_hettmqr.cc
@@ -52,10 +52,10 @@ void hettmqr(
     Matrix<scalar_t>&& V,
     Matrix<scalar_t>&& T,
     HermitianMatrix<scalar_t>&& C,
-    int tag, Options const& opts )
+    int tag )
 {
     hettmqr( internal::TargetType<target>(),
-             op, V, T, C, tag, opts );
+             op, V, T, C, tag );
 }
 
 //------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ void hettmqr(
     Matrix<scalar_t>& V,
     Matrix<scalar_t>& T,
     HermitianMatrix<scalar_t>& C,
-    int tag_base, Options const& opts )
+    int tag_base )
 {
     trace::Block trace_block("internal::hettmqr");
     using blas::conj;
@@ -363,7 +363,7 @@ void hettmqr<Target::HostTask, float>(
     Matrix<float>&& V,
     Matrix<float>&& T,
     HermitianMatrix<float>&& C,
-    int tag, Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -372,7 +372,7 @@ void hettmqr<Target::HostTask, double>(
     Matrix<double>&& V,
     Matrix<double>&& T,
     HermitianMatrix<double>&& C,
-    int tag, Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -381,7 +381,7 @@ void hettmqr< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& V,
     Matrix< std::complex<float> >&& T,
     HermitianMatrix< std::complex<float> >&& C,
-    int tag, Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -390,7 +390,7 @@ void hettmqr< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& V,
     Matrix< std::complex<double> >&& T,
     HermitianMatrix< std::complex<double> >&& C,
-    int tag, Options const& opts);
+    int tag );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_norm1est.cc
+++ b/src/internal/internal_norm1est.cc
@@ -121,15 +121,6 @@ void norm1est_set(Matrix<int64_t>& isgn, Matrix<scalar_t>& A)
 ///     isave[2]: index of maximum element in X
 ///     isave[3]: number of iterations
 ///
-/// @param[in] opts
-///     Additional options, as map of name = value pairs. Possible options:
-///     - Option::Target:
-///       Implementation to target. Possible values:
-///       - HostTask:  OpenMP tasks on CPU host [default].
-///       - HostNest:  nested OpenMP parallel for loop on CPU host.
-///       - HostBatch: batched BLAS on CPU host.
-///       - Devices:   batched BLAS on GPU device.
-///
 /// Note in LAPACK, norm1est is lacn2
 ///
 /// @ingroup cond_internal
@@ -141,8 +132,7 @@ void norm1est(
            Matrix<int64_t>& isgn,
            blas::real_type<scalar_t>* est,
            int* kase,
-           std::vector<int64_t>& isave,
-           Options const& opts)
+           std::vector<int64_t>& isave )
 {
     using real_t = blas::real_type<scalar_t>;
     using blas::real;
@@ -489,8 +479,7 @@ void norm1est<float>(
     Matrix<int64_t>& isgn,
     float* est,
     int* kase,
-    std::vector<int64_t>& isave,
-    Options const& opts);
+    std::vector<int64_t>& isave );
 
 template
 void norm1est<double>(
@@ -499,8 +488,7 @@ void norm1est<double>(
     Matrix<int64_t>& isgn,
     double* est,
     int* kase,
-    std::vector<int64_t>& isave,
-    Options const& opts);
+    std::vector<int64_t>& isave );
 
 template
 void norm1est< std::complex<float> >(
@@ -509,8 +497,7 @@ void norm1est< std::complex<float> >(
     Matrix<int64_t>& isgn,
     float* est,
     int* kase,
-    std::vector<int64_t>& isave,
-    Options const& opts);
+    std::vector<int64_t>& isave );
 
 template
 void norm1est< std::complex<double> >(
@@ -519,8 +506,7 @@ void norm1est< std::complex<double> >(
     Matrix<int64_t>& isgn,
     double* est,
     int* kase,
-    std::vector<int64_t>& isave,
-    Options const& opts);
+    std::vector<int64_t>& isave );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_symm.cc
+++ b/src/internal/internal_symm.cc
@@ -27,7 +27,7 @@ void symm(Side side,
           scalar_t alpha, SymmetricMatrix<scalar_t>&& A,
                           Matrix<scalar_t>&& B,
           scalar_t beta,  Matrix<scalar_t>&& C,
-          int priority, Options const& opts)
+          int priority )
 {
     // check dimensions
     assert(A.mt() == 1);
@@ -48,7 +48,7 @@ void symm(Side side,
          side,
          alpha, A, B,
          beta,  C,
-         priority, opts);
+         priority );
 }
 
 //------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ void symm(internal::TargetType<Target::HostTask>,
           scalar_t alpha, SymmetricMatrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          int priority, Options const& opts)
+          int priority )
 {
     // CPU uses ColMajor
     // todo: relax this assumption, by allowing Tile_blas.hh::symm() to take layout param
@@ -137,7 +137,7 @@ void symm(internal::TargetType<Target::HostNest>,
           scalar_t alpha, SymmetricMatrix<scalar_t>& A,
                           Matrix<scalar_t>& B,
           scalar_t beta,  Matrix<scalar_t>& C,
-          int priority, Options const& opts)
+          int priority )
 {
     // CPU uses ColMajor
     // todo: relax this assumption, by allowing Tile_blas.hh::symm() to take layout param
@@ -201,7 +201,7 @@ void symm<Target::HostTask, float>(
     float alpha, SymmetricMatrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void symm<Target::HostNest, float>(
@@ -209,7 +209,7 @@ void symm<Target::HostNest, float>(
     float alpha, SymmetricMatrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  Matrix<float>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -218,7 +218,7 @@ void symm<Target::HostTask, double>(
     double alpha, SymmetricMatrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void symm<Target::HostNest, double>(
@@ -226,7 +226,7 @@ void symm<Target::HostNest, double>(
     double alpha, SymmetricMatrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  Matrix<double>&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -235,7 +235,7 @@ void symm< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, SymmetricMatrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void symm< Target::HostNest, std::complex<float> >(
@@ -243,7 +243,7 @@ void symm< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, SymmetricMatrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  Matrix< std::complex<float> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 // ----------------------------------------
 template
@@ -252,7 +252,7 @@ void symm< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, SymmetricMatrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 template
 void symm< Target::HostNest, std::complex<double> >(
@@ -260,7 +260,7 @@ void symm< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, SymmetricMatrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  Matrix< std::complex<double> >&& C,
-    int priority, Options const& opts);
+    int priority );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_symm.cc
+++ b/src/internal/internal_symm.cc
@@ -70,12 +70,6 @@ void symm(internal::TargetType<Target::HostTask>,
     //       by watching 'layout' and 'C(i, j).layout()'
     const Layout layout = Layout::ColMajor;
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     int err = 0;
     #pragma omp taskgroup
     if (side == Side::Left) {
@@ -83,7 +77,7 @@ void symm(internal::TargetType<Target::HostTask>,
             if (C.tileIsLocal(0, j)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B, C, err ) \
-                    firstprivate(j, layout, side, alpha, beta, call_tile_tick) \
+                    firstprivate( j, layout, side, alpha, beta ) \
                     priority(priority)
                 {
                     try {
@@ -94,11 +88,6 @@ void symm(internal::TargetType<Target::HostTask>,
                             side,
                             alpha, A(0, 0), B(0, j),
                             beta,  C(0, j) );
-                        if (call_tile_tick) {
-                            // todo: should tileRelease()?
-                            A.tileTick(0, 0);
-                            B.tileTick(0, j);
-                        }
                     }
                     catch (std::exception& e) {
                         err = __LINE__;
@@ -113,7 +102,7 @@ void symm(internal::TargetType<Target::HostTask>,
             if (C.tileIsLocal(i, 0)) {
                 #pragma omp task slate_omp_default_none \
                     shared( A, B, C, err ) \
-                    firstprivate(i, layout, side, alpha, beta, call_tile_tick) \
+                    firstprivate( i, layout, side, alpha, beta ) \
                     priority(priority)
                 {
                     try {
@@ -124,11 +113,6 @@ void symm(internal::TargetType<Target::HostTask>,
                             side,
                             alpha, A(0, 0), B(i, 0),
                             beta,  C(i, 0) );
-                        if (call_tile_tick) {
-                            // todo: should tileRelease()?
-                            A.tileTick(0, 0);
-                            B.tileTick(i, 0);
-                        }
                     }
                     catch (std::exception& e) {
                         err = __LINE__;
@@ -161,16 +145,10 @@ void symm(internal::TargetType<Target::HostNest>,
     //       by watching 'layout' and 'C(i, j).layout()'
     const Layout layout = Layout::ColMajor;
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     int err = 0;
     if (side == Side::Left) {
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(layout, side, alpha, beta, call_tile_tick)
+            shared( A, B, C, err ) firstprivate( layout, side, alpha, beta )
         for (int64_t j = 0; j < C.nt(); ++j) {
             if (C.tileIsLocal(0, j)) {
                 try {
@@ -181,11 +159,6 @@ void symm(internal::TargetType<Target::HostNest>,
                         side,
                         alpha, A(0, 0), B(0, j),
                         beta,  C(0, j) );
-                    if (call_tile_tick) {
-                        // todo: should tileRelease()?
-                        A.tileTick(0, 0);
-                        B.tileTick(0, j);
-                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;
@@ -196,7 +169,7 @@ void symm(internal::TargetType<Target::HostNest>,
     else {
         // side == Right
         #pragma omp parallel for schedule(dynamic, 1) slate_omp_default_none \
-            shared(A, B, C, err) firstprivate(layout, side, alpha, beta, call_tile_tick)
+            shared( A, B, C, err ) firstprivate( layout, side, alpha, beta )
         for (int64_t i = 0; i < C.mt(); ++i) {
             if (C.tileIsLocal(i, 0)) {
                 try {
@@ -207,11 +180,6 @@ void symm(internal::TargetType<Target::HostNest>,
                         side,
                         alpha, A(0, 0), B(i, 0),
                         beta,  C(i, 0) );
-                    if (call_tile_tick) {
-                        // todo: should tileRelease()?
-                        A.tileTick(0, 0);
-                        B.tileTick(i, 0);
-                    }
                 }
                 catch (std::exception& e) {
                     err = __LINE__;

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -390,7 +390,6 @@ void norm(internal::TargetType<Target::Devices>,
                           (! lower && i <= j) ))
                     {
                         A_tiles_set.insert({i, j});
-                        // todo: should tileRelease() after?
                     }
                 }
             }

--- a/src/internal/internal_syr2k.cc
+++ b/src/internal/internal_syr2k.cc
@@ -25,7 +25,7 @@ template <Target target, typename scalar_t>
 void syr2k(scalar_t alpha, Matrix<scalar_t>&& A,
                            Matrix<scalar_t>&& B,
            scalar_t beta,  SymmetricMatrix<scalar_t>&& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     if (! ((C.uplo() == Uplo::Lower)
            &&
@@ -39,7 +39,7 @@ void syr2k(scalar_t alpha, Matrix<scalar_t>&& A,
           alpha, A,
                  B,
           beta,  C,
-          priority, queue_index, layout, opts);
+          priority, queue_index, layout );
 }
 
 //------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ void syr2k(internal::TargetType<Target::HostTask>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::syr2k()
@@ -133,7 +133,7 @@ void syr2k(internal::TargetType<Target::HostNest>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
 #if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
@@ -217,7 +217,7 @@ void syr2k(internal::TargetType<Target::HostBatch>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
 #ifdef BLAS_HAVE_MKL
     // CPU assumes column major
@@ -393,7 +393,7 @@ void syr2k(internal::TargetType<Target::Devices>,
            scalar_t alpha, Matrix<scalar_t>& A,
                            Matrix<scalar_t>& B,
            scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-           int priority, int queue_index, Layout layout, Options const& opts)
+           int priority, int queue_index, Layout layout )
 {
     using std::swap;
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
@@ -624,28 +624,28 @@ void syr2k<Target::HostTask, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k<Target::HostNest, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k<Target::HostBatch, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k<Target::Devices, float>(
     float alpha, Matrix<float>&& A,
                  Matrix<float>&& B,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
@@ -653,28 +653,28 @@ void syr2k<Target::HostTask, double>(
     double alpha, Matrix<double>&& A,
                            Matrix<double>&& B,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k<Target::HostNest, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k<Target::HostBatch, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k<Target::Devices, double>(
     double alpha, Matrix<double>&& A,
                   Matrix<double>&& B,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
@@ -682,28 +682,28 @@ void syr2k< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k< Target::HostBatch, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
                                Matrix< std::complex<float> >&& B,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
@@ -711,28 +711,28 @@ void syr2k< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k< Target::HostBatch, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syr2k< Target::Devices, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
                                 Matrix< std::complex<double> >&& B,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_syrk.cc
+++ b/src/internal/internal_syrk.cc
@@ -23,8 +23,7 @@ namespace internal {
 template <Target target, typename scalar_t>
 void syrk(scalar_t alpha, Matrix<scalar_t>&& A,
           scalar_t beta,  SymmetricMatrix<scalar_t>&& C,
-          int priority, int queue_index, Layout layout,
-          Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
     if (! ((C.uplo() == Uplo::Lower)
            &&
@@ -35,7 +34,7 @@ void syrk(scalar_t alpha, Matrix<scalar_t>&& A,
     syrk(internal::TargetType<target>(),
          alpha, A,
          beta,  C,
-         priority, queue_index, layout, opts);
+         priority, queue_index, layout );
 }
 
 //------------------------------------------------------------------------------
@@ -48,8 +47,7 @@ template <typename scalar_t>
 void syrk(internal::TargetType<Target::HostTask>,
           scalar_t alpha, Matrix<scalar_t>& A,
           scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout,
-          Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
     // CPU assumes column major
     // todo: relax this assumption, by updating Tile_blas.hh::syrk()
@@ -120,8 +118,7 @@ template <typename scalar_t>
 void syrk(internal::TargetType<Target::HostNest>,
           scalar_t alpha, Matrix<scalar_t>& A,
           scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout,
-          Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
 #if defined(SLATE_HAVE_OMPTARGET) || defined(SLATE_SKIP_HOSTNEST)
     // SYCL/OMP-target-offload can't process this section
@@ -199,8 +196,7 @@ template <typename scalar_t>
 void syrk(internal::TargetType<Target::HostBatch>,
           scalar_t alpha, Matrix<scalar_t>& A,
           scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout,
-          Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
 #ifdef BLAS_HAVE_MKL
     // CPU assumes column major
@@ -350,8 +346,7 @@ template <typename scalar_t>
 void syrk(internal::TargetType<Target::Devices>,
           scalar_t alpha, Matrix<scalar_t>& A,
           scalar_t beta,  SymmetricMatrix<scalar_t>& C,
-          int priority, int queue_index, Layout layout,
-          Options const& opts)
+          int priority, int queue_index, Layout layout )
 {
     int err = 0;
     using std::swap;
@@ -538,100 +533,100 @@ template
 void syrk<Target::HostTask, float>(
     float alpha, Matrix<float>&& A,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk<Target::HostNest, float>(
     float alpha, Matrix<float>&& A,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk<Target::HostBatch, float>(
     float alpha, Matrix<float>&& A,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk<Target::Devices, float>(
     float alpha, Matrix<float>&& A,
     float beta,  SymmetricMatrix<float>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
 void syrk<Target::HostTask, double>(
     double alpha, Matrix<double>&& A,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk<Target::HostNest, double>(
     double alpha, Matrix<double>&& A,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk<Target::HostBatch, double>(
     double alpha, Matrix<double>&& A,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk<Target::Devices, double>(
     double alpha, Matrix<double>&& A,
     double beta,  SymmetricMatrix<double>&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
 void syrk< Target::HostTask, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk< Target::HostNest, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk< Target::HostBatch, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk< Target::Devices, std::complex<float> >(
     std::complex<float> alpha, Matrix< std::complex<float> >&& A,
     std::complex<float> beta,  SymmetricMatrix< std::complex<float> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 // ----------------------------------------
 template
 void syrk< Target::HostTask, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk< Target::HostNest, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk< Target::HostBatch, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 template
 void syrk< Target::Devices, std::complex<double> >(
     std::complex<double> alpha, Matrix< std::complex<double> >&& A,
     std::complex<double> beta,  SymmetricMatrix< std::complex<double> >&& C,
-    int priority, int queue_index, Layout layout, Options const& opts);
+    int priority, int queue_index, Layout layout );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_trmm.cc
+++ b/src/internal/internal_trmm.cc
@@ -22,14 +22,13 @@ template <Target target, typename scalar_t>
 void trmm(Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
-          int priority, int64_t queue_index,
-          Options const& opts )
+          int priority, int64_t queue_index )
 {
     trmm(internal::TargetType<target>(),
          side,
          alpha, A,
                 B,
-         priority, queue_index, opts);
+         priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -42,8 +41,7 @@ void trmm(internal::TargetType<Target::HostTask>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, int64_t queue_index,
-          Options const& opts )
+          int priority, int64_t queue_index )
 {
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::trmm() to take layout param
@@ -102,8 +100,7 @@ void trmm(internal::TargetType<Target::HostNest>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, int64_t queue_index,
-          Options const& opts )
+          int priority, int64_t queue_index )
 {
     slate_not_implemented("Target::HostNest isn't yet supported.");
 }
@@ -118,8 +115,7 @@ void trmm(internal::TargetType<Target::HostBatch>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, int64_t queue_index,
-          Options const& opts )
+          int priority, int64_t queue_index )
 {
     slate_not_implemented("Target::HostBatch isn't yet supported.");
 }
@@ -133,8 +129,7 @@ void trmm(internal::TargetType<Target::Devices>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, int64_t queue_index,
-          Options const& opts )
+          int priority, int64_t queue_index )
 {
     // CPU assumes column major
     const Layout layout = Layout::ColMajor;
@@ -272,8 +267,7 @@ void trmm<Target::HostTask, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -281,8 +275,7 @@ void trmm<Target::HostTask, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -290,8 +283,7 @@ void trmm< Target::HostTask, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -299,8 +291,7 @@ void trmm< Target::HostTask, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -308,8 +299,7 @@ void trmm<Target::HostNest, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -317,8 +307,7 @@ void trmm<Target::HostNest, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -326,8 +315,7 @@ void trmm< Target::HostNest, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -335,8 +323,7 @@ void trmm< Target::HostNest, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -344,8 +331,7 @@ void trmm<Target::HostBatch, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -353,8 +339,7 @@ void trmm<Target::HostBatch, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -362,8 +347,7 @@ void trmm< Target::HostBatch, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -371,8 +355,7 @@ void trmm< Target::HostBatch, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -380,8 +363,7 @@ void trmm<Target::Devices, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -389,8 +371,7 @@ void trmm<Target::Devices, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -398,8 +379,7 @@ void trmm< Target::Devices, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -407,8 +387,7 @@ void trmm< Target::Devices, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, int64_t queue_index,
-    Options const& opts );
+    int priority, int64_t queue_index );
 
 
 } // namespace internal

--- a/src/internal/internal_trsm.cc
+++ b/src/internal/internal_trsm.cc
@@ -22,14 +22,13 @@ template <Target target, typename scalar_t>
 void trsm(Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                     Matrix<scalar_t>&& B,
-          int priority, Layout layout, int64_t queue_index,
-          Options const& opts)
+          int priority, Layout layout, int64_t queue_index )
 {
     trsm(internal::TargetType<target>(),
          side,
          alpha, A,
                 B,
-         priority, layout, queue_index, opts);
+         priority, layout, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -42,8 +41,7 @@ void trsm(internal::TargetType<Target::HostTask>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, Layout layout, int64_t queue_index,
-          Options const& opts)
+          int priority, Layout layout, int64_t queue_index )
 {
     // CPU assumes column major
     // todo: relax this assumption, by allowing Tile_blas.hh::trsm()
@@ -103,11 +101,10 @@ void trsm(internal::TargetType<Target::HostNest>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, Layout layout, int64_t queue_index,
-          Options const& opts)
+          int priority, Layout layout, int64_t queue_index )
 {
     trsm( internal::TargetType<Target::HostTask>(),
-            side, alpha, A, B, priority, layout, queue_index, opts );
+            side, alpha, A, B, priority, layout, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -120,11 +117,10 @@ void trsm(internal::TargetType<Target::HostBatch>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, Layout layout, int64_t queue_index,
-          Options const& opts)
+          int priority, Layout layout, int64_t queue_index )
 {
     trsm( internal::TargetType<Target::HostTask>(),
-            side, alpha, A, B, priority, layout, queue_index, opts );
+            side, alpha, A, B, priority, layout, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -137,8 +133,7 @@ void trsm(internal::TargetType<Target::Devices>,
           Side side,
           scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                     Matrix<scalar_t>& B,
-          int priority, Layout layout, int64_t queue_index,
-          Options const& opts)
+          int priority, Layout layout, int64_t queue_index )
 {
     using std::swap;
     using blas::conj;
@@ -273,32 +268,28 @@ void trsm<Target::HostTask, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm<Target::HostNest, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm<Target::HostBatch, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm<Target::Devices, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -306,32 +297,28 @@ void trsm<Target::HostTask, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm<Target::HostNest, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm<Target::HostBatch, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm<Target::Devices, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -339,32 +326,28 @@ void trsm< Target::HostTask, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm< Target::HostNest, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm< Target::HostBatch, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm< Target::Devices, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -372,32 +355,28 @@ void trsm< Target::HostTask, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm< Target::HostNest, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm< Target::HostBatch, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsm< Target::Devices, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_trsmA.cc
+++ b/src/internal/internal_trsmA.cc
@@ -24,8 +24,7 @@ template <Target target, typename scalar_t>
 void trsmA(Side side,
            scalar_t alpha, TriangularMatrix<scalar_t>&& A,
                                      Matrix<scalar_t>&& B,
-           int priority, Layout layout, int64_t queue_index,
-           Options const& opts)
+           int priority, Layout layout, int64_t queue_index )
 {
     assert( A.mt() == 1 );
     assert( side == Side::Left ? A.mt() == B.mt() : A.mt() == B.nt() );
@@ -34,7 +33,7 @@ void trsmA(Side side,
           side,
           alpha, A,
                  B,
-          priority, layout, queue_index, opts );
+          priority, layout, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -47,8 +46,7 @@ void trsmA(internal::TargetType<Target::HostTask>,
            Side side,
            scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                      Matrix<scalar_t>& B,
-           int priority, Layout layout, int64_t queue_index,
-           Options const& opts)
+           int priority, Layout layout, int64_t queue_index )
 {
 
     // CPU assumes column major
@@ -104,13 +102,12 @@ void trsmA(internal::TargetType<Target::HostNest>,
            Side side,
            scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                      Matrix<scalar_t>& B,
-           int priority, Layout layout, int64_t queue_index,
-           Options const& opts)
+           int priority, Layout layout, int64_t queue_index )
 {
     trsmA( internal::TargetType<Target::HostTask>(),
             side,
             alpha, A, B,
-            priority, layout, queue_index, opts );
+            priority, layout, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -123,13 +120,12 @@ void trsmA(internal::TargetType<Target::HostBatch>,
            Side side,
            scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                      Matrix<scalar_t>& B,
-           int priority, Layout layout, int64_t queue_index,
-           Options const& opts)
+           int priority, Layout layout, int64_t queue_index )
 {
     trsmA( internal::TargetType<Target::HostTask>(),
             side,
             alpha, A, B,
-            priority, layout, queue_index, opts );
+            priority, layout, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -142,8 +138,7 @@ void trsmA(internal::TargetType<Target::Devices>,
            Side side,
            scalar_t alpha, TriangularMatrix<scalar_t>& A,
                                      Matrix<scalar_t>& B,
-           int priority, Layout layout, int64_t queue_index,
-           Options const& opts)
+           int priority, Layout layout, int64_t queue_index )
 {
     using std::swap;
     using blas::conj;
@@ -359,32 +354,28 @@ void trsmA<Target::HostTask, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA<Target::HostNest, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA<Target::HostBatch, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA<Target::Devices, float>(
     Side side,
     float alpha, TriangularMatrix<float>&& A,
                            Matrix<float>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -392,32 +383,28 @@ void trsmA<Target::HostTask, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA<Target::HostNest, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA<Target::HostBatch, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA<Target::Devices, double>(
     Side side,
     double alpha, TriangularMatrix<double>&& A,
                             Matrix<double>&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -425,32 +412,28 @@ void trsmA< Target::HostTask, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA< Target::HostNest, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA< Target::HostBatch, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA< Target::Devices, std::complex<float> >(
     Side side,
     std::complex<float> alpha, TriangularMatrix< std::complex<float> >&& A,
                                          Matrix< std::complex<float> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -458,32 +441,28 @@ void trsmA< Target::HostTask, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA< Target::HostNest, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA< Target::HostBatch, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 template
 void trsmA< Target::Devices, std::complex<double> >(
     Side side,
     std::complex<double> alpha, TriangularMatrix< std::complex<double> >&& A,
                                           Matrix< std::complex<double> >&& B,
-    int priority, Layout layout, int64_t queue_index,
-    Options const& opts);
+    int priority, Layout layout, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_trsmA.cc
+++ b/src/internal/internal_trsmA.cc
@@ -159,9 +159,6 @@ void trsmA(internal::TargetType<Target::Devices>,
     assert(B.num_devices() > 0);
     assert(B.uploPhysical() == Uplo::General);
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
     Uplo uploA = A.uploPhysical();
     Diag diagA = A.diag();
     Op opA = A.op();
@@ -348,15 +345,6 @@ void trsmA(internal::TargetType<Target::Devices>,
                         b_array_host += group_count;
                     }
                     queue->sync();
-                }
-
-                if (tile_release_strategy == TileReleaseStrategy::Internal
-                    || tile_release_strategy == TileReleaseStrategy::All)
-                {
-                    A.tileRelease( 0, 0, device );
-                    for (auto i = 0; i < batch_size; ++i) {
-                        A.tileTick( 0, 0 );
-                    }
                 }
             }
         }

--- a/src/internal/internal_ttlqt.cc
+++ b/src/internal/internal_ttlqt.cc
@@ -20,11 +20,10 @@ namespace internal {
 ///
 template <Target target, typename scalar_t>
 void ttlqt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T,
-           Options const& opts)
+           Matrix<scalar_t>&& T )
 {
     ttlqt(internal::TargetType<target>(),
-          A, T, opts);
+          A, T );
 }
 
 //------------------------------------------------------------------------------
@@ -35,8 +34,7 @@ void ttlqt(Matrix<scalar_t>&& A,
 template <typename scalar_t>
 void ttlqt(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& A,
-           Matrix<scalar_t>& T,
-           Options const& opts)
+           Matrix<scalar_t>& T )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -137,29 +135,25 @@ void ttlqt(internal::TargetType<Target::HostTask>,
 template
 void ttlqt<Target::HostTask, float>(
     Matrix<float>&& A,
-    Matrix<float>&& T,
-    Options const& opts);
+    Matrix<float>&& T );
 
 // ----------------------------------------
 template
 void ttlqt<Target::HostTask, double>(
     Matrix<double>&& A,
-    Matrix<double>&& T,
-    Options const& opts);
+    Matrix<double>&& T );
 
 // ----------------------------------------
 template
 void ttlqt< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
-    Matrix< std::complex<float> >&& T,
-    Options const& opts);
+    Matrix< std::complex<float> >&& T );
 
 // ----------------------------------------
 template
 void ttlqt< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
-    Matrix< std::complex<double> >&& T,
-    Options const& opts);
+    Matrix< std::complex<double> >&& T );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_ttlqt.cc
+++ b/src/internal/internal_ttlqt.cc
@@ -38,12 +38,6 @@ void ttlqt(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& T,
            Options const& opts)
 {
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -130,9 +124,6 @@ void ttlqt(internal::TargetType<Target::HostTask>,
 
                 // Send updated tile back. This rank is done!
                 A.tileSend(0, j_src, src);
-                if (call_tile_tick) {
-                    A.tileTick(0, j_src);
-                }
                 break;
             }
             step *= 2;

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -58,14 +58,6 @@ void ttmlq(internal::TargetType<Target::HostTask>,
     else
         assert(A_nt == C.nt());
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-    // This routine assumes that tiles are never ticked for optimization's sake
-    assert( !call_tile_tick );
-
     // Find ranks in this row of A.
     std::set<int> ranks_set;
     A.getRanks(&ranks_set);

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -27,11 +27,10 @@ void ttmlq(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag,
-           Options const& opts)
+           int tag )
 {
     ttmlq(internal::TargetType<target>(),
-          side, op, A, T, C, tag, opts);
+          side, op, A, T, C, tag );
 }
 
 //------------------------------------------------------------------------------
@@ -45,8 +44,7 @@ void ttmlq(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& A,
            Matrix<scalar_t>& T,
            Matrix<scalar_t>& C,
-           int tag,
-           Options const& opts)
+           int tag )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -301,8 +299,7 @@ void ttmlq<Target::HostTask, float>(
     Matrix<float>&& A,
     Matrix<float>&& T,
     Matrix<float>&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -311,8 +308,7 @@ void ttmlq<Target::HostTask, double>(
     Matrix<double>&& A,
     Matrix<double>&& T,
     Matrix<double>&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -321,8 +317,7 @@ void ttmlq< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -331,8 +326,7 @@ void ttmlq< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -58,14 +58,6 @@ void ttmqr(internal::TargetType<Target::HostTask>,
     else
         assert(A_mt == C.nt());
 
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-    // This routine assumes that tiles are never ticked for optimization's sake
-    assert( ! call_tile_tick );
-
     // Find ranks in this column of A.
     std::set<int> ranks_set;
     A.getRanks(&ranks_set);
@@ -291,7 +283,6 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                 #pragma omp taskwait
                 slate_mpi_call(
                     MPI_Waitall( requests.size(), requests.data(), MPI_STATUSES_IGNORE ) );
-
             }
             break;
         }

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -27,11 +27,10 @@ void ttmqr(Side side, Op op,
            Matrix<scalar_t>&& A,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
-           int tag,
-           Options const& opts )
+           int tag )
 {
     ttmqr(internal::TargetType<target>(),
-          side, op, A, T, C, tag, opts);
+          side, op, A, T, C, tag );
 }
 
 //------------------------------------------------------------------------------
@@ -45,8 +44,7 @@ void ttmqr(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& A,
            Matrix<scalar_t>& T,
            Matrix<scalar_t>& C,
-           int tag,
-           Options const& opts )
+           int tag )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -302,8 +300,7 @@ void ttmqr<Target::HostTask, float>(
     Matrix<float>&& A,
     Matrix<float>&& T,
     Matrix<float>&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -312,8 +309,7 @@ void ttmqr<Target::HostTask, double>(
     Matrix<double>&& A,
     Matrix<double>&& T,
     Matrix<double>&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -322,8 +318,7 @@ void ttmqr< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 // ----------------------------------------
 template
@@ -332,8 +327,7 @@ void ttmqr< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
-    int tag,
-    Options const& opts);
+    int tag );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_ttqrt.cc
+++ b/src/internal/internal_ttqrt.cc
@@ -38,12 +38,6 @@ void ttqrt(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& T,
            Options const& opts)
 {
-    TileReleaseStrategy tile_release_strategy = get_option(
-            opts, Option::TileReleaseStrategy, TileReleaseStrategy::All );
-
-    bool call_tile_tick = tile_release_strategy == TileReleaseStrategy::Internal
-                          || tile_release_strategy == TileReleaseStrategy::All;
-
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -130,9 +124,6 @@ void ttqrt(internal::TargetType<Target::HostTask>,
 
                 // Send updated tile back. This rank is done!
                 A.tileSend(i_src, 0, src);
-                if (call_tile_tick) {
-                    A.tileTick(i_src, 0);
-                }
                 break;
             }
             step *= 2;

--- a/src/internal/internal_ttqrt.cc
+++ b/src/internal/internal_ttqrt.cc
@@ -20,11 +20,10 @@ namespace internal {
 ///
 template <Target target, typename scalar_t>
 void ttqrt(Matrix<scalar_t>&& A,
-           Matrix<scalar_t>&& T,
-           Options const& opts)
+           Matrix<scalar_t>&& T )
 {
     ttqrt(internal::TargetType<target>(),
-          A, T, opts);
+          A, T );
 }
 
 //------------------------------------------------------------------------------
@@ -35,8 +34,7 @@ void ttqrt(Matrix<scalar_t>&& A,
 template <typename scalar_t>
 void ttqrt(internal::TargetType<Target::HostTask>,
            Matrix<scalar_t>& A,
-           Matrix<scalar_t>& T,
-           Options const& opts)
+           Matrix<scalar_t>& T )
 {
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -137,29 +135,25 @@ void ttqrt(internal::TargetType<Target::HostTask>,
 template
 void ttqrt<Target::HostTask, float>(
     Matrix<float>&& A,
-    Matrix<float>&& T,
-    Options const& opts);
+    Matrix<float>&& T );
 
 // ----------------------------------------
 template
 void ttqrt<Target::HostTask, double>(
     Matrix<double>&& A,
-    Matrix<double>&& T,
-    Options const& opts);
+    Matrix<double>&& T );
 
 // ----------------------------------------
 template
 void ttqrt< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& A,
-    Matrix< std::complex<float> >&& T,
-    Options const& opts);
+    Matrix< std::complex<float> >&& T );
 
 // ----------------------------------------
 template
 void ttqrt< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& A,
-    Matrix< std::complex<double> >&& T,
-    Options const& opts);
+    Matrix< std::complex<double> >&& T );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_tzadd.cc
+++ b/src/internal/internal_tzadd.cc
@@ -21,12 +21,12 @@ namespace internal {
 template <Target target, typename scalar_t>
 void add(scalar_t alpha, BaseTrapezoidMatrix<scalar_t>&& A,
          scalar_t beta, BaseTrapezoidMatrix<scalar_t>&& B,
-         int priority, int queue_index, Options const& opts)
+         int priority, int queue_index )
 {
     add(internal::TargetType<target>(),
         alpha, A,
         beta,  B,
-        priority, queue_index, opts);
+        priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -39,7 +39,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostTask>,
            scalar_t alpha, BaseTrapezoidMatrix<scalar_t>& A,
            scalar_t beta, BaseTrapezoidMatrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+           int priority, int queue_index )
 {
     // trace::Block trace_block("add");
 
@@ -94,7 +94,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostNest>,
            scalar_t alpha, BaseTrapezoidMatrix<scalar_t>& A,
            scalar_t beta, BaseTrapezoidMatrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+           int priority, int queue_index )
 {
     slate_not_implemented("Target::HostNest isn't yet supported.");
 }
@@ -104,7 +104,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::HostBatch>,
            scalar_t alpha, BaseTrapezoidMatrix<scalar_t>& A,
            scalar_t beta, BaseTrapezoidMatrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+           int priority, int queue_index )
 {
     slate_not_implemented("Target::HostBatch isn't yet supported.");
 }
@@ -119,7 +119,7 @@ template <typename scalar_t>
 void add(internal::TargetType<Target::Devices>,
            scalar_t alpha, BaseTrapezoidMatrix<scalar_t>& A,
            scalar_t beta, BaseTrapezoidMatrix<scalar_t>& B,
-           int priority, int queue_index, Options const& opts)
+           int priority, int queue_index )
 {
     using ij_tuple = typename BaseMatrix<scalar_t>::ij_tuple;
     slate_error_if(A.uplo() != B.uplo());
@@ -224,100 +224,100 @@ template
 void add<Target::HostTask, float>(
      float alpha, BaseTrapezoidMatrix<float>&& A,
      float beta, BaseTrapezoidMatrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostNest, float>(
      float alpha, BaseTrapezoidMatrix<float>&& A,
      float beta, BaseTrapezoidMatrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostBatch, float>(
      float alpha, BaseTrapezoidMatrix<float>&& A,
      float beta, BaseTrapezoidMatrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::Devices, float>(
      float alpha, BaseTrapezoidMatrix<float>&& A,
      float beta, BaseTrapezoidMatrix<float>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 // ----------------------------------------
 template
 void add<Target::HostTask, double>(
      double alpha, BaseTrapezoidMatrix<double>&& A,
      double beta, BaseTrapezoidMatrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostNest, double>(
      double alpha, BaseTrapezoidMatrix<double>&& A,
      double beta, BaseTrapezoidMatrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::HostBatch, double>(
      double alpha, BaseTrapezoidMatrix<double>&& A,
      double beta, BaseTrapezoidMatrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add<Target::Devices, double>(
      double alpha, BaseTrapezoidMatrix<double>&& A,
      double beta, BaseTrapezoidMatrix<double>&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 // ----------------------------------------
 template
 void add< Target::HostTask, std::complex<float> >(
      std::complex<float> alpha, BaseTrapezoidMatrix< std::complex<float> >&& A,
      std::complex<float>  beta, BaseTrapezoidMatrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostNest, std::complex<float> >(
      std::complex<float> alpha, BaseTrapezoidMatrix< std::complex<float> >&& A,
      std::complex<float>  beta, BaseTrapezoidMatrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostBatch, std::complex<float> >(
      std::complex<float> alpha, BaseTrapezoidMatrix< std::complex<float> >&& A,
      std::complex<float>  beta, BaseTrapezoidMatrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::Devices, std::complex<float> >(
      std::complex<float> alpha, BaseTrapezoidMatrix< std::complex<float> >&& A,
      std::complex<float>  beta, BaseTrapezoidMatrix< std::complex<float> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 // ----------------------------------------
 template
 void add< Target::HostTask, std::complex<double> >(
      std::complex<double> alpha, BaseTrapezoidMatrix< std::complex<double> >&& A,
      std::complex<double> beta, BaseTrapezoidMatrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostNest, std::complex<double> >(
      std::complex<double> alpha, BaseTrapezoidMatrix< std::complex<double> >&& A,
      std::complex<double> beta, BaseTrapezoidMatrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::HostBatch, std::complex<double> >(
      std::complex<double> alpha, BaseTrapezoidMatrix< std::complex<double> >&& A,
      std::complex<double> beta, BaseTrapezoidMatrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 template
 void add< Target::Devices, std::complex<double> >(
      std::complex<double> alpha, BaseTrapezoidMatrix< std::complex<double> >&& A,
      std::complex<double> beta, BaseTrapezoidMatrix< std::complex<double> >&& B,
-     int priority, int queue_index, Options const& opts);
+     int priority, int queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -23,12 +23,11 @@ namespace internal {
 template <Target target, typename src_scalar_t, typename dst_scalar_t>
 void copy(BaseTrapezoidMatrix<src_scalar_t>&& A,
           BaseTrapezoidMatrix<dst_scalar_t>&& B,
-          int priority, int queue_index,
-          Options const& opts)
+          int priority, int queue_index )
 {
     copy(internal::TargetType<target>(),
          A, B,
-         priority, queue_index, opts);
+         priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -42,8 +41,7 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::HostTask>,
           BaseTrapezoidMatrix<src_scalar_t>& A,
           BaseTrapezoidMatrix<dst_scalar_t>& B,
-          int priority, int queue_index,
-          Options const& opts)
+          int priority, int queue_index )
 {
     // trace::Block trace_block("copy");
 
@@ -105,8 +103,7 @@ template <typename src_scalar_t, typename dst_scalar_t>
 void copy(internal::TargetType<Target::Devices>,
           BaseTrapezoidMatrix<src_scalar_t>& A,
           BaseTrapezoidMatrix<dst_scalar_t>& B,
-          int priority, int queue_index,
-          Options const& opts)
+          int priority, int queue_index )
 {
     using ij_tuple = typename BaseMatrix<src_scalar_t>::ij_tuple;
     slate_error_if(A.uplo() != B.uplo());
@@ -220,116 +217,100 @@ template
 void copy<Target::HostTask, float, float>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy<Target::HostTask, float, double>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, float, float>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, float, double>(
     BaseTrapezoidMatrix<float>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 // ----------------------------------------
 template
 void copy<Target::HostTask, double, double>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy<Target::HostTask, double, float>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, double, double>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<double>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy<Target::Devices, double, float>(
     BaseTrapezoidMatrix<double>&& A,
     BaseTrapezoidMatrix<float>&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 // ----------------------------------------
 template
 void copy< Target::HostTask, std::complex<float>, std::complex<float> >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy< Target::HostTask, std::complex<float>, std::complex<double> >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<float>, std::complex<float>  >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<float>, std::complex<double>  >(
     BaseTrapezoidMatrix< std::complex<float> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 // ----------------------------------------
 template
 void copy< Target::HostTask, std::complex<double>, std::complex<double> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy< Target::HostTask, std::complex<double>, std::complex<float> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<double>, std::complex<double> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<double> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 template
 void copy< Target::Devices, std::complex<double>, std::complex<float> >(
     BaseTrapezoidMatrix< std::complex<double> >&& A,
     BaseTrapezoidMatrix< std::complex<float> >&& B,
-    int priority, int queue_index,
-    Options const& opts);
+    int priority, int queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_unmlq.cc
+++ b/src/internal/internal_unmlq.cc
@@ -22,11 +22,10 @@ void unmlq(Side side, Op op,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
            Matrix<scalar_t>&& W,
-           int priority, int64_t queue_index,
-           Options const& opts)
+           int priority, int64_t queue_index )
 {
     unmlq<target>(internal::TargetType<target>(),
-          side, op, V, T, C, W, priority, queue_index, opts);
+          side, op, V, T, C, W, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -46,8 +45,7 @@ void unmlq(internal::TargetType<target>,
            Matrix<scalar_t>& T,
            Matrix<scalar_t>& C,
            Matrix<scalar_t>& W,
-           int priority, int64_t queue_index,
-           Options const& opts)
+           int priority, int64_t queue_index )
 {
     const scalar_t one = 1;
 
@@ -166,12 +164,12 @@ void unmlq(internal::TargetType<target>,
         // W <- V0 W
         internal::copy<target>(
                 std::move(C0), std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
         internal::trmm<target>(
                 Side::Left,
                 one, std::move(V0tr),
                      std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         if (trapezoid) {
             // W <- V0b C0b + W
@@ -180,7 +178,7 @@ void unmlq(internal::TargetType<target>,
                          std::move(C0b),
                     one, std::move(Wr),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- V1 C1 + W
@@ -196,7 +194,7 @@ void unmlq(internal::TargetType<target>,
                          std::move(Ci),
                     one, std::move(Wr),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // --------------------
@@ -205,7 +203,7 @@ void unmlq(internal::TargetType<target>,
                 Side::Left,
                 one, std::move(T0tr),
                      std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // --------------------
         // 3. C = C - V^H W
@@ -216,7 +214,7 @@ void unmlq(internal::TargetType<target>,
                           std::move(Wr),
                     one,  C.sub(row_indices[1], mt-1, 0, nt-1),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         if (trapezoid) {
@@ -226,7 +224,7 @@ void unmlq(internal::TargetType<target>,
                           std::move(Wr),
                     one,  std::move(C0b),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- V0^H W
@@ -234,13 +232,13 @@ void unmlq(internal::TargetType<target>,
                 Side::Left,
                 one, conj_transpose( V0tr ),
                      std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // C0 <- C0 - W
         internal::add<target>(
                 -one, std::move(Wr),
                 one,  std::move(C0),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // free workspace
         // todo: Wr.clear();
@@ -352,12 +350,12 @@ void unmlq(internal::TargetType<target>,
         // W <- W V0^H
         internal::copy<target>(
                 std::move(C0), std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
         internal::trmm<target>(
                 Side::Right,
                 one, conj_transpose( V0tr ),
                      std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         if (trapezoid) {
             // W <- C0b V0b^H + W
@@ -366,7 +364,7 @@ void unmlq(internal::TargetType<target>,
                          conj_transpose( V0b ),
                     one, std::move(Wc),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- C1 V1^H + W
@@ -382,7 +380,7 @@ void unmlq(internal::TargetType<target>,
                          conj_transpose( V.sub( 0, 0, col, col ) ),
                     one, std::move(Wc),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // --------------------
@@ -391,7 +389,7 @@ void unmlq(internal::TargetType<target>,
                 Side::Right,
                 one, std::move(T0tr),
                      std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // --------------------
         // 3. C = C - W V
@@ -402,7 +400,7 @@ void unmlq(internal::TargetType<target>,
                           V.sub(0, 0,    col_indices[1], nt-1),
                     one,  C.sub(0, mt-1, col_indices[1], nt-1),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         if (trapezoid) {
@@ -412,7 +410,7 @@ void unmlq(internal::TargetType<target>,
                           std::move(V0b),
                     one,  std::move(C0b),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- W V0
@@ -420,13 +418,13 @@ void unmlq(internal::TargetType<target>,
                 Side::Right,
                 one, std::move(V0tr),
                      std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // C0 <- C0 - W
         internal::add<target>(
                 -one, std::move(Wc),
                 one,  std::move(C0),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // free workspace
         // todo: Wc.clear();
@@ -448,8 +446,7 @@ void unmlq<Target::HostTask, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq<Target::HostNest, float>(
@@ -458,8 +455,7 @@ void unmlq<Target::HostNest, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq<Target::HostBatch, float>(
@@ -468,8 +464,7 @@ void unmlq<Target::HostBatch, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq<Target::Devices, float>(
@@ -478,8 +473,7 @@ void unmlq<Target::Devices, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -489,8 +483,7 @@ void unmlq<Target::HostTask, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq<Target::HostNest, double>(
@@ -499,8 +492,7 @@ void unmlq<Target::HostNest, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq<Target::HostBatch, double>(
@@ -509,8 +501,7 @@ void unmlq<Target::HostBatch, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq<Target::Devices, double>(
@@ -519,8 +510,7 @@ void unmlq<Target::Devices, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -530,8 +520,7 @@ void unmlq< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq< Target::HostNest, std::complex<float> >(
@@ -540,8 +529,7 @@ void unmlq< Target::HostNest, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq< Target::HostBatch, std::complex<float> >(
@@ -550,8 +538,7 @@ void unmlq< Target::HostBatch, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq< Target::Devices, std::complex<float> >(
@@ -560,8 +547,7 @@ void unmlq< Target::Devices, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -571,8 +557,7 @@ void unmlq< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq< Target::HostNest, std::complex<double> >(
@@ -581,8 +566,7 @@ void unmlq< Target::HostNest, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq< Target::HostBatch, std::complex<double> >(
@@ -591,8 +575,7 @@ void unmlq< Target::HostBatch, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmlq< Target::Devices, std::complex<double> >(
@@ -601,8 +584,7 @@ void unmlq< Target::Devices, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_unmqr.cc
+++ b/src/internal/internal_unmqr.cc
@@ -22,11 +22,10 @@ void unmqr(Side side, Op op,
            Matrix<scalar_t>&& T,
            Matrix<scalar_t>&& C,
            Matrix<scalar_t>&& W,
-           int priority, int64_t queue_index,
-           Options const& opts)
+           int priority, int64_t queue_index )
 {
     unmqr<target>(internal::TargetType<target>(),
-          side, op, V, T, C, W, priority, queue_index, opts);
+          side, op, V, T, C, W, priority, queue_index );
 }
 
 //------------------------------------------------------------------------------
@@ -46,8 +45,7 @@ void unmqr(internal::TargetType<target>,
            Matrix<scalar_t>& T,
            Matrix<scalar_t>& C,
            Matrix<scalar_t>& W,
-           int priority, int64_t queue_index,
-           Options const& opts)
+           int priority, int64_t queue_index )
 {
     const scalar_t one = 1;
 
@@ -162,12 +160,12 @@ void unmqr(internal::TargetType<target>,
         // W <- V0^H W
         internal::copy<target>(
                 std::move(C0), std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
         internal::trmm<target>(
                 Side::Left,
                 one, conj_transpose( V0tr ),
                      std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         if (trapezoid) {
             // W <- V0b^H C0b + W
@@ -176,7 +174,7 @@ void unmqr(internal::TargetType<target>,
                          std::move(C0b),
                     one, std::move(Wr),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- V1^H C1 + W
@@ -192,7 +190,7 @@ void unmqr(internal::TargetType<target>,
                          std::move(Ci),
                     one, std::move(Wr),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // --------------------
@@ -201,7 +199,7 @@ void unmqr(internal::TargetType<target>,
                 Side::Left,
                 one, std::move(T0tr),
                      std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // --------------------
         // 3. C = C - V W
@@ -212,7 +210,7 @@ void unmqr(internal::TargetType<target>,
                           std::move(Wr),
                     one,  C.sub(row_indices[1], mt-1, 0, nt-1),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         if (trapezoid) {
@@ -222,7 +220,7 @@ void unmqr(internal::TargetType<target>,
                           std::move(Wr),
                     one,  std::move(C0b),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- V0 W
@@ -230,13 +228,13 @@ void unmqr(internal::TargetType<target>,
                 Side::Left,
                 one, std::move(V0tr),
                      std::move(Wr),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // C0 <- C0 - W
         internal::add<target>(
                 -one, std::move(Wr),
                 one,  std::move(C0),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // free workspace
         for (int64_t j = 0; j < Wr.nt(); ++j) {
@@ -343,12 +341,12 @@ void unmqr(internal::TargetType<target>,
         // W <- W V0
         internal::copy<target>(
                 std::move(C0), std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
         internal::trmm<target>(
                 Side::Right,
                 one, std::move(V0tr),
                      std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         if (trapezoid) {
             // W <- C0b V0b + W
@@ -357,7 +355,7 @@ void unmqr(internal::TargetType<target>,
                          std::move(V0b),
                     one, std::move(Wc),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- C1 V1 + W
@@ -373,7 +371,7 @@ void unmqr(internal::TargetType<target>,
                          V.sub(col, col, 0, 0),
                     one, std::move(Wc),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // --------------------
@@ -382,7 +380,7 @@ void unmqr(internal::TargetType<target>,
                 Side::Right,
                 one, std::move(T0tr),
                      std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // --------------------
         // 3. C = C - W V^H
@@ -393,7 +391,7 @@ void unmqr(internal::TargetType<target>,
                           conj_transpose( V.sub( col_indices[1], nt-1, 0, 0 ) ),
                     one,  C.sub(0, mt-1, col_indices[1], nt-1),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         if (trapezoid) {
@@ -403,7 +401,7 @@ void unmqr(internal::TargetType<target>,
                           conj_transpose( V0b ),
                     one,  std::move(C0b),
                     layout,
-                    priority, queue_index, opts);
+                    priority, queue_index );
         }
 
         // W <- W V0^H
@@ -411,13 +409,13 @@ void unmqr(internal::TargetType<target>,
                 Side::Right,
                 one, conj_transpose( V0tr ),
                      std::move(Wc),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // C0 <- C0 - W
         internal::add<target>(
                 -one, std::move(Wc),
                 one,  std::move(C0),
-                priority, queue_index, opts);
+                priority, queue_index );
 
         // free workspace
         // todo: Wc.clear();
@@ -439,8 +437,7 @@ void unmqr<Target::HostTask, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr<Target::HostNest, float>(
@@ -449,8 +446,7 @@ void unmqr<Target::HostNest, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr<Target::HostBatch, float>(
@@ -459,8 +455,7 @@ void unmqr<Target::HostBatch, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr<Target::Devices, float>(
@@ -469,8 +464,7 @@ void unmqr<Target::Devices, float>(
     Matrix<float>&& T,
     Matrix<float>&& C,
     Matrix<float>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -480,8 +474,7 @@ void unmqr<Target::HostTask, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr<Target::HostNest, double>(
@@ -490,8 +483,7 @@ void unmqr<Target::HostNest, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr<Target::HostBatch, double>(
@@ -500,8 +492,7 @@ void unmqr<Target::HostBatch, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr<Target::Devices, double>(
@@ -510,8 +501,7 @@ void unmqr<Target::Devices, double>(
     Matrix<double>&& T,
     Matrix<double>&& C,
     Matrix<double>&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -521,8 +511,7 @@ void unmqr< Target::HostTask, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr< Target::HostNest, std::complex<float> >(
@@ -531,8 +520,7 @@ void unmqr< Target::HostNest, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr< Target::HostBatch, std::complex<float> >(
@@ -541,8 +529,7 @@ void unmqr< Target::HostBatch, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr< Target::Devices, std::complex<float> >(
@@ -551,8 +538,7 @@ void unmqr< Target::Devices, std::complex<float> >(
     Matrix< std::complex<float> >&& T,
     Matrix< std::complex<float> >&& C,
     Matrix< std::complex<float> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 // ----------------------------------------
 template
@@ -562,8 +548,7 @@ void unmqr< Target::HostTask, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr< Target::HostNest, std::complex<double> >(
@@ -572,8 +557,7 @@ void unmqr< Target::HostNest, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr< Target::HostBatch, std::complex<double> >(
@@ -582,8 +566,7 @@ void unmqr< Target::HostBatch, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 template
 void unmqr< Target::Devices, std::complex<double> >(
@@ -592,8 +575,7 @@ void unmqr< Target::Devices, std::complex<double> >(
     Matrix< std::complex<double> >&& T,
     Matrix< std::complex<double> >&& C,
     Matrix< std::complex<double> >&& W,
-    int priority, int64_t queue_index,
-    Options const& opts);
+    int priority, int64_t queue_index );
 
 } // namespace internal
 } // namespace slate

--- a/src/internal/internal_unmtr_hb2st.cc
+++ b/src/internal/internal_unmtr_hb2st.cc
@@ -20,11 +20,9 @@ template <Target target, typename scalar_t>
 void unmtr_hb2st(
     Side side, Op op,
     Matrix<scalar_t>& V,
-    Matrix<scalar_t>& C,
-    const std::map<Option, Value>& opts)
+    Matrix<scalar_t>& C )
 {
-    unmtr_hb2st(internal::TargetType<target>(),
-                side, op, V, C, opts);
+    unmtr_hb2st(internal::TargetType<target>(), side, op, V, C);
 }
 
 //------------------------------------------------------------------------------
@@ -40,8 +38,7 @@ template <Target target, typename scalar_t>
 void unmtr_hb2st( internal::TargetType<target>,
                   Side side, Op op,
                   Matrix<scalar_t>& V,
-                  Matrix<scalar_t>& C,
-                  const std::map<Option, Value>& opts)
+                  Matrix<scalar_t>& C )
 {
     slate_assert(side == Side::Left);
 
@@ -464,56 +461,49 @@ template
 void unmtr_hb2st<Target::HostTask, float>(
     Side side, Op op,
     Matrix<float>& V,
-    Matrix<float>& C,
-    const std::map<Option, Value>& opts);
+    Matrix<float>& C );
 
 template
 void unmtr_hb2st<Target::HostTask, double>(
     Side side, Op op,
     Matrix<double>& V,
-    Matrix<double>& C,
-    const std::map<Option, Value>& opts);
+    Matrix<double>& C );
 
 template
 void unmtr_hb2st<Target::HostTask, std::complex<float> >(
     Side side, Op op,
     Matrix< std::complex<float> >& V,
-    Matrix< std::complex<float> >& C,
-    const std::map<Option, Value>& opts);
+    Matrix< std::complex<float> >& C );
 
 template
 void unmtr_hb2st<Target::HostTask, std::complex<double> >(
     Side side, Op op,
     Matrix< std::complex<double> >& V,
-    Matrix< std::complex<double> >& C,
-    const std::map<Option, Value>& opts);
+    Matrix< std::complex<double> >& C );
 
 template
 void unmtr_hb2st<Target::Devices, float>(
     Side side, Op op,
     Matrix<float>& V,
-    Matrix<float>& C,
-    const std::map<Option, Value>& opts);
+    Matrix<float>& C );
 
 template
 void unmtr_hb2st<Target::Devices, double>(
     Side side, Op op,
     Matrix<double>& V,
-    Matrix<double>& C,
-    const std::map<Option, Value>& opts);
+    Matrix<double>& C );
 
 template
 void unmtr_hb2st<Target::Devices, std::complex<float> >(
     Side side, Op op,
     Matrix< std::complex<float> >& V,
-    Matrix< std::complex<float> >& C,
-    const std::map<Option, Value>& opts);
+    Matrix< std::complex<float> >& C );
 
 template
 void unmtr_hb2st<Target::Devices, std::complex<double> >(
     Side side, Op op,
     Matrix< std::complex<double> >& V,
-    Matrix< std::complex<double> >& C,
-    const std::map<Option, Value>& opts);
+    Matrix< std::complex<double> >& C );
+
 } // namespace internal
 } // namespace slate

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -87,7 +87,7 @@ int64_t pbtrf(
                         Side::Right,
                         one, conj_transpose( Tkk ),
                         A.sub(k+1, ij_end-1, k, k),
-                        priority_1, layout, queue_0, opts );
+                        priority_1, layout );
                 }
 
                 BcastList bcast_list_A;
@@ -109,7 +109,7 @@ int64_t pbtrf(
                     internal::herk<Target::HostTask>(
                         -r_one, A.sub(k+1+lookahead, ij_end-1, k, k),
                         r_one,  A.sub(k+1+lookahead, ij_end-1),
-                        priority_0, queue_0, layout, opts );
+                        priority_0, queue_0, layout );
                 }
             }
 
@@ -121,7 +121,7 @@ int64_t pbtrf(
                     internal::herk<Target::HostTask>(
                         -r_one, A.sub(j, j, k, k),
                         r_one,  A.sub(j, j),
-                        priority_0, queue_0, layout, opts );
+                        priority_0, queue_0, layout );
 
                     if (j+1 <= A_nt-1) {
                         auto Ajk = A.sub(j, j, k, k);
@@ -129,7 +129,7 @@ int64_t pbtrf(
                             -one, A.sub(j+1, ij_end-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, ij_end-1, j, j),
-                            layout, priority_1, queue_0, opts );
+                            layout, priority_1 );
                     }
                 }
             }

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -41,12 +41,6 @@ int64_t pbtrf(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for pbtrf
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper)
         A = conj_transpose( A );
@@ -93,7 +87,7 @@ int64_t pbtrf(
                         Side::Right,
                         one, conj_transpose( Tkk ),
                         A.sub(k+1, ij_end-1, k, k),
-                        priority_1, layout, queue_0, opts2);
+                        priority_1, layout, queue_0, opts );
                 }
 
                 BcastList bcast_list_A;
@@ -115,7 +109,7 @@ int64_t pbtrf(
                     internal::herk<Target::HostTask>(
                         -r_one, A.sub(k+1+lookahead, ij_end-1, k, k),
                         r_one,  A.sub(k+1+lookahead, ij_end-1),
-                        priority_0, queue_0, layout, opts2 );
+                        priority_0, queue_0, layout, opts );
                 }
             }
 
@@ -127,7 +121,7 @@ int64_t pbtrf(
                     internal::herk<Target::HostTask>(
                         -r_one, A.sub(j, j, k, k),
                         r_one,  A.sub(j, j),
-                        priority_0, queue_0, layout, opts2 );
+                        priority_0, queue_0, layout, opts );
 
                     if (j+1 <= A_nt-1) {
                         auto Ajk = A.sub(j, j, k, k);
@@ -135,7 +129,7 @@ int64_t pbtrf(
                             -one, A.sub(j+1, ij_end-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, ij_end-1, j, j),
-                            layout, priority_1, queue_0, opts2 );
+                            layout, priority_1, queue_0, opts );
                     }
                 }
             }

--- a/src/pocondest.cc
+++ b/src/pocondest.cc
@@ -103,7 +103,7 @@ blas::real_type<scalar_t> pocondest(
 
     // initial and final value of kase is 0
     kase = 0;
-    internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
+    internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave );
 
     MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
     MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
@@ -112,7 +112,7 @@ blas::real_type<scalar_t> pocondest(
         // A is symmetric, so both cases are equivalent
         potrs( A, X, opts );
 
-        internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
+        internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave );
         MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
         MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
     } // while (kase != 0)

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -39,16 +39,8 @@ int64_t potrf(
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
-
-    // Use only TileReleaseStrategy::Slate for potrf.
-    // Internal routines (trsm, herk, gemm) called in
-    // potrf won't release any tiles. Potrf will
-    // clean up tiles.
-    Options opts2 = Options( opts );
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     bool hold_local_workspace = get_option<bool>(
-            opts2, Option::HoldLocalWorkspace, 0 );
+            opts, Option::HoldLocalWorkspace, 0 );
 
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
@@ -125,7 +117,7 @@ int64_t potrf(
                         Side::Right,
                         one, conj_transpose( Tkk ),
                         A.sub(k+1, A_nt-1, k, k),
-                        priority_0, layout, queue_1, opts2 );
+                        priority_0, layout, queue_1, opts );
                 }
 
                 BcastListTag bcast_list_A;
@@ -153,7 +145,7 @@ int64_t potrf(
                     internal::herk<target>(
                         real_t(-1.0), A.sub(k+1+lookahead, A_nt-1, k, k),
                         real_t( 1.0), A.sub(k+1+lookahead, A_nt-1),
-                        priority_0, queue_0, layout, opts2 );
+                        priority_0, queue_0, layout, opts );
                 }
             }
 
@@ -171,7 +163,7 @@ int64_t potrf(
                     internal::herk<target>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
-                        priority_0, queue_jk2, layout, opts2 );
+                        priority_0, queue_jk2, layout, opts );
 
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
@@ -180,7 +172,7 @@ int64_t potrf(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, priority_0, queue_jk2, opts2 );
+                            layout, priority_0, queue_jk2, opts );
                     }
                 }
             }

--- a/src/potrf.cc
+++ b/src/potrf.cc
@@ -117,7 +117,7 @@ int64_t potrf(
                         Side::Right,
                         one, conj_transpose( Tkk ),
                         A.sub(k+1, A_nt-1, k, k),
-                        priority_0, layout, queue_1, opts );
+                        priority_0, layout, queue_1 );
                 }
 
                 BcastListTag bcast_list_A;
@@ -145,7 +145,7 @@ int64_t potrf(
                     internal::herk<target>(
                         real_t(-1.0), A.sub(k+1+lookahead, A_nt-1, k, k),
                         real_t( 1.0), A.sub(k+1+lookahead, A_nt-1),
-                        priority_0, queue_0, layout, opts );
+                        priority_0, queue_0, layout );
                 }
             }
 
@@ -163,7 +163,7 @@ int64_t potrf(
                     internal::herk<target>(
                         real_t(-1.0), A.sub(j, j, k, k),
                         real_t( 1.0), A.sub(j, j),
-                        priority_0, queue_jk2, layout, opts );
+                        priority_0, queue_jk2, layout );
 
                     // A(j+1:nt, j) -= A(j+1:nt-1, k) * A(j, k)^H
                     if (j+1 <= A_nt-1) {
@@ -172,7 +172,7 @@ int64_t potrf(
                             -one, A.sub(j+1, A_nt-1, k, k),
                                   conj_transpose( Ajk ),
                             one,  A.sub(j+1, A_nt-1, j, j),
-                            layout, priority_0, queue_jk2, opts );
+                            layout, priority_0, queue_jk2 );
                     }
                 }
             }

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -49,8 +49,6 @@ void symm(
 
     // Constants
     const scalar_t one = 1.0;
-    const int priority_0 = 0;
-    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
@@ -150,8 +148,7 @@ void symm(
                     Side::Left,
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
-                    beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts );
+                    beta,  C.sub( 0, 0, 0, C.nt()-1 ) );
 
                 // Erase local & remote tile on all devices including host.
                 A.releaseRemoteWorkspaceTile( 0, 0 );
@@ -163,7 +160,7 @@ void symm(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     // Don't release local Acol_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -236,7 +233,7 @@ void symm(
                         alpha,  transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     Arow_k.releaseRemoteWorkspace();
                     Arow_k.releaseLocalWorkspace();
@@ -245,8 +242,7 @@ void symm(
                         Side::Left,
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
-                        one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts );
+                        one,    C.sub( k, k, 0, C.nt()-1 ) );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -257,7 +253,7 @@ void symm(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts );
+                            layout );
 
                         // Don't release local Acol_k here, because it may be
                         // bcast again, creating a race condition.
@@ -343,8 +339,7 @@ void symm(
                     Side::Left,
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
-                    beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts );
+                    beta,  C.sub( 0, 0, 0, C.nt()-1 ) );
 
                 A.releaseRemoteWorkspaceTile( 0, 0 );
                 A.releaseLocalWorkspaceTile( 0, 0 );
@@ -355,7 +350,7 @@ void symm(
                         alpha, transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     // Don't release local Arow_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -426,7 +421,7 @@ void symm(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts );
+                        layout );
 
                     Acol_k.releaseRemoteWorkspace();
                     Acol_k.releaseLocalWorkspace();
@@ -435,8 +430,7 @@ void symm(
                         Side::Left,
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
-                        one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts );
+                        one,    C.sub( k, k, 0, C.nt()-1 ) );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -447,7 +441,7 @@ void symm(
                             alpha,  transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts );
+                            layout );
 
                         // Don't release local Arow_k here, because it may be
                         // bcast again, creating a race condition.

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -68,13 +68,7 @@ void symm(
     assert( B.mt() == C.mt() );
     assert( B.nt() == C.nt() );
 
-    // Use only TileReleaseStrategy::Slate for hemm.
-    // Internal hemm and gemm routines called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts_local = opts;
-    opts_local[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
-    int64_t lookahead = get_option<int64_t>( opts_local, Option::Lookahead, 1 );
+    int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector( A.nt() );
@@ -157,7 +151,7 @@ void symm(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts_local );
+                    priority_0, opts );
 
                 // Erase local & remote tile on all devices including host.
                 A.releaseRemoteWorkspaceTile( 0, 0 );
@@ -169,7 +163,7 @@ void symm(
                         alpha, std::move( Acol_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     // Don't release local Acol_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -242,7 +236,7 @@ void symm(
                         alpha,  transpose( Arow_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     Arow_k.releaseRemoteWorkspace();
                     Arow_k.releaseLocalWorkspace();
@@ -252,7 +246,7 @@ void symm(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts_local );
+                        priority_0, opts );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -263,7 +257,7 @@ void symm(
                             alpha,  std::move( Acol_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts );
 
                         // Don't release local Acol_k here, because it may be
                         // bcast again, creating a race condition.
@@ -350,7 +344,7 @@ void symm(
                     alpha, A.sub( 0, 0 ),
                            std::move( Brow_0 ),
                     beta,  C.sub( 0, 0, 0, C.nt()-1 ),
-                    priority_0, opts_local );
+                    priority_0, opts );
 
                 A.releaseRemoteWorkspaceTile( 0, 0 );
                 A.releaseLocalWorkspaceTile( 0, 0 );
@@ -361,7 +355,7 @@ void symm(
                         alpha, transpose( Arow_0 ),
                                std::move( Brow_0 ),
                         beta,  C.sub( 1, C.mt()-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     // Don't release local Arow_0 here, because it may be
                     // bcast again, creating a race condition.
@@ -432,7 +426,7 @@ void symm(
                         alpha,  std::move( Acol_k ),
                                 std::move( Brow_k ),
                         one,    C.sub( 0, k-1, 0, C.nt()-1 ),
-                        layout, priority_0, queue_0, opts_local );
+                        layout, priority_0, queue_0, opts );
 
                     Acol_k.releaseRemoteWorkspace();
                     Acol_k.releaseLocalWorkspace();
@@ -442,7 +436,7 @@ void symm(
                         alpha,  A.sub( k, k ),
                                 std::move( Brow_k ),
                         one,    C.sub( k, k, 0, C.nt()-1 ),
-                        priority_0, opts_local );
+                        priority_0, opts );
 
                     A.releaseRemoteWorkspaceTile( k, k );
                     A.releaseLocalWorkspaceTile( k, k );
@@ -453,7 +447,7 @@ void symm(
                             alpha,  transpose( Arow_k ),
                                     std::move( Brow_k ),
                             one,    C.sub( k+1, C.mt()-1, 0, C.nt()-1 ),
-                            layout, priority_0, queue_0, opts_local );
+                            layout, priority_0, queue_0, opts );
 
                         // Don't release local Arow_k here, because it may be
                         // bcast again, creating a race condition.

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -121,7 +121,7 @@ void syr2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                priority_0, queue_0, layout, opts );
+                priority_0, queue_0, layout );
 
             // Erase remote tiles on all devices including host
             A_col0.releaseRemoteWorkspace();
@@ -168,7 +168,7 @@ void syr2k(
                     alpha, std::move( A_colk ),
                            std::move( B_colk ),
                     one,   std::move( C ),
-                    priority_0, queue_0, layout, opts );
+                    priority_0, queue_0, layout );
 
                 // Erase remote tiles on all devices including host
                 A_colk.releaseRemoteWorkspace();

--- a/src/syr2k.cc
+++ b/src/syr2k.cc
@@ -51,12 +51,6 @@ void syr2k(
     assert(B.mt() == C.mt());
     assert(A.nt() == B.nt());
 
-    // Use only TileReleaseStrategy::Slate for syr2k.
-    // Internal syr2k routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options const opts_local =  {
-        {slate::Option::TileReleaseStrategy, TileReleaseStrategy::Slate}};
-
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector(A.nt());
     std::vector<uint8_t>  gemm_vector(A.nt());
@@ -127,7 +121,7 @@ void syr2k(
                 alpha, std::move( A_col0 ),
                        std::move( B_col0 ),
                 beta,  std::move( C ),
-                priority_0, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts );
 
             // Erase remote tiles on all devices including host
             A_col0.releaseRemoteWorkspace();
@@ -174,7 +168,7 @@ void syr2k(
                     alpha, std::move( A_colk ),
                            std::move( B_colk ),
                     one,   std::move( C ),
-                    priority_0, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts );
 
                 // Erase remote tiles on all devices including host
                 A_colk.releaseRemoteWorkspace();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -50,12 +50,6 @@ void syrk(
     // A is mt-by-nt, C is mt-by-mt
     assert(A.mt() == C.mt());
 
-    // Use only TileReleaseStrategy::Slate for syrk.
-    // Internal syrk routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options const opts_local =  {
-        {slate::Option::TileReleaseStrategy, TileReleaseStrategy::Slate}};
-
     // OpenMP needs pointer types, but vectors are exception safe
     std::vector<uint8_t> bcast_vector(A.nt());
     std::vector<uint8_t>  gemm_vector(A.nt());
@@ -113,7 +107,7 @@ void syrk(
             internal::syrk<target>(
                 alpha, std::move( A_col0 ),
                 beta,  std::move( C ),
-                priority_0, queue_0, layout, opts_local );
+                priority_0, queue_0, layout, opts );
 
             // Erase remote tiles on all devices including host
             A_col0.releaseRemoteWorkspace();
@@ -152,7 +146,7 @@ void syrk(
                 internal::syrk<target>(
                     alpha, std::move( A_colk ),
                     one,   std::move( C ),
-                    priority_0, queue_0, layout, opts_local );
+                    priority_0, queue_0, layout, opts );
 
                 // Erase remote tiles on all devices including host
                 A_colk.releaseRemoteWorkspace();

--- a/src/syrk.cc
+++ b/src/syrk.cc
@@ -107,7 +107,7 @@ void syrk(
             internal::syrk<target>(
                 alpha, std::move( A_col0 ),
                 beta,  std::move( C ),
-                priority_0, queue_0, layout, opts );
+                priority_0, queue_0, layout );
 
             // Erase remote tiles on all devices including host
             A_col0.releaseRemoteWorkspace();
@@ -146,7 +146,7 @@ void syrk(
                 internal::syrk<target>(
                     alpha, std::move( A_colk ),
                     one,   std::move( C ),
-                    priority_0, queue_0, layout, opts );
+                    priority_0, queue_0, layout );
 
                 // Erase remote tiles on all devices including host
                 A_colk.releaseRemoteWorkspace();

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -43,12 +43,6 @@ void tbsm(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for tbsmPivots.
-    // Internal tbsmPivots routine called here won't release
-    // any tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if on right, change to left by (conj)-transposing A and B to get
     // op(B) = op(A)^{-1} * op(B)
     if (side == Side::Right) {
@@ -145,7 +139,7 @@ void tbsm(
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_0, opts2 );
+                        priority_1, layout, queue_0, opts );
 
                     // send A(i=k+1:i_end-1, k) to ranks owning block row B(i, :)
                     BcastList bcast_list_A;
@@ -172,7 +166,7 @@ void tbsm(
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i, i, 0, nt-1),
-                            layout, priority_1, queue_0, opts2 );
+                            layout, priority_1, queue_0, opts );
                     }
                 }
 
@@ -190,7 +184,7 @@ void tbsm(
                             -one, A.sub(k+1+lookahead, i_end-1, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(k+1+lookahead, i_end-1, 0, nt-1),
-                            layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
 
@@ -229,7 +223,7 @@ void tbsm(
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_0, opts2 );
+                        priority_1, layout, queue_0, opts );
 
                     // send A(i=k-kdt:k-1, k) to ranks owning block row B(i, :)
                     BcastList bcast_list_A;
@@ -253,7 +247,7 @@ void tbsm(
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i, i, 0, nt-1),
-                            layout, priority_1, queue_0, opts2 );
+                            layout, priority_1, queue_0, opts );
                     }
                 }
 
@@ -270,7 +264,7 @@ void tbsm(
                             -one, A.sub(i_begin, k-1-lookahead, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i_begin, k-1-lookahead, 0, nt-1),
-                            layout, priority_0, queue_0, opts2 );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
 
@@ -324,7 +318,7 @@ void tbsm(
                                     -one, A.sub(k, k, i, i),
                                           B.sub(i, i, 0, nt-1),
                                     one,  B.sub(k, k, 0, nt-1),
-                                    layout, priority_1, queue_0, opts2 );
+                                    layout, priority_1, queue_0, opts );
                     }
                 }
 
@@ -338,7 +332,7 @@ void tbsm(
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_0, opts2 );
+                        priority_1, layout, queue_0, opts );
                 }
 
                 // swap rows in B(k:mt-1, 0:nt-1)

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -38,7 +38,6 @@ void tbsm(
     const Layout layout = Layout::ColMajor;
     const int priority_0 = 0;
     const int priority_1 = 1;
-    const int queue_0 = 0;
 
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
@@ -139,7 +138,7 @@ void tbsm(
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_0, opts );
+                        priority_1, layout );
 
                     // send A(i=k+1:i_end-1, k) to ranks owning block row B(i, :)
                     BcastList bcast_list_A;
@@ -166,7 +165,7 @@ void tbsm(
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i, i, 0, nt-1),
-                            layout, priority_1, queue_0, opts );
+                            layout, priority_1 );
                     }
                 }
 
@@ -184,7 +183,7 @@ void tbsm(
                             -one, A.sub(k+1+lookahead, i_end-1, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(k+1+lookahead, i_end-1, 0, nt-1),
-                            layout, priority_0, queue_0, opts );
+                            layout, priority_0 );
                     }
                 }
 
@@ -223,7 +222,7 @@ void tbsm(
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_0, opts );
+                        priority_1, layout );
 
                     // send A(i=k-kdt:k-1, k) to ranks owning block row B(i, :)
                     BcastList bcast_list_A;
@@ -247,7 +246,7 @@ void tbsm(
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i, i, 0, nt-1),
-                            layout, priority_1, queue_0, opts );
+                            layout, priority_1 );
                     }
                 }
 
@@ -264,7 +263,7 @@ void tbsm(
                             -one, A.sub(i_begin, k-1-lookahead, k, k),
                                   B.sub(k, k, 0, nt-1),
                             one,  B.sub(i_begin, k-1-lookahead, 0, nt-1),
-                            layout, priority_0, queue_0, opts );
+                            layout, priority_0 );
                     }
                 }
 
@@ -318,7 +317,7 @@ void tbsm(
                                     -one, A.sub(k, k, i, i),
                                           B.sub(i, i, 0, nt-1),
                                     one,  B.sub(k, k, 0, nt-1),
-                                    layout, priority_1, queue_0, opts );
+                                    layout, priority_1 );
                     }
                 }
 
@@ -332,7 +331,7 @@ void tbsm(
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_0, opts );
+                        priority_1, layout );
                 }
 
                 // swap rows in B(k:mt-1, 0:nt-1)

--- a/src/trcondest.cc
+++ b/src/trcondest.cc
@@ -108,7 +108,7 @@ blas::real_type<scalar_t> trcondest(
 
     // initial and final value of kase is 0
     kase = 0;
-    internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
+    internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave );
     MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
     MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
 
@@ -123,7 +123,7 @@ blas::real_type<scalar_t> trcondest(
             slate::trsm( Side::Left, alpha, AH, X, opts );
         }
 
-        internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave, opts);
+        internal::norm1est( X, V, isgn, &Ainvnorm, &kase, isave );
         MPI_Bcast( &isave[0], 4, MPI_INT64_T, X.tileRank(0, 0), A.mpiComm() );
         MPI_Bcast( &kase, 1, MPI_INT, X.tileRank(0, 0), A.mpiComm() );
     } // while (kase != 0)

--- a/src/trsmA.cc
+++ b/src/trsmA.cc
@@ -26,9 +26,6 @@ void trsmA(
     // Options
     int64_t lookahead = get_option<int64_t>(opts, Option::Lookahead, 1);
 
-    Options opts_local = opts;
-    opts_local[ Option::Lookahead ] = lookahead;
-
     if (target == Target::Devices) {
         if (A.num_devices() > 1)
             slate_not_implemented( "trsmA doesn't support multiple GPUs" );
@@ -62,7 +59,7 @@ void trsmA(
     {
         #pragma omp task
         {
-            work::trsmA<target, scalar_t>( side, alpha, A, B, row, opts_local );
+            work::trsmA<target, scalar_t>( side, alpha, A, B, row, opts );
             B.tileUpdateAllOrigin();
         }
     }

--- a/src/trtri.cc
+++ b/src/trtri.cc
@@ -36,12 +36,6 @@ void trtri(
     // Options
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
 
-    // Use only TileReleaseStrategy::Slate for trtri
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
         A = conj_transpose( A );
@@ -80,7 +74,7 @@ void trtri(
                 internal::trsm<Target::HostTask>(
                     Side::Right,
                     -one, A.sub(0, 0), A.sub(1, A_nt-1, 0, 0),
-                    priority_0, layout, queue_0, opts2 );
+                    priority_0, layout, queue_0, opts );
             }
             ++tag;
 
@@ -120,7 +114,7 @@ void trtri(
                 internal::trsm<Target::HostTask>(
                     Side::Right,
                     -one, A.sub(k, k), A.sub(k+1, A_nt-1, k, k),
-                    priority_0, layout, queue_0, opts2 );
+                    priority_0, layout, queue_0, opts );
 
                 // send leading column to the left
                 BcastList bcast_list_A;
@@ -154,7 +148,7 @@ void trtri(
                         -one, A.sub(k+lookahead, k+lookahead),
                               A.sub(k+1+lookahead, A_nt-1,
                                     k+lookahead, k+lookahead),
-                        priority_0, layout, queue_0, opts2 );
+                        priority_0, layout, queue_0, opts );
 
                     // send leading column to the left
                     BcastList bcast_list_A;
@@ -184,7 +178,7 @@ void trtri(
                         one, A.sub(i, i, k, k),
                              A.sub(k, k, 0, k-1),
                         one, A.sub(i, i, 0, k-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
 
                     if (i+1 < A_nt) {
                         // send the row down
@@ -212,7 +206,7 @@ void trtri(
                         one, A.sub(k+1+lookahead, A_nt-1, k, k),
                              A.sub(k, k, 0, k-1),
                         one, A.sub(k+1+lookahead, A_nt-1, 0, k-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
 
                 if (k+2+lookahead < A_nt) {
@@ -240,7 +234,7 @@ void trtri(
                 internal::trsm<Target::HostTask>(
                     Side::Left,
                     one, A.sub(k, k), A.sub(k, k, 0, k-1),
-                    priority_0, layout, queue_0, opts2 );
+                    priority_0, layout, queue_0, opts );
 
                 // invert A(k, k)
                 internal::trtri<Target::HostTask>(A.sub(k, k));

--- a/src/trtri.cc
+++ b/src/trtri.cc
@@ -28,7 +28,6 @@ void trtri(
 
     const scalar_t one = 1.0;
     const int64_t priority_0 = 0;
-    const int64_t queue_0 = 0;
 
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -74,7 +73,7 @@ void trtri(
                 internal::trsm<Target::HostTask>(
                     Side::Right,
                     -one, A.sub(0, 0), A.sub(1, A_nt-1, 0, 0),
-                    priority_0, layout, queue_0, opts );
+                    priority_0, layout );
             }
             ++tag;
 
@@ -114,7 +113,7 @@ void trtri(
                 internal::trsm<Target::HostTask>(
                     Side::Right,
                     -one, A.sub(k, k), A.sub(k+1, A_nt-1, k, k),
-                    priority_0, layout, queue_0, opts );
+                    priority_0, layout );
 
                 // send leading column to the left
                 BcastList bcast_list_A;
@@ -148,7 +147,7 @@ void trtri(
                         -one, A.sub(k+lookahead, k+lookahead),
                               A.sub(k+1+lookahead, A_nt-1,
                                     k+lookahead, k+lookahead),
-                        priority_0, layout, queue_0, opts );
+                        priority_0, layout );
 
                     // send leading column to the left
                     BcastList bcast_list_A;
@@ -178,7 +177,7 @@ void trtri(
                         one, A.sub(i, i, k, k),
                              A.sub(k, k, 0, k-1),
                         one, A.sub(i, i, 0, k-1),
-                        layout, priority_0, queue_0, opts );
+                        layout, priority_0 );
 
                     if (i+1 < A_nt) {
                         // send the row down
@@ -206,7 +205,7 @@ void trtri(
                         one, A.sub(k+1+lookahead, A_nt-1, k, k),
                              A.sub(k, k, 0, k-1),
                         one, A.sub(k+1+lookahead, A_nt-1, 0, k-1),
-                        layout, priority_0, queue_0, opts );
+                        layout, priority_0 );
                 }
 
                 if (k+2+lookahead < A_nt) {
@@ -234,7 +233,7 @@ void trtri(
                 internal::trsm<Target::HostTask>(
                     Side::Left,
                     one, A.sub(k, k), A.sub(k, k, 0, k-1),
-                    priority_0, layout, queue_0, opts );
+                    priority_0, layout );
 
                 // invert A(k, k)
                 internal::trtri<Target::HostTask>(A.sub(k, k));

--- a/src/trtrm.cc
+++ b/src/trtrm.cc
@@ -36,12 +36,6 @@ void trtrm(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
 
-    // Use only TileReleaseStrategy::Slate for trtrm
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // if upper, change to lower
     if (A.uplo() == Uplo::Upper) {
         A = conj_transpose( A );
@@ -98,7 +92,7 @@ void trtrm(
                 internal::herk<target>(
                     real_t(1.0), std::move(Ak),
                     real_t(1.0), std::move(H0),
-                    priority_0, queue_0, layout, opts2 );
+                    priority_0, queue_0, layout, opts );
             }
 
             // multiply the leading row by the diagonal block
@@ -113,7 +107,7 @@ void trtrm(
                 internal::trmm<Target::HostTask>(
                     Side::Left,
                     one, std::move( Akk ), A.sub(k, k, 0, k-1),
-                    priority_0, queue_0, opts2 );
+                    priority_0, queue_0, opts );
             }
 
             // diagonal block, L = L^H L

--- a/src/trtrm.cc
+++ b/src/trtrm.cc
@@ -92,7 +92,7 @@ void trtrm(
                 internal::herk<target>(
                     real_t(1.0), std::move(Ak),
                     real_t(1.0), std::move(H0),
-                    priority_0, queue_0, layout, opts );
+                    priority_0, queue_0, layout );
             }
 
             // multiply the leading row by the diagonal block
@@ -107,7 +107,7 @@ void trtrm(
                 internal::trmm<Target::HostTask>(
                     Side::Left,
                     one, std::move( Akk ), A.sub(k, k, 0, k-1),
-                    priority_0, queue_0, opts );
+                    priority_0 );
             }
 
             // diagonal block, L = L^H L

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -33,8 +33,6 @@ void unmlq(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const int64_t tag_0 = 0;
-    const int64_t priority_0 = 0;
-    const int64_t queue_0 = 0;
 
     int64_t A_mt = A.mt();
     int64_t A_nt = A.nt();
@@ -199,7 +197,7 @@ void unmlq(
                                     std::move(A_panel),
                                     Treduce.sub(k, k, k, A_nt-1),
                                     std::move(C_trail),
-                                    tag_0, opts );
+                                    tag_0 );
                 }
 
                 // Apply local reflectors.
@@ -208,8 +206,7 @@ void unmlq(
                                 std::move(A_panel),
                                 Tlocal.sub(k, k, k, A_nt-1),
                                 std::move(C_trail),
-                                std::move(W_trail),
-                                priority_0, queue_0, opts );
+                                std::move(W_trail) );
 
                 // Left,  NoTrans:     Qi C   = Qi_reduce Qi_local C, or
                 // Right, (Conj)Trans: C Qi^H = C Qi_local^H Qi_reduce^H,
@@ -221,7 +218,7 @@ void unmlq(
                                     std::move(A_panel),
                                     Treduce.sub(k, k, k, A_nt-1),
                                     std::move(C_trail),
-                                    tag_0, opts );
+                                    tag_0 );
                 }
             }
 

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -143,7 +143,7 @@ void unmlq(
                     bcast_list_V.push_back(
                         {k, j, {C.sub(i0, i1, j0, j1)}});
                 }
-                A.template listBcast<target>(bcast_list_V, layout, 0, 1);
+                A.template listBcast<target>(bcast_list_V, layout);
 
                 // Send Tlocal(j) across row C(j, 0:nt-1) or col C(0:mt-1, j).
                 if (first_indices.size() > 0) {

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -30,12 +30,6 @@ void unmlq(
     // trace::Block trace_block("unmlq");
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
-    // Use only TileReleaseStrategy::Slate for unmlq
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const int64_t tag_0 = 0;
@@ -205,7 +199,7 @@ void unmlq(
                                     std::move(A_panel),
                                     Treduce.sub(k, k, k, A_nt-1),
                                     std::move(C_trail),
-                                    tag_0, opts2);
+                                    tag_0, opts );
                 }
 
                 // Apply local reflectors.
@@ -215,7 +209,7 @@ void unmlq(
                                 Tlocal.sub(k, k, k, A_nt-1),
                                 std::move(C_trail),
                                 std::move(W_trail),
-                                priority_0, queue_0, opts2);
+                                priority_0, queue_0, opts );
 
                 // Left,  NoTrans:     Qi C   = Qi_reduce Qi_local C, or
                 // Right, (Conj)Trans: C Qi^H = C Qi_local^H Qi_reduce^H,
@@ -227,7 +221,7 @@ void unmlq(
                                     std::move(A_panel),
                                     Treduce.sub(k, k, k, A_nt-1),
                                     std::move(C_trail),
-                                    tag_0, opts2);
+                                    tag_0, opts );
                 }
             }
 

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -147,7 +147,7 @@ void unmqr(
                     bcast_list_V.push_back(
                         {i, k, {C.sub(i0, i1, j0, j1)}});
                 }
-                A.template listBcast<target>(bcast_list_V, layout, 0, 1);
+                A.template listBcast<target>(bcast_list_V, layout);
 
                 // Send Tlocal(i) across row C(i, 0:nt-1) or col C(0:mt-1, i).
                 if (first_indices.size() > 0) {

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -33,8 +33,6 @@ void unmqr(
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const int64_t tag_0 = 0;
-    const int64_t priority_0 = 0;
-    const int64_t queue_0 = 0;
 
     int64_t A_mt = A.mt();
     int64_t A_nt = A.nt();
@@ -203,7 +201,7 @@ void unmqr(
                                     std::move(A_panel),
                                     Treduce.sub(k, A_mt-1, k, k),
                                     std::move(C_trail),
-                                    tag_0, opts );
+                                    tag_0 );
                 }
 
                 // Apply local reflectors.
@@ -212,8 +210,7 @@ void unmqr(
                                 std::move(A_panel),
                                 Tlocal.sub(k, A_mt-1, k, k),
                                 std::move(C_trail),
-                                std::move(W_trail),
-                                priority_0, queue_0, opts );
+                                std::move(W_trail) );
 
                 // Left,  (Conj)Trans: Qi^H C = Qi_reduce^H Qi_local^H C, or
                 // Right, NoTrans:     C Qi   = C Qi_local Qi_reduce,
@@ -225,7 +222,7 @@ void unmqr(
                                     std::move(A_panel),
                                     Treduce.sub(k, A_mt-1, k, k),
                                     std::move(C_trail),
-                                    tag_0, opts );
+                                    tag_0 );
                 }
             }
             #pragma omp task depend(in:block[k])

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -30,12 +30,6 @@ void unmqr(
     // trace::Block trace_block("unmqr");
     using BcastList = typename Matrix<scalar_t>::BcastList;
 
-    // Use only TileReleaseStrategy::Slate for unmqr
-    // Internal routines called here won't release any
-    // tiles. This routine will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // Assumes column major
     const Layout layout = Layout::ColMajor;
     const int64_t tag_0 = 0;
@@ -209,7 +203,7 @@ void unmqr(
                                     std::move(A_panel),
                                     Treduce.sub(k, A_mt-1, k, k),
                                     std::move(C_trail),
-                                    tag_0, opts2);
+                                    tag_0, opts );
                 }
 
                 // Apply local reflectors.
@@ -219,7 +213,7 @@ void unmqr(
                                 Tlocal.sub(k, A_mt-1, k, k),
                                 std::move(C_trail),
                                 std::move(W_trail),
-                                priority_0, queue_0, opts2);
+                                priority_0, queue_0, opts );
 
                 // Left,  (Conj)Trans: Qi^H C = Qi_reduce^H Qi_local^H C, or
                 // Right, NoTrans:     C Qi   = C Qi_local Qi_reduce,
@@ -231,7 +225,7 @@ void unmqr(
                                     std::move(A_panel),
                                     Treduce.sub(k, A_mt-1, k, k),
                                     std::move(C_trail),
-                                    tag_0, opts2);
+                                    tag_0, opts );
                 }
             }
             #pragma omp task depend(in:block[k])

--- a/src/unmtr_hb2st.cc
+++ b/src/unmtr_hb2st.cc
@@ -42,7 +42,7 @@ void unmtr_hb2st(
     {
         #pragma omp task
         {
-            internal::unmtr_hb2st<target>(side, op, V, C, opts);
+            internal::unmtr_hb2st<target>( side, op, V, C );
         }
         #pragma omp taskwait
         C.tileUpdateAllOrigin();

--- a/src/work/work_trmm.cc
+++ b/src/work/work_trmm.cc
@@ -67,16 +67,9 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
 
     // Constants
     const scalar_t one = 1.0;
-    const int priority_0 = 0;
     const int priority_1 = 1;
-    const int queue_0 = 0;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
-
-    // Use only TileReleaseStrategy::Slate for trmm.
-    // Internal routines (trmm and gemm) called here won't release
-    // any tiles. Trsm will clean up tiles.
-    Options opts2 = {{Option::TileReleaseStrategy, TileReleaseStrategy::Slate}};
 
     // if on right, change to left by (conj)-transposing A and B to get
     // op(B) = op(A)*op(B)
@@ -147,7 +140,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 Side::Left,
                 alpha, A.sub(0, 0),
                        B.sub(0, 0, 0, nt-1),
-                priority_1, queue_0, opts2 );
+                priority_1 );
         }
 
         #pragma omp task depend(in:gemm[0])
@@ -195,13 +188,12 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(0, k-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(0, k-1, 0, nt-1),
-                    layout, priority_0, queue_0, opts2 );
+                    layout );
 
                 internal::trmm<target>(
                     Side::Left,
                     alpha, A.sub(k, k),
-                           B.sub(k, k, 0, nt-1),
-                    priority_0, queue_0, opts2 );
+                           B.sub(k, k, 0, nt-1));
             }
 
             #pragma omp task depend(in:gemm[k])
@@ -261,7 +253,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 Side::Left,
                 alpha, A.sub(mt-1, mt-1),
                        B.sub(mt-1, mt-1, 0, nt-1),
-                priority_1, queue_0, opts2 );
+                priority_1 );
         }
 
         #pragma omp task depend(in:gemm[mt-1])
@@ -309,13 +301,12 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(k+1, mt-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(k+1, mt-1, 0, nt-1),
-                    layout, priority_0, queue_0, opts2 );
+                    layout );
 
                 internal::trmm<target>(
                     Side::Left,
                     alpha, A.sub(k, k),
-                           B.sub(k, k, 0, nt-1),
-                    priority_0, queue_0, opts2 );
+                           B.sub(k, k, 0, nt-1));
             }
 
             #pragma omp task depend(in:gemm[k])

--- a/src/work/work_trmm.cc
+++ b/src/work/work_trmm.cc
@@ -67,6 +67,7 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
 
     // Constants
     const scalar_t one = 1.0;
+    const int priority_0 = 0;
     const int priority_1 = 1;
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -188,12 +189,13 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(0, k-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(0, k-1, 0, nt-1),
-                    layout );
+                    layout, priority_0 );
 
                 internal::trmm<target>(
                     Side::Left,
                     alpha, A.sub(k, k),
-                           B.sub(k, k, 0, nt-1));
+                           B.sub(k, k, 0, nt-1),
+                    priority_0 );
             }
 
             #pragma omp task depend(in:gemm[k])
@@ -301,12 +303,13 @@ void trmm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     alpha, A.sub(k+1, mt-1, k, k),
                            B.sub(k, k, 0, nt-1),
                     one,   B.sub(k+1, mt-1, 0, nt-1),
-                    layout );
+                    layout, priority_0 );
 
                 internal::trmm<target>(
                     Side::Left,
                     alpha, A.sub(k, k),
-                           B.sub(k, k, 0, nt-1));
+                           B.sub(k, k, 0, nt-1),
+                    priority_0 );
             }
 
             #pragma omp task depend(in:gemm[k])

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -113,7 +113,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_1, layout, queue_1, opts );
+                    priority_1, layout, queue_1 );
 
                 // send A(i=k+1:mt-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -141,7 +141,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_1, queue_ik1, opts );
+                        layout, priority_1, queue_ik1 );
                 }
             }
 
@@ -159,7 +159,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(k+1+lookahead, mt-1, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(k+1+lookahead, mt-1, 0, nt-1),
-                        layout, priority_0, queue_0, opts );
+                        layout, priority_0, queue_0 );
                 }
             }
 
@@ -198,7 +198,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_1, layout, queue_1, opts );
+                    priority_1, layout, queue_1 );
 
                 // send A(i=0:k-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -223,7 +223,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_1, queue_ikl2, opts );
+                        layout, priority_1, queue_ikl2 );
                 }
             }
 
@@ -240,7 +240,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(0, k-1-lookahead, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(0, k-1-lookahead, 0, nt-1),
-                        layout, priority_0, queue_0, opts );
+                        layout, priority_0, queue_0 );
                 }
             }
 

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -90,12 +90,6 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     int64_t mt = B.mt();
     int64_t nt = B.nt();
 
-    // Use only TileReleaseStrategy::Slate for trsm.
-    // Internal routines (trsm and gemm) called here won't release
-    // any tiles. Trsm will clean up tiles.
-    Options opts2 = opts;
-    opts2[ Option::TileReleaseStrategy ] = TileReleaseStrategy::Slate;
-
     // Requires 2+lookahead queues
     if (target == Target::Devices) {
         assert(B.numComputeQueues() >= 2+lookahead);
@@ -119,7 +113,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_1, layout, queue_1, opts2 );
+                    priority_1, layout, queue_1, opts );
 
                 // send A(i=k+1:mt-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -147,7 +141,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_1, queue_ik1, opts2 );
+                        layout, priority_1, queue_ik1, opts );
                 }
             }
 
@@ -165,7 +159,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(k+1+lookahead, mt-1, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(k+1+lookahead, mt-1, 0, nt-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
             }
 
@@ -204,7 +198,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     Side::Left,
                     alph, A.sub(k, k),
                           B.sub(k, k, 0, nt-1),
-                    priority_1, layout, queue_1, opts2 );
+                    priority_1, layout, queue_1, opts );
 
                 // send A(i=0:k-1, k) to ranks owning block row B(i, :)
                 BcastList bcast_list_A;
@@ -229,7 +223,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(i, i, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(i, i, 0, nt-1),
-                        layout, priority_1, queue_ikl2, opts2 );
+                        layout, priority_1, queue_ikl2, opts );
                 }
             }
 
@@ -246,7 +240,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         -one, A.sub(0, k-1-lookahead, k, k),
                               B.sub(k, k, 0, nt-1),
                         alph, B.sub(0, k-1-lookahead, 0, nt-1),
-                        layout, priority_0, queue_0, opts2 );
+                        layout, priority_0, queue_0, opts );
                 }
             }
 

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -245,10 +245,6 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     bcast_list_upd_B.push_back(
                         {k, j, { A.sub(k + 1, mt - 1, k, k), }});
                 }
-
-                auto B_row_k = B.sub( k, k, 0, nt-1 );
-                // XXX Should it be just 1 at the last iteration?
-                // XXX Should we ignore this since the life will be removed
                 B.template listBcast<target>( bcast_list_upd_B, layout, k );
 
             }

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -256,7 +256,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                 auto B_row_k = B.sub( k, k, 0, nt-1 );
                 // XXX Should it be just 1 at the last iteration?
                 // XXX Should we ignore this since the life will be removed
-                B.template listBcast<target>( bcast_list_upd_B, layout, k, lookahead + 1 );
+                B.template listBcast<target>( bcast_list_upd_B, layout, k );
 
             }
 
@@ -409,7 +409,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                     bcast_list_upd_B.push_back(
                         {k, j, { A.sub(0, k - 1, k, k), }});
                 }
-                B.template listBcast<target>(bcast_list_upd_B, layout, k, lookahead + 1 );
+                B.template listBcast<target>(bcast_list_upd_B, layout, k );
             }
 
             // lookahead update, B(k-la:k-1, :) -= A(k-la:k-1, k) B(k, :)

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -70,13 +70,6 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
     const int queue_1 = 1;
 
     int64_t lookahead = get_option<int64_t>( opts, Option::Lookahead, 1 );
-    auto tileStrategy = get_option<TileReleaseStrategy>( opts, Option::TileReleaseStrategy, TileReleaseStrategy::Slate );
-
-    Options local_opts = opts;
-    local_opts[ Option::Lookahead ] = lookahead;
-
-    // XXX This should be removed later, based on Kadir's comment.
-    local_opts[ Option::TileReleaseStrategy ] = tileStrategy;
 
     // Assumes column major
     const Layout layout = Layout::ColMajor;
@@ -108,7 +101,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
 
     // Scale the RHS to handle the alpha issue since B is moved
     // around instead of the A as in trsm
-    // TODO Call scale( alpha, one, B, local_opts ) when
+    // TODO Call scale( alpha, one, B, opts ) when
     // transpose will be handled.
     if (alpha != one) {
         if (target == Target::Devices) {
@@ -218,7 +211,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_1, local_opts );
+                        priority_1, layout, queue_1, opts );
                 }
 
                 // Send the solution back to where it belongs
@@ -272,7 +265,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(i, i, j, j),
-                            layout, priority_1, queue_ik1, local_opts );
+                            layout, priority_1, queue_ik1, opts );
                     }
                 }
             }
@@ -292,7 +285,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(k+1+lookahead, mt-1, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(k+1+lookahead, mt-1, j, j),
-                            layout, priority_0, queue_0, local_opts );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
             }
@@ -379,7 +372,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_1, local_opts );
+                        priority_1, layout, queue_1, opts );
                 }
 
                 // Send the solution back to where it belongs
@@ -423,7 +416,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(i, i, j, j),
-                            layout, priority_1, queue_k1lai, local_opts );
+                            layout, priority_1, queue_k1lai, opts );
                     }
                 }
             }
@@ -443,7 +436,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(0, k-1-lookahead, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(0, k-1-lookahead, j, j),
-                            layout, priority_0, queue_0, local_opts );
+                            layout, priority_0, queue_0, opts );
                     }
                 }
             }

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -211,7 +211,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_1, opts );
+                        priority_1, layout, queue_1 );
                 }
 
                 // Send the solution back to where it belongs
@@ -261,7 +261,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(i, i, j, j),
-                            layout, priority_1, queue_ik1, opts );
+                            layout, priority_1, queue_ik1 );
                     }
                 }
             }
@@ -281,7 +281,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(k+1+lookahead, mt-1, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(k+1+lookahead, mt-1, j, j),
-                            layout, priority_0, queue_0, opts );
+                            layout, priority_0, queue_0 );
                     }
                 }
             }
@@ -368,7 +368,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         Side::Left,
                         one, A.sub(k, k),
                              B.sub(k, k, 0, nt-1),
-                        priority_1, layout, queue_1, opts );
+                        priority_1, layout, queue_1 );
                 }
 
                 // Send the solution back to where it belongs
@@ -412,7 +412,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(i, i, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(i, i, j, j),
-                            layout, priority_1, queue_k1lai, opts );
+                            layout, priority_1, queue_k1lai );
                     }
                 }
             }
@@ -432,7 +432,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                             -one, A.sub(0, k-1-lookahead, k, k),
                                   B.sub(k, k, j, j),
                             one,  B.sub(0, k-1-lookahead, j, j),
-                            layout, priority_0, queue_0, opts );
+                            layout, priority_0, queue_0 );
                     }
                 }
             }

--- a/test/test.cc
+++ b/test/test.cc
@@ -357,7 +357,6 @@ Params::Params():
     method_trsm   ("trsm",   4, ParamType::List, 0, str2methodTrsm,   methodTrsm2str,   "auto=auto, A=trsmA, B=trsmB"),
 
     grid_order("go",      3, ParamType::List, slate::GridOrder::Col,   str2grid_order, grid_order2str, "(go) MPI grid order: c=Col, r=Row"),
-    tile_release_strategy ("trs", 3, ParamType::List, slate::TileReleaseStrategy::All, str2tile_release_strategy,   tile_release_strategy2str,   "tile release strategy: n=none, i=only internal routines, s=only top-level routines in slate namespace, a=all routines"),
     dev_dist  ("dev-dist",9,    ParamType::List, slate::Dist::Col,        str2dist,     dist2str,     "matrix tiles distribution across local devices (one-dimensional block-cyclic): col=column, row=row"),
 
     //         name,      w,    type,            default,                 char2enum,         enum2char,         enum2str,         help

--- a/test/test.hh
+++ b/test/test.hh
@@ -88,7 +88,6 @@ public:
     testsweeper::ParamEnum< slate::Method >         method_trsm;
 
     testsweeper::ParamEnum< slate::GridOrder >      grid_order;
-    testsweeper::ParamEnum< slate::TileReleaseStrategy > tile_release_strategy;
     testsweeper::ParamEnum< slate::Dist >           dev_dist;
 
     // ----- test matrix parameters
@@ -426,34 +425,6 @@ inline const char* grid_order2str( slate::GridOrder grid_order )
         case slate::GridOrder::Col:     return "col";
         case slate::GridOrder::Row:     return "row";
         case slate::GridOrder::Unknown: return "un";
-    }
-    return "?";
-}
-
-// -----------------------------------------------------------------------------
-inline slate::TileReleaseStrategy str2tile_release_strategy(const char* tile_release_strategy)
-{
-    std::string tile_release_strategy_ = tile_release_strategy;
-    std::transform(tile_release_strategy_.begin(), tile_release_strategy_.end(), tile_release_strategy_.begin(), ::tolower);
-    if (tile_release_strategy_ == "n" || tile_release_strategy_ == "none")
-        return slate::TileReleaseStrategy::None;
-    else if (tile_release_strategy_ == "i" || tile_release_strategy_ == "internal")
-        return slate::TileReleaseStrategy::Internal;
-    else if (tile_release_strategy_ == "s" || tile_release_strategy_ == "src")
-        return slate::TileReleaseStrategy::Slate;
-    else if (tile_release_strategy_ == "a" || tile_release_strategy_ == "all")
-        return slate::TileReleaseStrategy::All;
-    else
-        throw slate::Exception("unknown tile_release_strategy");
-}
-
-inline const char* tile_release_strategy2str(slate::TileReleaseStrategy tile_release_strategy)
-{
-    switch (tile_release_strategy) {
-        case slate::TileReleaseStrategy::None:     return "none";
-        case slate::TileReleaseStrategy::Internal: return "int";
-        case slate::TileReleaseStrategy::Slate:    return "src";
-        case slate::TileReleaseStrategy::All:      return "all";
     }
     return "?";
 }

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -47,7 +47,6 @@ void test_posv_work(Params& params, bool run)
     slate::Origin origin = params.origin();
     slate::Target target = params.target();
     slate::Dist dev_dist = params.dev_dist();
-    slate::TileReleaseStrategy tile_release_strategy = params.tile_release_strategy();
     params.matrix.mark();
     params.matrixB.mark();
     slate::Method methodTrsm = params.method_trsm();
@@ -128,7 +127,6 @@ void test_posv_work(Params& params, bool run)
     slate::Options const opts =  {
         {slate::Option::Lookahead, lookahead},
         {slate::Option::Target, target},
-        {slate::Option::TileReleaseStrategy, tile_release_strategy},
         {slate::Option::HoldLocalWorkspace, hold_local_workspace},
         {slate::Option::MethodTrsm, methodTrsm},
         {slate::Option::MethodHemm, methodHemm},

--- a/unit_test/test_Matrix.cc
+++ b/unit_test/test_Matrix.cc
@@ -991,47 +991,6 @@ void test_Matrix_tileInsert_data()
 }
 
 //------------------------------------------------------------------------------
-/// Test tileLife.
-void test_Matrix_tileLife()
-{
-    int lda = roundup(m, mb);
-    std::vector<double> Ad( lda*n );
-    auto A = slate::Matrix<double>::fromLAPACK(
-        m, n, Ad.data(), lda, mb, nb, p, q, mpi_comm );
-
-    const int max_life = 4;
-    for (int j = 0; j < A.nt(); ++j) {
-        for (int i = 0; i < A.mt(); ++i) {
-            if (! A.tileIsLocal(i, j))
-                A.tileInsert(i, j);
-            A.tileLife(i, j, max_life);
-        }
-    }
-
-    for (int life = max_life; life > 0; --life) {
-        for (int j = 0; j < A.nt(); ++j) {
-            for (int i = 0; i < A.mt(); ++i) {
-                if (! A.tileIsLocal(i, j)) {
-                    // non-local tiles get decremented, and deleted when life reaches 0.
-                    test_assert( A.tileLife(i, j) == life );
-                    A.tileTick(i, j);
-                    if (life - 1 == 0)
-                        test_assert_throw_std( A.at(i, j) ); // std::exception (map::at)
-                    else
-                        test_assert( A.tileLife(i, j) == life - 1 );
-                }
-                else {
-                    // local tiles don't get decremented
-                    test_assert( A.tileLife(i, j) == max_life );
-                    A.tileTick(i, j);
-                    test_assert( A.tileLife(i, j) == max_life );
-                }
-            }
-        }
-    }
-}
-
-//------------------------------------------------------------------------------
 /// Test tileErase.
 void test_Matrix_tileErase()
 {
@@ -2170,7 +2129,6 @@ void run_tests()
     run_test(test_Matrix_swap,                 "swap",                                     mpi_comm);
     run_test(test_Matrix_tileInsert_new,       "Matrix::tileInsert(i, j, dev) ",           mpi_comm);
     run_test(test_Matrix_tileInsert_data,      "Matrix::tileInsert(i, j, dev, data, lda)", mpi_comm);
-    run_test(test_Matrix_tileLife,             "Matrix::tileLife",                         mpi_comm);
     run_test(test_Matrix_tileErase,            "Matrix::tileErase",                        mpi_comm);
     run_test(test_Matrix_tileReduceFromSet,    "Matrix::tileReduceFromSet(i, j, set,...)", mpi_comm);
     run_test(test_Matrix_insertLocalTiles,     "Matrix::insertLocalTiles()",               mpi_comm);

--- a/unit_test/test_c_api.cc
+++ b/unit_test/test_c_api.cc
@@ -22,11 +22,6 @@ void test_enums()
     assert( slate_Target_HostBatch == int( slate::Target::HostBatch ) );
     assert( slate_Target_Devices   == int( slate::Target::Devices   ) );
 
-    //----------
-    assert( slate_TileReleaseStrategy_None     == int( slate::TileReleaseStrategy::None     ) );
-    assert( slate_TileReleaseStrategy_Internal == int( slate::TileReleaseStrategy::Internal ) );
-    assert( slate_TileReleaseStrategy_Slate    == int( slate::TileReleaseStrategy::Slate    ) );
-    assert( slate_TileReleaseStrategy_All      == int( slate::TileReleaseStrategy::All      ) );
 
     //----------
     assert( slate_MethodEig_QR == int( slate::MethodEig::QR ) );
@@ -40,7 +35,6 @@ void test_enums()
     assert( slate_Option_MaxPanelThreads     == int( slate::Option::MaxPanelThreads     ) );
     assert( slate_Option_Tolerance           == int( slate::Option::Tolerance           ) );
     assert( slate_Option_Target              == int( slate::Option::Target              ) );
-    assert( slate_Option_TileReleaseStrategy == int( slate::Option::TileReleaseStrategy ) );
     assert( slate_Option_HoldLocalWorkspace  == int( slate::Option::HoldLocalWorkspace  ) );
 
     assert( slate_Option_PrintVerbose        == int( slate::Option::PrintVerbose        ) );

--- a/unit_test/test_lq.cc
+++ b/unit_test/test_lq.cc
@@ -379,14 +379,12 @@ void test_ttlqt_work( int m, int n, int nb, int ib, int p, int q )
         T_panel.tileBcast( 0, j, T.sub( 0, T.mt()-1, j, j ), slate::Layout::ColMajor );
     }
     if (debug) printf( "rank %2d, ttmlq\n", mpi_rank );
-    slate::Options const opts = {{slate::Option::TileReleaseStrategy,
-                                            slate::TileReleaseStrategy::Slate}};
     slate::internal::ttmlq(
         slate::Side::Right, slate::Op::NoTrans,
         std::move( A_panel ),
         std::move( T ),
         std::move( L ),
-        0, opts);
+        0 );
     if (verbose > 1) {
         slate::print( "LQ", L );
     }

--- a/unit_test/test_qr.cc
+++ b/unit_test/test_qr.cc
@@ -380,14 +380,12 @@ void test_ttqrt_work( int m, int n, int nb, int ib, int p, int q )
         T_panel.tileBcast( i, 0, T.sub( i, i, 0, T.nt()-1 ), slate::Layout::ColMajor );
     }
     if (debug) printf( "rank %2d, ttmqr\n", mpi_rank );
-    slate::Options const opts = {{slate::Option::TileReleaseStrategy,
-                                            slate::TileReleaseStrategy::Slate}};
     slate::internal::ttmqr(
         slate::Side::Left, slate::Op::NoTrans,
         std::move( A_panel ),
         std::move( T ),
         std::move( R ),
-        0, opts);
+        0 );
     if (verbose > 1) {
         slate::print( "QR", R );
     }


### PR DESCRIPTION
This PR removes the tile life infrastructure.

While part of the goal in removing tile life is to remove the Hold status, I did not start removing that yet since we still use it in the iterative routines.

In addition to being based on on #150, this PR will have merge conflicts with #2, #122, #127, and #148.  So, we'll need to keep an eye on all that.
