### PR TITLE
Commits that didn't get pushed to #122

### DIFF
--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -223,15 +223,16 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         int dest = B.tileRank(k, j);
                         if (dest == root) continue;
 
-                        B.tileSend(k, j, dest);
+                        B.template tileSend<target>(k, j, dest);
                     }
                 }
                 else {
                     const int root = A.tileRank(k, k);
 
+                    #pragma omp taskgroup
                     for (int64_t j = 0; j < nt; ++j) {
                         if (B.tileIsLocal(k, j)) {
-                            B.tileRecv(k, j, root, layout);
+                            B.template tileRecv<target>(k, j, root, layout);
                         }
                     }
                 }
@@ -378,15 +379,16 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         int dest = B.tileRank(k, j);
                         if (dest == root) continue;
 
-                        B.tileSend(k, j, dest);
+                        B.template tileSend<target>(k, j, dest);
                     }
                 }
                 else {
                     const int root = A.tileRank(k, k);
 
+                    #pragma omp taskgroup
                     for (int64_t j = 0; j < nt; ++j) {
                         if (B.tileIsLocal(k, j)) {
-                            B.tileRecv(k, j, root, layout);
+                            B.template tileRecv<target>(k, j, root, layout);
                         }
                     }
                 }

--- a/src/work/work_trsmA.cc
+++ b/src/work/work_trsmA.cc
@@ -223,7 +223,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         int dest = B.tileRank(k, j);
                         if (dest == root) continue;
 
-                        B.template tileSend<target>(k, j, dest);
+                        B.tileSend(k, j, dest);
                     }
                 }
                 else {
@@ -379,7 +379,7 @@ void trsmA(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
                         int dest = B.tileRank(k, j);
                         if (dest == root) continue;
 
-                        B.template tileSend<target>(k, j, dest);
+                        B.tileSend(k, j, dest);
                     }
                 }
                 else {


### PR DESCRIPTION
I accidentally forgot to push these commits to #122 .  This is what gives the 10% speedup for `trsmA` on Frontier.

Note the `omp taskgroup`s around the device-aware `tileRecv` calls wrt to the comments about the OpenMP task in `tileRecv`.