### PR TITLE
Improve GPU thread safety

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2724,7 +2724,7 @@ void BaseMatrix<scalar_t>::tileGet(int64_t i, int64_t j, int dst_device,
 // todo: async version
 template <typename scalar_t>
 void BaseMatrix<scalar_t>::tileGet(std::set<ij_tuple>& tile_set, int device,
-                                   LayoutConvert in_layoutConvert, bool modify, bool hold,
+                                   LayoutConvert layoutConvert, bool modify, bool hold,
                                    bool async)
 {
     if (device != HostNum) {
@@ -2743,21 +2743,12 @@ void BaseMatrix<scalar_t>::tileGet(std::set<ij_tuple>& tile_set, int device,
             storage_->ensureDeviceWorkspace(device, tile_set.size() - existing_tiles);
     }
 
-    LayoutConvert layoutConvert = (device == HostNum)
-                                  ? in_layoutConvert
-                                  : LayoutConvert::None;
-
     for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
         int64_t i = std::get<0>(*iter);
         int64_t j = std::get<1>(*iter);
         {
             tileGet(i, j, device, layoutConvert, modify, hold, true);
         }
-    }
-
-    // todo: if modify and target is host, batch convert on device first
-    if (device != HostNum && in_layoutConvert != LayoutConvert::None) {
-        tileLayoutConvert(tile_set, device, Layout(in_layoutConvert));
     }
 
     if (! async && device != HostNum)


### PR DESCRIPTION
When working #157, I ran into a few errors when using a column-major device distribution with the LU routines.

The first issue is when using GPU->GPU copies, we weren't ensuring the correct synchronization.  Specifically, we were just assumed that any previous copies into `src_device` were complete.  We had ensured this when the previous copy was GPU->GPU, but not if the previous copy was Host->GPU.  `fc0a5c` fixes this by added some extra queue synchronizations.  On Saturn's 16 gtx1060 GPUs w/ single precision, this caused about a 5% performance hit, but is needed for correctness.  (The issue and fix only affects multiple GPUs/proc, so it doesn't affect Frontier.)  Using CUDA streams et al., we might be able to improve that by preventing the host synchronizations.  But, I didn't think I'd have enough time to do that this week with the other things I need to finish up.

The second issue is that `tileLayoutConvert(set<ij_tuple> tiles, int device, ...)` uses different locking from `tileGet`, so doing two calls to `tileGet(set<ij_tuple> tiles, int device, ...)` simultaneously can result in the layout of a tile instance being converted while another tile is trying to copy it.  `26ef41` fixes this by replacing the batch transpose with individual, per tile transposes within `tileCopyDataLayout`.  On Frontier, this doesn't seem to affect the performance of `gemm` or `gesv`.  (Interestingly, it seems to give a few percent speedup on Saturn's 16 gtx1060 GPUs w/ single precision.)