### PR TITLE
Misc cleanup

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -691,24 +691,17 @@ public:
     }
 
     //--------------------------------------------------------------------------
-    /// @return batch arrays for the A, B, or C matrices,
-    /// on host, to send to device
+    /// @return batch arrays on host, to send to device
     scalar_t** array_host(int device, int64_t batch_arrays_index=0)
     {
-        assert(batch_arrays_index >= 0);
-        std::vector< scalar_t** >& array = storage_->array_host_.at(
-                                                            batch_arrays_index);
-        return array.at(device);
+        return storage_->batchArrayHost( device, batch_arrays_index );
     }
 
     //--------------------------------------------------------------------------
-    /// @return batch arrays for the A, B, or C matrices, on device
+    /// @return batch arrays on device
     scalar_t** array_device(int device, int64_t batch_arrays_index=0)
     {
-        assert(batch_arrays_index >= 0);
-        std::vector< scalar_t** >& array = storage_->array_dev_.at(
-                                                            batch_arrays_index);
-        return array.at(device);
+        return storage_->batchArrayDevice( device, batch_arrays_index );
     }
 
     //--------------------------------------------------------------------------
@@ -719,7 +712,7 @@ public:
     ///
     lapack::Queue* comm_queue(int device)
     {
-        return storage_->comm_queues_.at(device);
+        return storage_->comm_queue( device );
     }
 
     //--------------------------------------------------------------------------
@@ -733,9 +726,7 @@ public:
     ///
     lapack::Queue* compute_queue(int device, int queue_index=0)
     {
-        assert((queue_index >= 0) &&
-               (queue_index < int(storage_->compute_queues_.size())));
-        return storage_->compute_queues_.at(queue_index).at(device);
+        return storage_->compute_queue( device, queue_index );
     }
 
     //--------------------------------------------------------------------------
@@ -743,7 +734,7 @@ public:
     ///
     int numComputeQueues()
     {
-        return int(storage_->compute_queues_.size());
+        return storage_->num_compute_queues();
     }
 
 protected:

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -625,9 +625,6 @@ public:
     int       mpiRank()  const { return mpi_rank_; }
     MPI_Group mpiGroup() const { return mpi_group_; }
 
-    [[deprecated("use slate::HostNum constant")]]
-    int       hostNum()  const { return HostNum; }
-
     /// Removes all tiles from matrix.
     /// WARNING: currently this clears the entire parent matrix,
     /// not just a sub-matrix.

--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -144,10 +144,6 @@ public:
     template<typename MatrixType>
     friend MatrixType conj_transpose( MatrixType& A );
 
-    /// @deprecated
-    template<typename MatrixType>
-    friend MatrixType conjTranspose( MatrixType& A );
-
     template <typename T>
     friend void swap(BaseMatrix<T>& A, BaseMatrix<T>& B);
 

