### PR TITLE
Optimize class sizes

### DIFF
--- a/include/slate/BaseBandMatrix.hh
+++ b/include/slate/BaseBandMatrix.hh
@@ -252,7 +252,7 @@ void BaseBandMatrix<scalar_t>::allocateBatchArrays(
     int64_t batch_size, int64_t num_arrays)
 {
     if (batch_size == 0) {
-        for (int device = 0; device < this->num_devices_; ++device)
+        for (int device = 0; device < this->num_devices(); ++device)
             batch_size = std::max(batch_size, getMaxDeviceTiles(device));
     }
     this->storage_->allocateBatchArrays(batch_size, num_arrays);
@@ -264,7 +264,7 @@ template <typename scalar_t>
 void BaseBandMatrix<scalar_t>::reserveDeviceWorkspace()
 {
     int64_t num_tiles = 0;
-    for (int device = 0; device < this->num_devices_; ++device)
+    for (int device = 0; device < this->num_devices(); ++device)
         num_tiles = std::max(num_tiles, getMaxDeviceTiles(device));
     this->storage_->reserveDeviceWorkspace(num_tiles);
 }

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -615,7 +615,7 @@ void BaseTrapezoidMatrix<scalar_t>::allocateBatchArrays(
     int64_t batch_size, int64_t num_arrays)
 {
     if (batch_size == 0) {
-        for (int device = 0; device < this->num_devices_; ++device)
+        for (int device = 0; device < this->num_devices(); ++device)
             batch_size = std::max(batch_size, getMaxDeviceTiles(device));
     }
     this->storage_->allocateBatchArrays(batch_size, num_arrays);
@@ -635,7 +635,7 @@ template <typename scalar_t>
 void BaseTrapezoidMatrix<scalar_t>::reserveDeviceWorkspace()
 {
     int64_t num_tiles = 0;
-    for (int device = 0; device < this->num_devices_; ++device)
+    for (int device = 0; device < this->num_devices(); ++device)
         num_tiles = std::max(num_tiles, getMaxDeviceTiles(device));
     this->storage_->reserveDeviceWorkspace(num_tiles);
 }

--- a/include/slate/Matrix.hh
+++ b/include/slate/Matrix.hh
@@ -726,7 +726,7 @@ void Matrix<scalar_t>::allocateBatchArrays(
     int64_t batch_size, int64_t num_arrays)
 {
     if (batch_size == 0) {
-        for (int device = 0; device < this->num_devices_; ++device)
+        for (int device = 0; device < this->num_devices(); ++device)
             batch_size = std::max(batch_size, getMaxDeviceTiles(device));
     }
     this->storage_->allocateBatchArrays(batch_size, num_arrays);
@@ -746,7 +746,7 @@ template <typename scalar_t>
 void Matrix<scalar_t>::reserveDeviceWorkspace()
 {
     int64_t num_tiles = 0;
-    for (int device = 0; device < this->num_devices_; ++device)
+    for (int device = 0; device < this->num_devices(); ++device)
         num_tiles = std::max(num_tiles, getMaxDeviceTiles(device));
     this->storage_->reserveDeviceWorkspace(num_tiles);
 }

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -117,10 +117,10 @@ MatrixType conjTranspose( MatrixType&& A )
 /// and who owns (allocated, deallocates) the data.
 /// @ingroup enum
 ///
-enum class TileKind {
-    Workspace,   ///< SLATE allocated workspace tile
-    SlateOwned,  ///< SLATE allocated origin tile
-    UserOwned,   ///< User owned origin tile
+enum class TileKind : char {
+    Workspace  = 'w',   ///< SLATE allocated workspace tile
+    SlateOwned = 'o',  ///< SLATE allocated origin tile
+    UserOwned  = 'u',   ///< User owned origin tile
 };
 
 //------------------------------------------------------------------------------
@@ -223,6 +223,12 @@ public:
     /// false if the user provided the tile's memory,
     /// e.g., via a fromScaLAPACK constructor.
     bool allocated() const { return kind_ != TileKind::UserOwned; }
+
+    /// Returns the TileKind of this tile
+    TileKind kind()
+    {
+        return kind_;
+    }
 
     /// Returns number of bytes; but NOT consecutive if stride != mb_.
     size_t bytes() const { return sizeof(scalar_t) * size(); }
@@ -371,11 +377,6 @@ protected:
     void nb(int64_t in_nb);
     void offset(int64_t i, int64_t j);
 
-    void kind(TileKind kind)
-    {
-        kind_ = kind;
-    }
-
     void state(MOSI_State stateIn)
     {
         switch (stateIn) {
@@ -405,12 +406,12 @@ protected:
     int64_t stride_;
     int64_t user_stride_; // Temporarily store user-provided-memory's stride
 
-    Op op_;
-    Uplo uplo_;
-
     scalar_t* data_;
     scalar_t* user_data_; // Temporarily point to user-provided memory buffer.
     scalar_t* ext_data_; // Points to auxiliary buffer.
+
+    Op op_;
+    Uplo uplo_;
 
     TileKind kind_;
     /// layout_: The physical ordering of elements in the data buffer:
@@ -434,11 +435,11 @@ Tile<scalar_t>::Tile()
       nb_(0),
       stride_(0),
       user_stride_(0),
-      op_(Op::NoTrans),
-      uplo_(Uplo::General),
       data_(nullptr),
       user_data_(nullptr),
       ext_data_(nullptr),
+      op_(Op::NoTrans),
+      uplo_(Uplo::General),
       kind_(TileKind::UserOwned),
       layout_(Layout::ColMajor),
       user_layout_(Layout::ColMajor),
@@ -487,11 +488,11 @@ Tile<scalar_t>::Tile(
       nb_(nb),
       stride_(lda),
       user_stride_(lda),
-      op_(Op::NoTrans),
-      uplo_(Uplo::General),
       data_(A),
       user_data_(A),
       ext_data_(nullptr),
+      op_(Op::NoTrans),
+      uplo_(Uplo::General),
       kind_(kind),
       layout_(layout),
       user_layout_(layout),
@@ -530,11 +531,11 @@ Tile<scalar_t>::Tile(
       nb_(src_tile.nb_),
       stride_(lda),
       user_stride_(lda),
-      op_(src_tile.op_),
-      uplo_(src_tile.uplo_),
       data_(A),
       user_data_(A),
       ext_data_(nullptr),
+      op_(src_tile.op_),
+      uplo_(src_tile.uplo_),
       kind_(kind),
       layout_(src_tile.layout_),
       user_layout_(src_tile.user_layout_),

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -179,6 +179,7 @@ public:
     int64_t stride() const { return stride_; }
 
     /// Sets column stride of this tile
+    [[deprecated( "Use setLayout to manage the Tile's layout.  Will be removed 2024-12." )]]
     void stride(int64_t in_stride) { stride_ = in_stride; }
 
     /// Returns const pointer to data, i.e., A(0,0), where A is this tile

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -118,9 +118,9 @@ MatrixType conjTranspose( MatrixType&& A )
 /// @ingroup enum
 ///
 enum class TileKind : char {
-    Workspace  = 'w',   ///< SLATE allocated workspace tile
+    Workspace  = 'w',  ///< SLATE allocated workspace tile
     SlateOwned = 'o',  ///< SLATE allocated origin tile
-    UserOwned  = 'u',   ///< User owned origin tile
+    UserOwned  = 'u',  ///< User owned origin tile
 };
 
 //------------------------------------------------------------------------------

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -452,8 +452,6 @@ private:
     TilesMap tiles_;        ///< map of tiles and associated states
     mutable omp_nest_lock_t lock_;  ///< TilesMap lock
     slate::Memory memory_;  ///< memory allocator
-    scalar_t *host_mem;
-    std::map< int, std::stack<void*> > allocated_mem_;
 
     int mpi_rank_;
     static int num_devices_;

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -454,7 +454,6 @@ private:
     slate::Memory memory_;  ///< memory allocator
     scalar_t *host_mem;
     std::map< int, std::stack<void*> > allocated_mem_;
-    bool own;
 
     int mpi_rank_;
     static int num_devices_;

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -199,6 +199,8 @@ protected:
     void destroyQueues();
 
 public:
+    static int num_devices() { return Memory::num_devices_; };
+
     //--------------------------------------------------------------------------
     // batch arrays
     void allocateBatchArrays(int64_t batch_size, int64_t num_arrays);
@@ -454,7 +456,6 @@ private:
     slate::Memory memory_;  ///< memory allocator
 
     int mpi_rank_;
-    static int num_devices_;
 
     int64_t batch_array_size_;
 
@@ -482,10 +483,6 @@ MatrixStorage<scalar_t>::MatrixStorage(
     slate_mpi_call(
         MPI_Comm_rank(mpi_comm, &mpi_rank_));
 
-    // todo: these are static, but we (re-)initialize with each matrix.
-    // todo: similar code in BaseMatrix(...) and MatrixStorage(...)
-    num_devices_ = memory_.num_devices_;
-
     // functions for computing the tile's size
     tileMb = func::uniform_blocksize(m, mb);
     tileNb = func::uniform_blocksize(n, nb);
@@ -501,8 +498,8 @@ MatrixStorage<scalar_t>::MatrixStorage(
         slate_error( "invalid GridOrder, must be Col or Row" );
     }
     // function for computing the tile's device, assuming 1d block cyclic
-    if (num_devices_ > 0) {
-        tileDevice = func::device_1d_grid( GridOrder::Row, q, num_devices_ );
+    if (num_devices() > 0) {
+        tileDevice = func::device_1d_grid( GridOrder::Row, q, num_devices() );
     }
     else {
         tileDevice = []( ij_tuple ij ) {
@@ -536,10 +533,6 @@ MatrixStorage<scalar_t>::MatrixStorage(
     slate_mpi_call(
         MPI_Comm_rank(mpi_comm, &mpi_rank_));
 
-    // todo: these are static, but we (re-)initialize with each matrix.
-    // todo: similar code in BaseMatrix(...) and MatrixStorage(...)
-    num_devices_ = memory_.num_devices_;
-
     initQueues();
     omp_init_nest_lock(&lock_);
 }
@@ -555,7 +548,7 @@ MatrixStorage<scalar_t>::~MatrixStorage()
         clearBatchArrays();
         // Clear all host and device memory allocations
         memory_.clearHostBlocks();
-        for (int device = 0; device < num_devices_; ++device) {
+        for (int device = 0; device < num_devices(); ++device) {
             blas::Queue* queue = comm_queues_[device];
             memory_.clearDeviceBlocks(device, queue);
         }
@@ -577,11 +570,11 @@ MatrixStorage<scalar_t>::~MatrixStorage()
 template <typename scalar_t>
 void MatrixStorage<scalar_t>::initQueues()
 {
-    comm_queues_   .resize(num_devices_);
+    comm_queues_   .resize(num_devices());
     compute_queues_.resize(1);
 
-    compute_queues_.at(0).resize(num_devices_, nullptr);
-    for (int device = 0; device < num_devices_; ++device) {
+    compute_queues_.at(0).resize(num_devices(), nullptr);
+    for (int device = 0; device < num_devices(); ++device) {
         comm_queues_        [ device ] = new lapack::Queue( device );
         compute_queues_[ 0 ][ device ] = new lapack::Queue( device );
     }
@@ -589,8 +582,8 @@ void MatrixStorage<scalar_t>::initQueues()
     array_host_.resize(1);
     array_dev_ .resize(1);
 
-    array_host_.at(0).resize(num_devices_, nullptr);
-    array_dev_ .at(0).resize(num_devices_, nullptr);
+    array_host_.at(0).resize(num_devices(), nullptr);
+    array_dev_ .at(0).resize(num_devices(), nullptr);
 }
 
 //------------------------------------------------------------------------------
@@ -601,7 +594,7 @@ template <typename scalar_t>
 void MatrixStorage<scalar_t>::destroyQueues()
 {
     int num_queues = int(compute_queues_.size());
-    for (int device = 0; device < num_devices_; ++device) {
+    for (int device = 0; device < num_devices(); ++device) {
         delete comm_queues_[device];
                comm_queues_[device] = nullptr;
 
@@ -647,9 +640,9 @@ void MatrixStorage<scalar_t>::allocateBatchArrays(
         compute_queues_.resize(num_arrays);
 
         for (int64_t i = i_begin; i < num_arrays; ++i) {
-            array_host_    .at(i).resize(num_devices_, nullptr);
-            array_dev_     .at(i).resize(num_devices_, nullptr);
-            compute_queues_.at(i).resize(num_devices_, nullptr);
+            array_host_    .at(i).resize(num_devices(), nullptr);
+            array_dev_     .at(i).resize(num_devices(), nullptr);
+            compute_queues_.at(i).resize(num_devices(), nullptr);
         }
         is_resized = true;
     }
@@ -668,7 +661,7 @@ void MatrixStorage<scalar_t>::allocateBatchArrays(
         assert(int(array_host_.size()) >= num_arrays);
 
         for (std::size_t i = i_begin; i < array_host_.size(); ++i) {
-            for (int device = 0; device < num_devices_; ++device) {
+            for (int device = 0; device < num_devices(); ++device) {
 
                 // Get the original queue for malloc
                 blas::Queue* queue = comm_queues_[device];
@@ -711,7 +704,7 @@ void MatrixStorage<scalar_t>::clearBatchArrays()
     assert(array_host_.size() == array_dev_.size());
 
     for (std::size_t i = 0; i < array_host_.size(); ++i) {
-        for (int device = 0; device < num_devices_; ++device) {
+        for (int device = 0; device < num_devices(); ++device) {
 
             // Get the original queue for memory allocations
             blas::Queue* queue = comm_queues_[device];
@@ -750,7 +743,7 @@ void MatrixStorage<scalar_t>::reserveHostWorkspace(int64_t num_tiles)
 template <typename scalar_t>
 void MatrixStorage<scalar_t>::reserveDeviceWorkspace(int64_t num_tiles)
 {
-    for (int device = 0; device < num_devices_; ++device) {
+    for (int device = 0; device < num_devices(); ++device) {
         int64_t n = num_tiles - memory_.capacity(device);
         if (n > 0) {
             blas::Queue* queue = comm_queues_[device];
@@ -795,7 +788,7 @@ void MatrixStorage<scalar_t>::clearWorkspace()
     LockGuard guard(getTilesMapLock());
     for (auto iter = begin(); iter != end(); /* incremented below */) {
         auto& tile_node = *(iter->second);
-        for (int d = HostNum; d < num_devices_; ++d) {
+        for (int d = HostNum; d < num_devices(); ++d) {
             if (tile_node.existsOn(d) &&
                 tile_node[d]->workspace())
             {
@@ -817,7 +810,7 @@ void MatrixStorage<scalar_t>::clearWorkspace()
         memory_.clearHostBlocks();
     }
 
-    for (int device = 0; device < num_devices_; ++device) {
+    for (int device = 0; device < num_devices(); ++device) {
         if (memory_.allocated(device) == 0) {
             blas::Queue* queue = comm_queues_[device];
             memory_.clearDeviceBlocks(device, queue);
@@ -847,7 +840,7 @@ void MatrixStorage<scalar_t>::releaseWorkspace()
     if (memory_.allocated( HostNum ) == 0) {
         memory_.clearHostBlocks();
     }
-    for (int device = 0; device < num_devices_; ++device) {
+    for (int device = 0; device < num_devices(); ++device) {
         if (memory_.allocated(device) == 0) {
             blas::Queue* queue = comm_queues_[device];
             memory_.clearDeviceBlocks(device, queue);
@@ -905,13 +898,13 @@ void MatrixStorage<scalar_t>::release(
     int end   = device + 1;
     if (device == AllDevices) {
         begin = HostNum;
-        end   = num_devices_;
+        end   = num_devices();
     }
 
     // Don't release tiles if it'd delete the last valid copy
     // Remote tiles never have the last valid copy
     bool last_valid = tileIsLocal( iter->first );
-    for (int dev = HostNum; dev < num_devices_; ++dev) {
+    for (int dev = HostNum; dev < num_devices(); ++dev) {
         if (tile_node.existsOn( dev )
             && (dev < begin || dev >= end || tile_node[ dev ]->origin())
             && ! tile_node[ dev ]->stateOn( MOSI::Invalid )) {
@@ -981,7 +974,7 @@ void MatrixStorage<scalar_t>::erase(ij_tuple ij)
 
         auto& tile_node = iter->second;
 
-        for (int d = HostNum; (! tile_node->empty()) && d < num_devices_; ++d) {
+        for (int d = HostNum; (! tile_node->empty()) && d < num_devices(); ++d) {
             if (tile_node->existsOn(d)) {
                 freeTileMemory(tile_node->at(d));
                 tile_node->eraseOn(d);
@@ -1065,7 +1058,7 @@ Tile<scalar_t>* MatrixStorage<scalar_t>::tileInsert(
     // find the tileNode
     // if not found, insert new-entry in TilesMap
     if (find({i, j}) == end()) {
-        tiles_[{i, j}] = std::make_shared<TileNode_t>( num_devices_ );
+        tiles_[{i, j}] = std::make_shared<TileNode_t>( num_devices() );
     }
     auto& tile_node = this->at({i, j});
 
@@ -1101,13 +1094,13 @@ Tile<scalar_t>* MatrixStorage<scalar_t>::tileInsert(
     int64_t i  = std::get<0>(ijdev);
     int64_t j  = std::get<1>(ijdev);
     int device = std::get<2>(ijdev);
-    slate_assert( HostNum <= device && device < num_devices_ );
+    slate_assert( HostNum <= device && device < num_devices() );
 
     LockGuard guard(getTilesMapLock());
 
     assert(find({i, j}) == end());
     // insert new-entry in map
-    tiles_[{i, j}] = std::make_shared<TileNode_t>( num_devices_ );
+    tiles_[{i, j}] = std::make_shared<TileNode_t>( num_devices() );
 
     auto& tile_node = this->at({i, j});
 
@@ -1179,10 +1172,6 @@ void MatrixStorage<scalar_t>::tileTick(ij_tuple ij)
         }
     }
 }
-
-//------------------------------------------------------------------------------
-template <typename scalar_t>
-int MatrixStorage<scalar_t>::num_devices_ = 0;
 
 } // namespace slate
 

--- a/include/slate/internal/Memory.hh
+++ b/include/slate/internal/Memory.hh
@@ -54,14 +54,20 @@ public:
     /// which can be host.
     size_t available(int device) const
     {
-        return free_blocks_.at(device).size();
+        if (device == HostNum)
+            return 0;
+        else
+            return free_blocks_.at(device).size();
     }
 
     /// @return total number of blocks in device's memory pool,
     /// which can be host.
     size_t capacity(int device) const
     {
-        return capacity_.at(device);
+        if (device == HostNum)
+            return 0;
+        else
+            return capacity_.at(device);
     }
 
     /// @return total number of allocated blocks from device's memory pool,
@@ -89,9 +95,9 @@ private:
     size_t block_size_;
 
     // map device number to stack of blocks
-    std::map< int, std::stack<void*> > free_blocks_;
-    std::map< int, std::stack<void*> > allocated_mem_;
-    std::map< int, size_t > capacity_;
+    std::vector< std::stack<void*> > free_blocks_;
+    std::vector< std::stack<void*> > allocated_mem_;
+    std::vector< size_t > capacity_;
 };
 
 } // namespace slate

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -304,9 +304,9 @@ void Debug::printNumFreeMemBlocks(Memory const& m)
 {
     if (! debug_) return;
     printf("\n");
-    for (auto iter = m.free_blocks_.begin(); iter != m.free_blocks_.end(); ++iter) {
-        printf("\tdevice: %d\tfree blocks: %lu\n", iter->first,
-               (unsigned long) iter->second.size());
+    for (int dev = 0; dev < m.num_devices_; ++dev) {
+        printf("\tdevice: %d\tfree blocks: %lu\n",
+               dev, m.free_blocks_[dev].size());
     }
 }
 

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -194,7 +194,7 @@ void Debug::printTiles_(
         for (int64_t j = 0; j < A.nt(); ++j) {
             msg += pad;
             int life = 0;
-            for (int device = HostNum; device < A.num_devices_; ++device) {
+            for (int device = HostNum; device < A.num_devices(); ++device) {
                 // Space between tiles if multiple fields.
                 if (multi && device > HostNum)
                     msg += ' ';

--- a/src/auxiliary/Debug.cc
+++ b/src/auxiliary/Debug.cc
@@ -204,9 +204,7 @@ void Debug::printTiles_(
                 if (iter != A.storage_->end()) {
                     auto tile = iter->second->at( device );
                     if (do_kind) {
-                        msg += tile->origin()
-                                ? (tile->allocated() ? 'o' : 'u')
-                                : 'w';
+                        msg += char(tile->kind());
                     }
                     if (do_mosi) {
                         char ch = to_char( iter->second->at( device )->state() );

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -5,6 +5,7 @@
 
 #include "auxiliary/Debug.hh"
 #include "slate/internal/Memory.hh"
+#include "slate/Exception.hh"
 
 namespace slate {
 
@@ -14,16 +15,11 @@ Memory::StaticConstructor Memory::static_constructor_;
 //------------------------------------------------------------------------------
 /// Construct saves block size, but does not allocate any memory.
 Memory::Memory(size_t block_size):
-    block_size_(block_size)
+    block_size_(block_size),
+    free_blocks_( num_devices_ ),
+    allocated_mem_( num_devices_ ),
+    capacity_( num_devices_ )
 {
-    // touch maps to create entries;
-    // this allows available() and capacity() to be const by using at()
-    free_blocks_[ HostNum ];
-    capacity_[ HostNum ] = 0;
-    for (int device = 0; device < num_devices_; ++device) {
-        free_blocks_[device];
-        capacity_[device] = 0;
-    }
 }
 
 //------------------------------------------------------------------------------
@@ -35,7 +31,7 @@ Memory::~Memory()
     // needed to release memory (and can't be passed in here).  So to
     // release the memory, an explicit clear must called using the
     // queue parameter ( Memory::clearDeviceBlocks(device, *queue) ).
-    assert(capacity_[ HostNum ] == 0);
+    //assert(capacity_[ HostNum ] == 0);
     for (int device = 0; device < num_devices_; ++device) {
         assert(capacity_[ device ] == 0);
     }
@@ -182,12 +178,16 @@ void* Memory::allocBlock(int device, blas::Queue *queue)
 ///
 void* Memory::allocHostMemory(size_t size)
 {
+    slate_not_implemented( "Memory pool currently doesn't handle host memory" );
+    return nullptr;
+    /*
     void* host_mem;
     host_mem = malloc(size);
     assert(host_mem != nullptr);
     allocated_mem_[ HostNum ].push( host_mem );
 
     return host_mem;
+    */
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR does some miscellaneous cleanup, particularly reducing the size of some classes.

* `Tile`'s member variables were reordered for better packing and `TileKind` was switched to `char` storage
* Deprecated `Tile::stride(int64_t)` since it will break the layout management and removed the unused, internal `Tile::kind(TileKind)`
* Removed some unused member variables in `MatrixStorage`
* Replaced the `std::map`s in `Memory` w/ `std::vectors` since the keys are just `0, 1, ..., num_devices`
* Consolidated all the `num_devices_` into `Memory::num_devices_`.  To assist this change, all of the accesses are replaced with calls to helper functions (which the compiler will inline).