--- a/include/slate/BaseTrapezoidMatrix.hh
+++ b/include/slate/BaseTrapezoidMatrix.hh
@@ -768,7 +768,7 @@ template <typename scalar_t>
 void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
 {
     int64_t mt = this->mt();
-    std::vector< std::set<ij_tuple> > tiles_set_host(this->num_devices());
+    std::set<ij_tuple> tiles_set_host;
     std::vector< std::set<ij_tuple> > tiles_set_dev(this->num_devices());
 
     for (int64_t j = 0; j < this->nt(); ++j) {
@@ -784,14 +784,7 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
                     && tile_node[ HostNum ]->origin()) {
                     if (tile_node[ HostNum ]->stateOn( MOSI::Invalid )) {
                         // tileGetForReading(i, j, LayoutConvert::None);
-                        for (int d = 0; d < this->num_devices(); ++d) {
-                            if (tile_node.existsOn(d)
-                                && tile_node[d]->state() != MOSI::Invalid)
-                            {
-                                tiles_set_host[d].insert({i, j});
-                                break;
-                            }
-                        }
+                        tiles_set_host.insert({i, j});
                     }
                 }
                 else {
@@ -813,14 +806,13 @@ void BaseTrapezoidMatrix<scalar_t>::tileUpdateAllOrigin()
 
     #pragma omp taskgroup
     {
-        for (int d = 0; d < this->num_devices(); ++d) {
-            if (! tiles_set_host[d].empty()) {
-                #pragma omp task slate_omp_default_none \
-                    firstprivate( d ) shared( tiles_set_host )
-                {
-                    this->tileGetForReading(tiles_set_host[d], LayoutConvert::None, d);
-                }
+        if (! tiles_set_host.empty()) {
+            #pragma omp task slate_omp_default_none shared( tiles_set_host )
+            {
+                this->tileGetForReading(tiles_set_host, LayoutConvert::None);
             }
+        }
+        for (int d = 0; d < this->num_devices(); ++d) {
             if (! tiles_set_dev[d].empty()) {
                 #pragma omp task slate_omp_default_none \
                     firstprivate( d ) shared( tiles_set_dev )

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -165,10 +165,6 @@ public:
     template <typename TileType>
     friend TileType conj_transpose( TileType& A );
 
-    /// @deprecated
-    template <typename TileType>
-    friend TileType conjTranspose( TileType& A );
-
     /// Returns number of rows of op(A), where A is this tile
     int64_t mb() const { return (op_ == Op::NoTrans ? mb_ : nb_); }
 

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -362,8 +362,11 @@ public:
         return false;
     }
 
+    Tile<scalar_t> slice(
+        Op op, int64_t i, int64_t j, int64_t mb, int64_t nb, Uplo uplo);
+
 protected:
-    // BaseMatrix sets mb, nb, offset.
+    // BaseMatrix sets tile state
     template <typename T>
     friend class BaseMatrix;
 
@@ -372,11 +375,6 @@ protected:
     friend class TileNode;
     template <typename T>
     friend class MatrixStorage;
-
-
-    void mb(int64_t in_mb);
-    void nb(int64_t in_nb);
-    void offset(int64_t i, int64_t j);
 
     void state(MOSI_State stateIn)
     {
@@ -662,81 +660,68 @@ Uplo Tile<scalar_t>::uploPhysical() const
 }
 
 //------------------------------------------------------------------------------
-/// Sets number of rows of op(A), where A is this tile.
+/// Creates a tile with the same data that slices the view of this tile.
 ///
-/// @param[in] in_mb
-///     New number of rows. 0 <= in_mb <= mb.
+/// Specifically offsets the data pointer to op(A)(i, j), where this is this
+/// tile, sets the number of rows and columns to mb, and sets uplo to uplo
 ///
-template <typename scalar_t>
-void Tile<scalar_t>::mb(int64_t in_mb)
-{
-    slate_assert(0 <= in_mb && in_mb <= mb());
-    if (op_ == Op::NoTrans)
-        mb_ = in_mb;
-    else
-        nb_ = in_mb;
-}
-
-//------------------------------------------------------------------------------
-/// Sets number of cols of op(A), where A is this tile.
-///
-/// @param[in] in_nb
-///     New number of cols. 0 <= in_nb <= nb.
-///
-template <typename scalar_t>
-void Tile<scalar_t>::nb(int64_t in_nb)
-{
-    slate_assert(0 <= in_nb && in_nb <= nb());
-    if (op_ == Op::NoTrans)
-        nb_ = in_nb;
-    else
-        mb_ = in_nb;
-}
-
-//------------------------------------------------------------------------------
-/// Offsets data pointer to op(A)(i, j), where A is this tile.
+/// @param[in] op
+///     Whether the matrix is transposed or not
 ///
 /// @param[in] i
-///     Row offset. 0 <= i < mb.
+///     Row offset. 0 <= i <= i+mb < this->mb.
 ///
 /// @param[in] j
-///     Col offset. 0 <= j < nb.
+///     Col offset. 0 <= j <= j+nb < this->nb.
+///
+/// @param[in] mb
+///     Number of rows. 0 <= mb <= this->mb.
+///
+/// @param[in] nb
+///     Number of columns. 0 <= nb <= this->nb.
+///
+/// @param[in] uplo
+///     Upper, lower, or general storage flag
 ///
 template <typename scalar_t>
-void Tile<scalar_t>::offset(int64_t i, int64_t j)
+Tile<scalar_t> Tile<scalar_t>::slice(
+    Op op, int64_t i, int64_t j, int64_t mb, int64_t nb, Uplo uplo)
 {
-    slate_assert(0 <= i && i < mb());
-    slate_assert(0 <= j && j < nb());
+    assert(0 <= i && 0 <= mb && i + mb <= mb_);
+    assert(0 <= j && 0 <= nb && j + nb <= nb_);
 
-    if ((op_ == Op::NoTrans) == (layout_ == Layout::ColMajor)) {
-        data_ = &data_[ i + j*stride_ ];
+    auto out = *this;
+
+    out.op_ = op;
+    out.mb_ = mb;
+    out.nb_ = nb;
+    out.uplo_ = uplo;
+
+    if (layout_ == Layout::ColMajor) {
+        out.data_ = &data_[ i + j*stride_ ];
     }
     else {
-        data_ = &data_[ j + i*stride_ ];
+        out.data_ = &data_[ j + i*stride_ ];
     }
 
-    if ((op_ == Op::NoTrans) == (user_layout_ == Layout::ColMajor)) {
-        user_data_ = &user_data_[ i + j*user_stride_ ];
+    if (user_layout_ == Layout::ColMajor) {
+        out.user_data_ = &user_data_[ i + j*user_stride_ ];
         if (ext_data_ != nullptr) {
-            ext_data_ = &ext_data_[ j + i*nb_];
+            out.ext_data_ = &ext_data_[ j + i*nb_];
         }
     }
     else {
-        user_data_ = &user_data_[ j + i*user_stride_ ];
+        out.user_data_ = &user_data_[ j + i*user_stride_ ];
         if (ext_data_ != nullptr) {
-            ext_data_ = &ext_data_[ i + j*mb_];
+            out.ext_data_ = &ext_data_[ i + j*mb_];
         }
     }
+
+    return out;
 }
 
 //------------------------------------------------------------------------------
 /// Set's the tile's layout, updating the stride and front buffer as need be
-///
-/// @param[in] i
-///     Row offset. 0 <= i < mb.
-///
-/// @param[in] j
-///     Col offset. 0 <= j < nb.
 ///
 template <typename scalar_t>
 void Tile<scalar_t>::setLayout(Layout new_layout)

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -329,18 +329,6 @@ public:
     void clear();
 
     //--------------------------------------------------------------------------
-    /// @return number of allocated tile nodes (size of tiles map).
-    size_t size() const
-    {
-        LockGuard guard(getTilesMapLock());
-        return tiles_.size();
-    }
-
-    //--------------------------------------------------------------------------
-    /// @return True if map has no tiles.
-    bool empty() const { return size() == 0; }
-
-    //--------------------------------------------------------------------------
     /// Return pointer to tiles-map OMP lock
     omp_nest_lock_t* getTilesMapLock()
     {

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -759,15 +759,11 @@ void MatrixStorage<scalar_t>::reserveDeviceWorkspace(int64_t num_tiles)
 template <typename scalar_t>
 void MatrixStorage<scalar_t>::ensureDeviceWorkspace(int device, int64_t num_tiles)
 {
+    slate_assert( device != HostNum );
     int64_t n = num_tiles - memory_.available( device );
     if (n > 0) {
-        if (device != HostNum) {
-            blas::Queue* queue = comm_queues_[ device ];
-            memory_.addDeviceBlocks( device, n, queue );
-        }
-        else {
-            memory_.addHostBlocks( n );
-        }
+        blas::Queue* queue = comm_queues_[ device ];
+        memory_.addDeviceBlocks( device, n, queue );
     }
 }
 

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -570,7 +570,7 @@ MatrixStorage<scalar_t>::~MatrixStorage()
 template <typename scalar_t>
 void MatrixStorage<scalar_t>::initQueues()
 {
-    comm_queues_   .resize(num_devices());
+    comm_queues_.resize(num_devices());
 
     compute_queues_.resize(1);
     compute_queues_.at(0).resize(num_devices(), nullptr);

--- a/include/slate/internal/MatrixStorage.hh
+++ b/include/slate/internal/MatrixStorage.hh
@@ -759,10 +759,15 @@ void MatrixStorage<scalar_t>::reserveDeviceWorkspace(int64_t num_tiles)
 template <typename scalar_t>
 void MatrixStorage<scalar_t>::ensureDeviceWorkspace(int device, int64_t num_tiles)
 {
-    if (memory_.available(device) < size_t(num_tiles)) {
-        // if device==HostNum (-1) use nullptr as queue (not comm_queues_[-1])
-        blas::Queue* queue = ( device == HostNum ? nullptr : comm_queues_[device]);
-        memory_.addDeviceBlocks(device, num_tiles - memory_.available(device), queue);
+    int64_t n = num_tiles - memory_.available( device );
+    if (n > 0) {
+        if (device != HostNum) {
+            blas::Queue* queue = comm_queues_[ device ];
+            memory_.addDeviceBlocks( device, n, queue );
+        }
+        else {
+            memory_.addHostBlocks( n );
+        }
     }
 }
 

--- a/include/slate/internal/Memory.hh
+++ b/include/slate/internal/Memory.hh
@@ -41,10 +41,10 @@ public:
     ~Memory();
 
     // todo: change add* to reserve*?
-    void addHostBlocks(int64_t num_blocks);
+    void addHostBlocks(int64_t num_blocks) { /* No host pool currently */ }
     void addDeviceBlocks(int device, int64_t num_blocks, blas::Queue *queue);
 
-    void clearHostBlocks();
+    void clearHostBlocks() { /* No host pool currently */ }
     void clearDeviceBlocks(int device, blas::Queue *queue);
 
     void* alloc(int device, size_t size, blas::Queue *queue);

--- a/src/core/Memory.cc
+++ b/src/core/Memory.cc
@@ -38,6 +38,7 @@ Memory::~Memory()
     // Debug::printNumFreeMemBlocks(*this);
 }
 
+/*
 //------------------------------------------------------------------------------
 /// Allocates num_blocks in host memory
 /// and adds them to the pool of free blocks.
@@ -45,7 +46,6 @@ Memory::~Memory()
 // todo: merge with addDeviceBlocks by recognizing HostNum?
 void Memory::addHostBlocks(int64_t num_blocks)
 {
-/*
     // or std::byte* (C++17)
     uint8_t* host_mem;
     host_mem = (uint8_t*) allocHostMemory(block_size_*num_blocks);
@@ -53,8 +53,8 @@ void Memory::addHostBlocks(int64_t num_blocks)
 
     for (int64_t i = 0; i < num_blocks; ++i)
         free_blocks_[ HostNum ].push(host_mem + i*block_size_);
-*/
 }
+*/
 
 //------------------------------------------------------------------------------
 /// Allocates num_blocks in given device's memory
@@ -71,13 +71,13 @@ void Memory::addDeviceBlocks(int device, int64_t num_blocks, blas::Queue *queue)
         free_blocks_[device].push(dev_mem + i*block_size_);
 }
 
+/*
 //------------------------------------------------------------------------------
 /// Empties the pool of free blocks of host memory and frees the allocations.
 ///
 // todo: merge with clearDeviceBlocks by recognizing HostNum?
 void Memory::clearHostBlocks()
 {
-/*
     Debug::checkHostMemoryLeaks(*this);
 
     while (! free_blocks_[ HostNum ].empty())
@@ -89,8 +89,8 @@ void Memory::clearHostBlocks()
         allocated_mem_[ HostNum ].pop();
     }
     capacity_[ HostNum ] = 0;
-*/
 }
+*/
 
 //------------------------------------------------------------------------------
 /// Empties the pool of free blocks of given device's memory and frees the


### PR DESCRIPTION
This improves miscellaneous things in SLATE.  I had started trying to cleanup some of the chaff in BaseMatrix/MatrixStorage but ended up including other random improvements.

* Removed some friend declarations to help ensure locality of logic (f564cc8de85971de3e7ea0dc10a9a37804a032a4, c3ec066fe35683b588b8468384c324db9021f6a3)
* Removed some unused internal functions (5a1ff1cb067b2ed343782ef83259fecec50f1105)
* Remove a `BaseMatrix::hostNum()` since it was deprecated over 19 months ago (52ebe3c5cc6c88b3546b1f2f839ba1d8e000e7ae)
* Deprecated `tileGetForReading(set<ij_tuple>, Layout, int from_device)` and removed it's use internally since the `from_device` logic is no longer implemented (15d3f9801383f53cc3d7249dbcff5b09be7ff026)
* Consolidate some logic (ea8b8f96b9ba66d2e973ca9ab54b251fe7a33f9e, 4dc12a5ec28cc96f16668390e1198cf7802bc186)
* Add a fast special case to `BaseMatrix::getRanks` when we know the distribution is 2d block cyclic (4e7871f7c981f7c11b627ae1ca28ce5bd637b47c)
* Allow the compiler to inline some function stubs (0a4fade28e588fc65984db889b811759b686ca03)
* Avoid redundant loop overheads when using multiple devices (3a4a28c9dd3636bf500e7e85b7596941916954fb)
* Simplify banded norms (6e1c7bbef65bba5ce4fbc1bdd75e68e4261a08c1)

Between b37d19d20ce9914fd1610beb4e6ca377af1bc946 and 567efbd18ddc4fea3152301424a9064efb74ced9, we no longer use `getMaxDeviceTiles(int64_t)` in SLATE.  Do we think user's want that available?  Or can we deprecate it?