### PR TITLE
cleanup Tile namespace

### DIFF
--- a/examples/util.hh
+++ b/examples/util.hh
@@ -41,8 +41,9 @@ void random_matrix( int64_t m, int64_t n, scalar_type* A, int64_t lda )
 {
     for (int64_t j = 0; j < n; ++j) {
         for (int64_t i = 0; i < m; ++i) {
-            A[ i + j*lda ] = make<scalar_type>( rand() / double(RAND_MAX),
-                                                rand() / double(RAND_MAX) );
+            A[ i + j*lda ] = blas::make_scalar<scalar_type>(
+                                 rand() / double(RAND_MAX),
+                                 rand() / double(RAND_MAX) );
         }
     }
 }
@@ -56,8 +57,9 @@ void random_matrix_diag_dominant( int64_t m, int64_t n, scalar_type* A, int64_t 
     int64_t max_mn = std::max( m, n );
     for (int64_t j = 0; j < n; ++j) {
         for (int64_t i = 0; i < m; ++i) {
-            A[ i + j*lda ] = make<scalar_type>( rand() / double(RAND_MAX),
-                                                rand() / double(RAND_MAX) );
+            A[ i + j*lda ] = blas::make_scalar<scalar_type>(
+                                 rand() / double(RAND_MAX),
+                                 rand() / double(RAND_MAX) );
         }
         if (j < m) {
             // make diagonal real & dominant

--- a/old/src/internal/internal_gemm_split.cc
+++ b/old/src/internal/internal_gemm_split.cc
@@ -5,7 +5,6 @@
 
 #include "slate/Matrix.hh"
 #include "slate/types.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 #include "internal/internal_batch.hh"
 

--- a/src/bdsqr.cc
+++ b/src/bdsqr.cc
@@ -5,7 +5,6 @@
 
 #include "slate/slate.hh"
 // #include "auxiliary/Debug.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularBandMatrix.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"

--- a/src/gbsv.cc
+++ b/src/gbsv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gbtrf.cc
+++ b/src/gbtrf.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/BandMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gbtrs.cc
+++ b/src/gbtrs.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularBandMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gels.cc
+++ b/src/gels.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gels_cholqr.cc
+++ b/src/gels_cholqr.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gels_qr.cc
+++ b/src/gels_qr.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gesv.cc
+++ b/src/gesv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/gesv_mixed.cc
+++ b/src/gesv_mixed.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/gesv_mixed_gmres.cc
+++ b/src/gesv_mixed_gmres.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/gesv_nopiv.cc
+++ b/src/gesv_nopiv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/getrf.cc
+++ b/src/getrf.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/getrf_nopiv.cc
+++ b/src/getrf_nopiv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/getrf_tntpiv.cc
+++ b/src/getrf_tntpiv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/getriOOP.cc
+++ b/src/getriOOP.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/getrs.cc
+++ b/src/getrs.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/getrs_nopiv.cc
+++ b/src/getrs_nopiv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/heev.cc
+++ b/src/heev.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/HermitianBandMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/hegv.cc
+++ b/src/hegv.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/HermitianBandMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/hesv.cc
+++ b/src/hesv.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/hetrs.cc
+++ b/src/hetrs.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/internal/Tile_geqrf.hh
+++ b/src/internal/Tile_geqrf.hh
@@ -21,7 +21,7 @@
 #include <lapack.hh>
 
 namespace slate {
-namespace internal {
+namespace tile {
 
 //------------------------------------------------------------------------------
 /// Compute the QR factorization of a panel.
@@ -487,7 +487,7 @@ void geqrf(
     }
 }
 
-} // namespace internal
+} // namespace tile
 } // namespace slate
 
 #endif // SLATE_TILE_GEQRF_HH

--- a/src/internal/Tile_geqrf.hh
+++ b/src/internal/Tile_geqrf.hh
@@ -78,6 +78,8 @@ void geqrf(
 {
     trace::Block trace_block("lapack::geqrf");
 
+    using std::real;
+    using std::imag;
     using blas::conj;
     using real_t = blas::real_type<scalar_t>;
 
@@ -221,7 +223,8 @@ void geqrf(
                 }
 
                 // todo: Use overflow-safe division (see CLADIV/ZLADIV)
-                scalar_t tau = make<scalar_t>((beta-alphr)/beta, -alphi/beta);
+                scalar_t tau = blas::make_scalar<scalar_t>(
+                                   (beta - alphr) / beta, -alphi / beta );
                 scalar_t scal_alpha = one / (alpha-beta);
                 scalar_t ger_alpha = -conj(tau);
                 betas.at(j) = beta;

--- a/src/internal/Tile_geqrf.hh
+++ b/src/internal/Tile_geqrf.hh
@@ -8,8 +8,6 @@
 
 #include "internal/internal_util.hh"
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 #include "slate/internal/util.hh"
 

--- a/src/internal/Tile_gerbt.hh
+++ b/src/internal/Tile_gerbt.hh
@@ -7,7 +7,7 @@
 
 namespace slate {
 
-namespace internal {
+namespace tile {
 
 //------------------------------------------------------------------------------
 /// Applies a single butterfly matrix to each side of A.
@@ -266,7 +266,7 @@ void gerbt_right_trans(Tile<scalar_t> B1,
     }
 }
 
-} // namespace internal
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_getrf.hh
+++ b/src/internal/Tile_getrf.hh
@@ -9,8 +9,6 @@
 #include "internal/internal.hh"
 #include "internal/internal_swap.hh"
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 #include "slate/internal/util.hh"
 

--- a/src/internal/Tile_henorm.hh
+++ b/src/internal/Tile_henorm.hh
@@ -12,6 +12,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// Hermitian matrix norm.
 /// The only difference from symmetric matrix norm is the diagonal is assumed
@@ -105,6 +107,8 @@ void henorm(Norm norm, Tile<scalar_t> const&& A,
 {
     return henorm(norm, A, values);
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_householder_reflection_generator.hh
+++ b/src/internal/Tile_householder_reflection_generator.hh
@@ -21,7 +21,7 @@
 #include <lapack.hh>
 
 namespace slate {
-namespace internal {
+namespace tile {
 
 //--------------------------------------------------------------------------------
 /// Compute at the qr2 level, Householder reflections of a panel, with tau scalars.
@@ -308,7 +308,8 @@ void householder_reflection_generator(
         }
     }
 }
-} // namespace internal
+
+} // namespace tile
 } // namespace slate
 
 #endif // SLATE_TILE_HOUSEHOLDER_REFLECTION_GENERATOR

--- a/src/internal/Tile_householder_reflection_generator.hh
+++ b/src/internal/Tile_householder_reflection_generator.hh
@@ -8,8 +8,6 @@
 
 #include "internal/internal_util.hh"
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 #include "slate/internal/util.hh"
 

--- a/src/internal/Tile_householder_reflection_generator.hh
+++ b/src/internal/Tile_householder_reflection_generator.hh
@@ -134,7 +134,8 @@ void householder_reflection_generator(
             -std::copysign(lapack::lapy3(alphr, alphi, xnorm), alphr);
 
         scalar_t scal_alpha = one / (alpha-beta);
-        scalar_t tau = make<scalar_t>((beta-alphr)/beta, -alphi/beta);
+        scalar_t tau = blas::make_scalar<scalar_t>(
+                           (beta - alphr) / beta, -alphi / beta );
         betas.at(k) = beta; // only need beta for correct QR-factorization
         taus.at(k) = tau;
 

--- a/src/internal/Tile_lapack.hh
+++ b/src/internal/Tile_lapack.hh
@@ -15,6 +15,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// General matrix norm.
 /// @ingroup norm_tile
@@ -410,6 +412,8 @@ int64_t scale(scalar_t value, Tile<scalar_t>&& A)
 {
     return scale(value, A);
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_synorm.hh
+++ b/src/internal/Tile_synorm.hh
@@ -12,6 +12,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// Symmetric matrix norm.
 /// @ingroup norm_tile
@@ -105,9 +107,10 @@ void synorm(Norm norm, Tile<scalar_t> const&& A,
 /// @ingroup norm_tile
 ///
 template <typename scalar_t>
-void synormOffdiag(Norm norm, Tile<scalar_t> const& A,
-                    blas::real_type<scalar_t>* col_sums,
-                    blas::real_type<scalar_t>* row_sums)
+void synorm_offdiag(
+    Norm norm, Tile<scalar_t> const& A,
+    blas::real_type<scalar_t>* col_sums,
+    blas::real_type<scalar_t>* row_sums )
 {
     using real_t = blas::real_type<scalar_t>;
 
@@ -142,12 +145,15 @@ void synormOffdiag(Norm norm, Tile<scalar_t> const& A,
 /// @ingroup norm_tile
 ///
 template <typename scalar_t>
-void synormOffdiag(Norm norm, Tile<scalar_t> const&& A,
-                    blas::real_type<scalar_t>* col_sums,
-                    blas::real_type<scalar_t>* row_sums)
+void synorm_offdiag(
+    Norm norm, Tile<scalar_t> const&& A,
+    blas::real_type<scalar_t>* col_sums,
+    blas::real_type<scalar_t>* row_sums )
 {
-    return synormOffdiag(norm, A, col_sums, row_sums);
+    return synorm_offdiag( norm, A, col_sums, row_sums );
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_tplqt.hh
+++ b/src/internal/Tile_tplqt.hh
@@ -8,8 +8,6 @@
 
 #include "internal/internal.hh"
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 #include "slate/internal/util.hh"
 

--- a/src/internal/Tile_tplqt.hh
+++ b/src/internal/Tile_tplqt.hh
@@ -21,6 +21,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// Compute the triangular-pentagonal LQ factorization of 2 tiles, A1 and A2.
 /// On exit, the pentagonal tile A2 has been eliminated.
@@ -172,6 +174,8 @@ void tplqt(
     slate_not_implemented( "In gelqf: tplqt requires LAPACK >= 3.7" );
 #endif
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_tpmlqt.hh
+++ b/src/internal/Tile_tpmlqt.hh
@@ -17,6 +17,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// Multiply the matrix C by the unitary matrix Q obtained from a
 /// "triangular-pentagonal" block reflector H.
@@ -147,6 +149,8 @@ void tpmlqt(
     slate_not_implemented( "In gelqf: tpmlqt requires LAPACK >= 3.7" );
 #endif
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_tpmqrt.hh
+++ b/src/internal/Tile_tpmqrt.hh
@@ -17,6 +17,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// Multiply the matrix C by the unitary matrix Q obtained from a
 /// "triangular-pentagonal" block reflector H.
@@ -147,6 +149,8 @@ void tpmqrt(
     slate_not_implemented( "In geqrf: tpmqrt requires LAPACK >= 3.4" );
 #endif
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_tpqrt.hh
+++ b/src/internal/Tile_tpqrt.hh
@@ -21,6 +21,8 @@
 
 namespace slate {
 
+namespace tile {
+
 //------------------------------------------------------------------------------
 /// Compute the triangular-pentagonal QR factorization of 2 tiles, A1 and A2.
 /// On exit, the pentagonal tile A2 has been eliminated.
@@ -169,6 +171,8 @@ void tpqrt(
     slate_not_implemented( "In geqrf: tpqrt requires LAPACK >= 3.4" );
 #endif
 }
+
+} // namespace tile
 
 } // namespace slate
 

--- a/src/internal/Tile_tpqrt.hh
+++ b/src/internal/Tile_tpqrt.hh
@@ -8,8 +8,6 @@
 
 #include "internal/internal.hh"
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 #include "slate/internal/util.hh"
 

--- a/src/internal/internal_copyhb2st.cc
+++ b/src/internal/internal_copyhb2st.cc
@@ -6,7 +6,6 @@
 #include "slate/Matrix.hh"
 #include "slate/HermitianBandMatrix.hh"
 #include "slate/types.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 
 namespace slate {

--- a/src/internal/internal_copytb2bd.cc
+++ b/src/internal/internal_copytb2bd.cc
@@ -6,7 +6,6 @@
 #include "slate/Matrix.hh"
 #include "slate/TriangularBandMatrix.hh"
 #include "slate/types.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 
 namespace slate {

--- a/src/internal/internal_gbnorm.cc
+++ b/src/internal/internal_gbnorm.cc
@@ -91,7 +91,8 @@ void norm(
                     {
                         A.tileGetForReading(i, j, LayoutConvert(layout));
                         real_t tile_max;
-                        genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                        tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                      &tile_max );
                         #pragma omp critical
                         {
                             tiles_maxima.push_back(tile_max);
@@ -126,7 +127,8 @@ void norm(
                         firstprivate(i, j, layout, jj, in_norm) priority(priority)
                     {
                         A.tileGetForReading(i, j, LayoutConvert(layout));
-                        genorm(in_norm, NormScope::Matrix, A(i, j), &tiles_sums[A.n()*i+jj]);
+                        tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                      &tiles_sums[ A.n()*i + jj ] );
                     }
                 }
             }
@@ -165,7 +167,8 @@ void norm(
                         firstprivate(i, j, ii, in_norm, layout) priority(priority)
                     {
                         A.tileGetForReading(i, j, LayoutConvert(layout));
-                        genorm(in_norm, NormScope::Matrix, A(i, j), &tiles_sums[A.m()*j + ii]);
+                        tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                      &tiles_sums[ A.m()*j + ii ] );
                     }
                 }
             }
@@ -206,7 +209,8 @@ void norm(
                     {
                         A.tileGetForReading(i, j, LayoutConvert(layout));
                         real_t tile_values[2];
-                        genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                        tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                      tile_values );
                         #pragma omp critical
                         {
                             combine_sumsq(values[0], values[1],
@@ -265,7 +269,7 @@ void norm(
             if (A.tileIsLocal(i, j)) {
                 A.tileGetForReading(i, j, LayoutConvert(layout));
                 real_t tile_max;
-                genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                tile::genorm( in_norm, NormScope::Matrix, A( i, j ), &tile_max );
                 #pragma omp critical
                 {
                     tiles_maxima.push_back(tile_max);

--- a/src/internal/internal_genorm.cc
+++ b/src/internal/internal_genorm.cc
@@ -77,7 +77,7 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, scope, A(i, j), &tile_max);
+                            tile::genorm( in_norm, scope, A( i, j ), &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -110,7 +110,8 @@ void norm(
                             firstprivate(i, j, layout, in_norm, scope, jj) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, scope, A(i, j), &tiles_sums[A.n()*i+jj]);
+                            tile::genorm( in_norm, scope, A( i, j ),
+                                          &tiles_sums[ A.n()*i + jj ] );
                         }
                     }
                     jj += A.tileNb(j);
@@ -156,7 +157,8 @@ void norm(
                             firstprivate(i, j, layout, in_norm, scope, ii) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, scope, A(i, j), &tiles_sums[A.m()*j + ii]);
+                            tile::genorm( in_norm, scope, A( i, j ),
+                                          &tiles_sums[ A.m()*j + ii ] );
                         }
                     }
                 ii += A.tileMb(i);
@@ -202,7 +204,7 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, scope, A(i, j), tile_values);
+                            tile::genorm( in_norm, scope, A( i, j ), tile_values );
                             #pragma omp critical
                             {
                                 combine_sumsq(values[0], values[1],
@@ -229,7 +231,8 @@ void norm(
                             firstprivate(i, j, layout, in_norm, scope, jj) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, scope, A(i, j), &cols_maxima[A.n()*i+jj]);
+                            tile::genorm( in_norm, scope, A( i, j ),
+                                          &cols_maxima[ A.n()*i + jj ] );
                         }
                     }
                     jj += A.tileNb(j);
@@ -298,7 +301,7 @@ void norm(
                 if (A.tileIsLocal(i, j)) {
                     A.tileGetForReading(i, j, LayoutConvert(layout));
                     real_t tile_max;
-                    genorm(in_norm, scope, A(i, j), &tile_max);
+                    tile::genorm( in_norm, scope, A( i, j ), &tile_max );
                     #pragma omp critical
                     {
                         tiles_maxima.push_back(tile_max);
@@ -326,7 +329,8 @@ void norm(
             for (int64_t j = 0; j < A_nt; ++j) {
                 if (A.tileIsLocal(i, j)) {
                     A.tileGetForReading(i, j, LayoutConvert(layout));
-                    genorm(in_norm, scope, A(i, j), &cols_maxima[A.n()*i+jj]);
+                    tile::genorm( in_norm, scope, A( i, j ),
+                                  &cols_maxima[ A.n()*i + jj ] );
                 }
                 jj += A.tileNb(j);
             }

--- a/src/internal/internal_geqrf.cc
+++ b/src/internal/internal_geqrf.cc
@@ -109,11 +109,11 @@ void geqrf(
             // todo: double check the size of W.
             int thread_rank = omp_get_thread_num();
             W.at(thread_rank).resize(ib*A.tileNb(0));
-            geqrf(ib,
-                  tiles, tile_indices, T00,
-                  thread_rank, thread_size,
-                  thread_barrier,
-                  scale, sumsq, xnorm, W);
+            tile::geqrf( ib,
+                         tiles, tile_indices, T00,
+                         thread_rank, thread_size,
+                         thread_barrier,
+                         scale, sumsq, xnorm, W );
         }
     }
 }

--- a/src/internal/internal_gerbt.cc
+++ b/src/internal/internal_gerbt.cc
@@ -156,7 +156,7 @@ void gerbt(Matrix<scalar_t> A11,
                         a22 = Tile<scalar_t>(a21.mb(), a12.nb(), &dummy, a21.mb(), HostNum,
                                              TileKind::SlateOwned, Layout::ColMajor);
                     }
-                    gerbt( a11, a12, a21, a22, u1, u2, v1, v2 );
+                    tile::gerbt( a11, a12, a21, a22, u1, u2, v1, v2 );
                 }
             }
         }
@@ -324,30 +324,30 @@ void gerbt(Side side,
 
                     if (leftp) {
                         if (transp) {
-                            gerbt_left_trans( B1(ii, jj),
-                                              B2(ii, jj),
-                                              U1(ii, 0),
-                                              U2(ii, 0) );
+                            tile::gerbt_left_trans( B1( ii, jj ),
+                                                    B2( ii, jj ),
+                                                    U1( ii, 0  ),
+                                                    U2( ii, 0  ) );
                         }
                         else {
-                            gerbt_left_notrans( B1(ii, jj),
-                                                B2(ii, jj),
-                                                U1(ii, 0),
-                                                U2(ii, 0) );
+                            tile::gerbt_left_notrans( B1( ii, jj ),
+                                                      B2( ii, jj ),
+                                                      U1( ii, 0  ),
+                                                      U2( ii, 0  ) );
                         }
                     }
                     else {
                         if (transp) {
-                            gerbt_right_trans( B1(ii, jj),
-                                               B2(ii, jj),
-                                               U1(jj, 0),
-                                               U2(jj, 0) );
+                            tile::gerbt_right_trans( B1( ii, jj ),
+                                                     B2( ii, jj ),
+                                                     U1( jj, 0  ),
+                                                     U2( jj, 0  ) );
                         }
                         else {
-                            gerbt_right_notrans( B1(ii, jj),
-                                                 B2(ii, jj),
-                                                 U1(jj, 0),
-                                                 U2(jj, 0) );
+                            tile::gerbt_right_notrans( B1( ii, jj ),
+                                                       B2( ii, jj ),
+                                                       U1( jj, 0  ),
+                                                       U2( jj, 0  ) );
                         }
                     }
                 }
@@ -374,10 +374,10 @@ void gerbt(Side side,
                                             TileKind::SlateOwned, Layout::ColMajor);
 
                         if (transp) {
-                            gerbt_left_trans( b1, b2, u1, u2 );
+                            tile::gerbt_left_trans( b1, b2, u1, u2 );
                         }
                         else {
-                            gerbt_left_notrans( b1, b2, u1, u2 );
+                            tile::gerbt_left_notrans( b1, b2, u1, u2 );
                         }
                     }
                 }
@@ -404,10 +404,10 @@ void gerbt(Side side,
                                             TileKind::SlateOwned, Layout::ColMajor);
 
                         if (transp) {
-                            gerbt_right_trans( b1, b2, u1, u2 );
+                            tile::gerbt_right_trans( b1, b2, u1, u2 );
                         }
                         else {
-                            gerbt_right_notrans( b1, b2, u1, u2 );
+                            tile::gerbt_right_notrans( b1, b2, u1, u2 );
                         }
                     }
                 }

--- a/src/internal/internal_gescale.cc
+++ b/src/internal/internal_gescale.cc
@@ -50,7 +50,7 @@ void scale(
                     firstprivate(i, j, numer, denom) priority(priority)
                 {
                     A.tileGetForWriting(i, j, LayoutConvert::None);
-                    scale(numer, denom, A(i, j));
+                    tile::scale( numer, denom, A( i, j ) );
                 }
             }
         }

--- a/src/internal/internal_geset.cc
+++ b/src/internal/internal_geset.cc
@@ -8,7 +8,6 @@
 #include "internal/internal.hh"
 #include "slate/internal/util.hh"
 #include "slate/Matrix.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 
 namespace slate {

--- a/src/internal/internal_hbnorm.cc
+++ b/src/internal/internal_hbnorm.cc
@@ -91,7 +91,7 @@ void norm(
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
                     real_t tile_max;
-                    henorm(in_norm, A(j, j), &tile_max);
+                    tile::henorm( in_norm, A( j, j ), &tile_max );
                     #pragma omp critical
                     {
                         tiles_maxima.push_back(tile_max);
@@ -109,7 +109,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -128,7 +129,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -162,7 +164,8 @@ void norm(
                     firstprivate(j, jj, layout, in_norm) priority(priority)
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
-                    henorm(in_norm, A(j, j), &tiles_sums[A.n()*j + jj]);
+                    tile::henorm( in_norm, A( j, j ),
+                                  &tiles_sums[ A.n()*j + jj ] );
                 }
             }
             // off-diagonal tiles (same as synorm)
@@ -173,12 +176,13 @@ void norm(
                     if (A.tileIsLocal(i, j)) {
                         #pragma omp task slate_omp_default_none \
                             shared( A, tiles_sums ) \
-                            firstprivate(i, j, ii, jj, layout, in_norm) priority(priority)
+                            firstprivate( i, j, ii, jj, layout, in_norm ) \
+                            priority( priority )
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            synormOffdiag(in_norm, A(i, j),
-                                          &tiles_sums[A.n()*i + jj],
-                                          &tiles_sums[A.n()*j + ii]);
+                            tile::synorm_offdiag( in_norm, A( i, j ),
+                                                  &tiles_sums[ A.n()*i + jj ],
+                                                  &tiles_sums[ A.n()*j + ii ] );
                         }
                     }
                     ii += A.tileMb(i);
@@ -194,12 +198,13 @@ void norm(
                         if (A.tileIsLocal(i, j)) {
                             #pragma omp task slate_omp_default_none \
                                 shared( A, tiles_sums ) \
-                                firstprivate(i, j, ii, jj, layout, in_norm) priority(priority)
+                                firstprivate( i, j, ii, jj, layout, in_norm ) \
+                                priority( priority )
                             {
                                 A.tileGetForReading(i, j, LayoutConvert(layout));
-                                synormOffdiag(in_norm, A(i, j),
-                                              &tiles_sums[A.n()*i + jj],
-                                              &tiles_sums[A.n()*j + ii]);
+                                tile::synorm_offdiag( in_norm, A( i, j ),
+                                                      &tiles_sums[ A.n()*i + jj ],
+                                                      &tiles_sums[ A.n()*j + ii ] );
                             }
                     }
                     ii += A.tileMb(i);
@@ -266,7 +271,7 @@ void norm(
             if (j < A.mt() && A.tileIsLocal(j, j)) {
                 A.tileGetForReading(j, j, LayoutConvert(layout));
                 real_t tile_values[2];
-                henorm(in_norm, A(j, j), tile_values);
+                tile::henorm( in_norm, A( j, j ), tile_values );
                 #pragma omp critical
                 {
                     combine_sumsq(values[0], values[1],
@@ -284,7 +289,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             // double for symmetric entries
                             tile_values[1] *= 2;
                             #pragma omp critical
@@ -306,7 +312,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             // double for symmetric entries
                             tile_values[1] *= 2;
                             #pragma omp critical

--- a/src/internal/internal_hegst.cc
+++ b/src/internal/internal_hegst.cc
@@ -41,11 +41,9 @@ void hegst(internal::TargetType<Target::HostTask>,
     assert(B.nt() == 1);
 
     if (A.tileIsLocal(0, 0)) {
-        {
-            A.tileGetForWriting(0, 0, LayoutConvert::ColMajor);
-            B.tileGetForReading(0, 0, LayoutConvert::ColMajor);
-            hegst(itype, A(0, 0), B(0, 0));
-        }
+        A.tileGetForWriting( 0, 0, LayoutConvert::ColMajor );
+        B.tileGetForReading( 0, 0, LayoutConvert::ColMajor );
+        tile::hegst( itype, A( 0, 0 ), B( 0, 0 ) );
     }
 }
 

--- a/src/internal/internal_henorm.cc
+++ b/src/internal/internal_henorm.cc
@@ -83,7 +83,7 @@ void norm(
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
                     real_t tile_max;
-                    henorm(in_norm, A(j, j), &tile_max);
+                    tile::henorm( in_norm, A( j, j ), &tile_max );
                     #pragma omp critical
                     {
                         tiles_maxima.push_back(tile_max);
@@ -100,7 +100,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -118,7 +119,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -151,7 +153,7 @@ void norm(
                     firstprivate(j, jj, layout, in_norm) priority(priority)
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
-                    henorm(in_norm, A(j, j), &tiles_sums[A.n()*j + jj]);
+                    tile::henorm( in_norm, A( j, j ), &tiles_sums[ A.n()*j + jj ] );
                 }
             }
             // off-diagonal tiles (same as synorm)
@@ -164,9 +166,9 @@ void norm(
                             firstprivate(i, j, ii, jj, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            synormOffdiag(in_norm, A(i, j),
-                                          &tiles_sums[A.n()*i + jj],
-                                          &tiles_sums[A.n()*j + ii]);
+                            tile::synorm_offdiag( in_norm, A( i, j ),
+                                                  &tiles_sums[ A.n()*i + jj ],
+                                                  &tiles_sums[ A.n()*j + ii ] );
                         }
                     }
                     ii += A.tileMb(i);
@@ -181,9 +183,9 @@ void norm(
                             firstprivate(i, j, ii, jj, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            synormOffdiag(in_norm, A(i, j),
-                                          &tiles_sums[A.n()*i + jj],
-                                          &tiles_sums[A.n()*j + ii]);
+                            tile::synorm_offdiag( in_norm, A( i, j ),
+                                                  &tiles_sums[ A.n()*i + jj ],
+                                                  &tiles_sums[ A.n()*j + ii ] );
                         }
                     }
                     ii += A.tileMb(i);
@@ -247,7 +249,7 @@ void norm(
             if (j < A.mt() && A.tileIsLocal(j, j)) {
                 A.tileGetForReading(j, j, LayoutConvert(layout));
                 real_t tile_values[2];
-                henorm(in_norm, A(j, j), tile_values);
+                tile::henorm( in_norm, A( j, j ), tile_values );
                 #pragma omp critical
                 {
                     combine_sumsq(values[0], values[1],
@@ -264,7 +266,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             // double for symmetric entries
                             tile_values[1] *= 2;
                             #pragma omp critical
@@ -285,7 +288,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             // double for symmetric entries
                             tile_values[1] *= 2;
                             #pragma omp critical

--- a/src/internal/internal_norm1est.cc
+++ b/src/internal/internal_norm1est.cc
@@ -5,7 +5,6 @@
 
 #include "slate/slate.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/HermitianBandMatrix.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"

--- a/src/internal/internal_potrf.cc
+++ b/src/internal/internal_potrf.cc
@@ -44,7 +44,7 @@ int64_t potrf(
     int64_t info = 0;
     if (A.tileIsLocal( 0, 0 )) {
         A.tileGetForWriting( 0, 0, LayoutConvert::ColMajor );
-        info = potrf( A( 0, 0 ) );
+        info = tile::potrf( A( 0, 0 ) );
     }
     return info;
 }

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -82,7 +82,7 @@ void norm(
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
                     real_t tile_max;
-                    synorm(in_norm, A(j, j), &tile_max);
+                    tile::synorm( in_norm, A( j, j ), &tile_max );
                     #pragma omp critical
                     {
                         tiles_maxima.push_back(tile_max);
@@ -99,7 +99,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -117,7 +118,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -150,7 +152,8 @@ void norm(
                     firstprivate(j, jj, layout, in_norm) priority(priority)
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
-                    synorm(in_norm, A(j, j), &tiles_sums[A.n()*j + jj]);
+                    tile::synorm( in_norm, A( j, j ),
+                                  &tiles_sums[ A.n()*j + jj ] );
                 }
             }
             // off-diagonal tiles
@@ -163,9 +166,9 @@ void norm(
                             firstprivate(i, j, ii, jj, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            synormOffdiag(in_norm, A(i, j),
-                                          &tiles_sums[A.n()*i + jj],
-                                          &tiles_sums[A.n()*j + ii]);
+                            tile::synorm_offdiag( in_norm, A( i, j ),
+                                                  &tiles_sums[ A.n()*i + jj ],
+                                                  &tiles_sums[ A.n()*j + ii ] );
                         }
                     }
                     ii += A.tileMb(i);
@@ -180,9 +183,9 @@ void norm(
                             firstprivate(i, j, ii, jj, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            synormOffdiag(in_norm, A(i, j),
-                                          &tiles_sums[A.n()*i + jj],
-                                          &tiles_sums[A.n()*j + ii]);
+                            tile::synorm_offdiag( in_norm, A( i, j ),
+                                                  &tiles_sums[ A.n()*i + jj ],
+                                                  &tiles_sums[ A.n()*j + ii ] );
                         }
                     }
                     ii += A.tileMb(i);
@@ -250,7 +253,7 @@ void norm(
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
                     real_t tile_values[2];
-                    synorm(in_norm, A(j, j), tile_values);
+                    tile::synorm( in_norm, A( j, j ), tile_values );
                     #pragma omp critical
                     {
                         combine_sumsq(values[0], values[1],
@@ -268,7 +271,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             // double for symmetric entries
                             tile_values[1] *= 2;
                             #pragma omp critical
@@ -289,7 +293,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             // double for symmetric entries
                             tile_values[1] *= 2;
                             #pragma omp critical

--- a/src/internal/internal_trnorm.cc
+++ b/src/internal/internal_trnorm.cc
@@ -78,7 +78,7 @@ void norm(
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
                     real_t tile_max;
-                    trnorm(in_norm, A.diag(), A(j, j), &tile_max);
+                    tile::trnorm( in_norm, A.diag(), A( j, j ), &tile_max );
                     #pragma omp critical
                     {
                         tiles_maxima.push_back(tile_max);
@@ -95,7 +95,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -113,7 +114,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_max;
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tile_max);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tile_max );
                             #pragma omp critical
                             {
                                 tiles_maxima.push_back(tile_max);
@@ -146,7 +148,8 @@ void norm(
                     firstprivate(j, jj, layout, in_norm) priority(priority)
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
-                    trnorm(in_norm, A.diag(), A(j, j), &tiles_sums[A.n()*j+jj]);
+                    tile::trnorm( in_norm, A.diag(), A( j, j ),
+                                  &tiles_sums[ A.n()*j + jj ] );
                 }
             }
             // off-diagonal tiles
@@ -158,7 +161,8 @@ void norm(
                             firstprivate(i, j, jj, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tiles_sums[A.n()*i+jj]);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tiles_sums[ A.n()*i + jj ] );
                         }
                     }
                 }
@@ -171,7 +175,8 @@ void norm(
                             firstprivate(i, j, jj, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tiles_sums[A.n()*i+jj]);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tiles_sums[ A.n()*i + jj ] );
                         }
                     }
                 }
@@ -209,7 +214,8 @@ void norm(
                     firstprivate(i, ii, layout, in_norm) priority(priority)
                 {
                     A.tileGetForReading(i, i, LayoutConvert(layout));
-                    trnorm(in_norm, A.diag(), A(i, i), &tiles_sums[A.m()*i + ii]);
+                    tile::trnorm( in_norm, A.diag(), A( i, i ),
+                                  &tiles_sums[ A.m()*i + ii ] );
                 }
             }
             // off-diagonal tiles
@@ -221,7 +227,8 @@ void norm(
                             firstprivate(i, j, ii, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tiles_sums[A.m()*j + ii]);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tiles_sums[ A.m()*j + ii ] );
                         }
                     }
                 }
@@ -234,7 +241,8 @@ void norm(
                             firstprivate(i, j, ii, layout, in_norm) priority(priority)
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
-                            genorm(in_norm, NormScope::Matrix, A(i, j), &tiles_sums[A.m()*j + ii]);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          &tiles_sums[ A.m()*j + ii ] );
                         }
                     }
                 }
@@ -272,7 +280,7 @@ void norm(
                 {
                     A.tileGetForReading(j, j, LayoutConvert(layout));
                     real_t tile_values[2];
-                    trnorm(in_norm, A.diag(), A(j, j), tile_values);
+                    tile::trnorm( in_norm, A.diag(), A( j, j ), tile_values );
                     #pragma omp critical
                     {
                         combine_sumsq(values[0], values[1],
@@ -290,7 +298,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             #pragma omp critical
                             {
                                 combine_sumsq(values[0], values[1],
@@ -309,7 +318,8 @@ void norm(
                         {
                             A.tileGetForReading(i, j, LayoutConvert(layout));
                             real_t tile_values[2];
-                            genorm(in_norm, NormScope::Matrix, A(i, j), tile_values);
+                            tile::genorm( in_norm, NormScope::Matrix, A( i, j ),
+                                          tile_values );
                             #pragma omp critical
                             {
                                 combine_sumsq(values[0], values[1],

--- a/src/internal/internal_trtri.cc
+++ b/src/internal/internal_trtri.cc
@@ -36,7 +36,7 @@ void trtri(internal::TargetType<Target::HostTask>,
 
     if (A.tileIsLocal(0, 0)) {
         A.tileGetForWriting(0, 0, LayoutConvert::ColMajor);
-        trtri(A.diag(), A(0, 0));
+        tile::trtri( A.diag(), A( 0, 0 ) );
     }
 }
 

--- a/src/internal/internal_trtrm.cc
+++ b/src/internal/internal_trtrm.cc
@@ -39,7 +39,7 @@ void trtrm(internal::TargetType<Target::HostTask>,
 
     if (A.tileIsLocal(0, 0)) {
         A.tileGetForWriting(0, 0, LayoutConvert::ColMajor);
-        trtrm(A(0, 0));
+        tile::trtrm( A( 0, 0 ) );
     }
 }
 

--- a/src/internal/internal_ttlqt.cc
+++ b/src/internal/internal_ttlqt.cc
@@ -116,7 +116,7 @@ void ttlqt(internal::TargetType<Target::HostTask>,
                 T.tileInsert(0, j);
                 T( 0, j ).set( 0 );
                 int64_t l = std::min(A.tileMb(0), A.tileNb(j));
-                tplqt(l, A(0, j_src), A(0, j), T(0, j));
+                tile::tplqt( l, A( 0, j_src ), A( 0, j ), T( 0, j ) );
 
                 T.tileModified(0, j);
 

--- a/src/internal/internal_ttmlq.cc
+++ b/src/internal/internal_ttmlq.cc
@@ -266,9 +266,10 @@ void ttmlq(internal::TargetType<Target::HostTask>,
                             C.tileGetForWriting(i, j, LayoutConvert(layout));
 
                             // Apply Q.
-                            tpmlqt(side, op, std::min(A.tileMb(0), A.tileNb(rank_ind)),
-                                   A(0, rank_ind), T(0, rank_ind),
-                                   C(i1, j1), C(i, j));
+                            tile::tpmlqt( side, op,
+                                          std::min( A.tileMb( 0 ), A.tileNb( rank_ind ) ),
+                                          A( 0, rank_ind ), T( 0, rank_ind ),
+                                          C( i1, j1 ), C( i, j ) );
 
                             int src = C.tileRank( i1, j1 );
                             // Send updated tile back.

--- a/src/internal/internal_ttmqr.cc
+++ b/src/internal/internal_ttmqr.cc
@@ -267,9 +267,10 @@ void ttmqr(internal::TargetType<Target::HostTask>,
                             C.tileGetForWriting(i, j, LayoutConvert(layout));
 
                             // Apply Q.
-                            tpmqrt(side, op, std::min(A.tileMb(rank_ind), A.tileNb(0)),
-                                   A(rank_ind, 0), T(rank_ind, 0),
-                                   C(i1, j1), C(i, j));
+                            tile::tpmqrt( side, op,
+                                          std::min( A.tileMb( rank_ind ), A.tileNb( 0 ) ),
+                                          A( rank_ind, 0 ), T( rank_ind, 0 ),
+                                          C( i1, j1 ), C( i, j ) );
 
                             int src = C.tileRank( i1, j1 );
                             // Send updated tile back.

--- a/src/internal/internal_ttqrt.cc
+++ b/src/internal/internal_ttqrt.cc
@@ -116,7 +116,7 @@ void ttqrt(internal::TargetType<Target::HostTask>,
                 T.tileInsert(i, 0);
                 T(i, 0).set(0);
                 int64_t l = std::min(A.tileMb(i), A.tileNb(0));
-                tpqrt(l, A(i_src, 0), A(i, 0), T(i, 0));
+                tile::tpqrt( l, A( i_src, 0 ), A( i, 0 ), T( i, 0 ) );
 
                 T.tileModified(i, 0);
 

--- a/src/internal/internal_tzscale.cc
+++ b/src/internal/internal_tzscale.cc
@@ -53,7 +53,7 @@ void scale(
                         firstprivate(i, j, numer, denom)
                     {
                         A.tileGetForWriting(i, j, LayoutConvert::None);
-                        scale(numer, denom, A(i, j));
+                        tile::scale( numer, denom, A( i, j ) );
                     }
                 }
             }
@@ -68,7 +68,7 @@ void scale(
                         firstprivate(i, j, numer, denom)
                     {
                         A.tileGetForWriting(i, j, LayoutConvert::None);
-                        scale(numer, denom, A(i, j));
+                        tile::scale( numer, denom, A( i, j ) );
                     }
                 }
             }

--- a/src/internal/internal_tzset.cc
+++ b/src/internal/internal_tzset.cc
@@ -8,7 +8,6 @@
 #include "internal/internal.hh"
 #include "slate/internal/util.hh"
 #include "slate/Matrix.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/types.hh"
 
 namespace slate {

--- a/src/internal/internal_unmlq.cc
+++ b/src/internal/internal_unmlq.cc
@@ -5,7 +5,6 @@
 
 #include "slate/Matrix.hh"
 #include "slate/types.hh"
-#include "internal/Tile_tpmlqt.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/internal/internal_unmqr.cc
+++ b/src/internal/internal_unmqr.cc
@@ -5,7 +5,6 @@
 
 #include "slate/Matrix.hh"
 #include "slate/types.hh"
-#include "internal/Tile_tpmqrt.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/internal/internal_unmtr_hb2st.cc
+++ b/src/internal/internal_unmtr_hb2st.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/internal/internal_util.hh
+++ b/src/internal/internal_util.hh
@@ -25,39 +25,6 @@ T pow(T base, T exp);
 
 void mpi_max_nan(void* invec, void* inoutvec, int* len, MPI_Datatype* datatype);
 
-//------------------------------------------
-inline float real(float val) { return val; }
-inline double real(double val) { return val; }
-inline float real(std::complex<float> val) { return val.real(); }
-inline double real(std::complex<double> val) { return val.real(); }
-
-inline float imag(float val) { return 0.0; }
-inline double imag(double val) { return 0.0; }
-inline float imag(std::complex<float> val) { return val.imag(); }
-inline double imag(std::complex<double> val) { return val.imag(); }
-
-//--------------------------
-template <typename scalar_t>
-scalar_t make(blas::real_type<scalar_t> real, blas::real_type<scalar_t> imag);
-
-template <>
-inline float make<float>(float real, float imag) { return real; }
-
-template <>
-inline double make<double>(double real, double imag) { return real; }
-
-template <>
-inline std::complex<float> make<std::complex<float>>(float real, float imag)
-{
-    return std::complex<float>(real, imag);
-}
-
-template <>
-inline std::complex<double> make<std::complex<double>>(double real, double imag)
-{
-    return std::complex<double>(real, imag);
-}
-
 //------------------------------------------------------------------------------
 /// Helper function to sort by second element of a pair.
 /// Used to sort rank_rows by row (see ttqrt, ttmqr), and rank_cols by col.

--- a/src/pbsv.cc
+++ b/src/pbsv.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianBandMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/HermitianBandMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/pbtrs.cc
+++ b/src/pbtrs.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianBandMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/posv.cc
+++ b/src/posv.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/posv_mixed.cc
+++ b/src/posv_mixed.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/posv_mixed_gmres.cc
+++ b/src/posv_mixed_gmres.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/potrs.cc
+++ b/src/potrs.cc
@@ -7,7 +7,6 @@
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
 #include "slate/HermitianMatrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/steqr2.cc
+++ b/src/steqr2.cc
@@ -5,7 +5,6 @@
 
 #include "slate/slate.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/HermitianBandMatrix.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"

--- a/src/sterf.cc
+++ b/src/sterf.cc
@@ -5,7 +5,6 @@
 
 #include "slate/slate.hh"
 // #include "auxiliary/Debug.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/svd.cc
+++ b/src/svd.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularBandMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/unmbr_ge2tb.cc
+++ b/src/unmbr_ge2tb.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "internal/Tile_tpmlqt.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "internal/Tile_tpmqrt.hh"
 #include "internal/internal.hh"
 #include "internal/internal_util.hh"
 

--- a/src/unmtr_hb2st.cc
+++ b/src/unmtr_hb2st.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/src/unmtr_he2hb.cc
+++ b/src/unmtr_he2hb.cc
@@ -6,7 +6,6 @@
 #include "slate/slate.hh"
 #include "auxiliary/Debug.hh"
 #include "slate/Matrix.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/TriangularMatrix.hh"
 #include "internal/internal.hh"
 

--- a/unit_test/test_Tile.cc
+++ b/unit_test/test_Tile.cc
@@ -4,7 +4,6 @@
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
 #include "slate/internal/util.hh"
 #include "slate/print.hh"
 

--- a/unit_test/test_Tile_kernels.cc
+++ b/unit_test/test_Tile_kernels.cc
@@ -716,7 +716,7 @@ void test_potrf()
         //}
 
         // run test
-        int info = potrf( A );
+        int info = slate::tile::potrf( A );
         test_assert( info == 0 );
 
         //if (verbose) {
@@ -805,7 +805,8 @@ void test_genorm()
 
             //---------------------
             // call kernel
-            slate::genorm( norm, slate::NormScope::Matrix, A, values.data() );
+            slate::tile::genorm( norm, slate::NormScope::Matrix, A,
+                                 values.data() );
 
             // post-process result
             if (norm == lapack::Norm::Max) {

--- a/unit_test/test_gecopy.cc
+++ b/unit_test/test_gecopy.cc
@@ -5,8 +5,6 @@
 
 #include "slate/Tile.hh"
 #include "internal/internal.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/internal/device.hh"
 #include "slate/internal/util.hh"
 

--- a/unit_test/test_gescale.cc
+++ b/unit_test/test_gescale.cc
@@ -5,8 +5,6 @@
 
 #include "slate/Tile.hh"
 #include "internal/internal.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/internal/device.hh"
 #include "slate/internal/util.hh"
 

--- a/unit_test/test_geset.cc
+++ b/unit_test/test_geset.cc
@@ -5,8 +5,6 @@
 
 #include "slate/Tile.hh"
 #include "internal/internal.hh"
-#include "slate/Tile_blas.hh"
-#include "internal/Tile_lapack.hh"
 #include "slate/internal/device.hh"
 #include "slate/internal/util.hh"
 

--- a/unit_test/test_lq.cc
+++ b/unit_test/test_lq.cc
@@ -43,6 +43,8 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
     using lapack::Uplo;
     using lapack::Diag;
     using lapack::MatrixType;
+    using lapack::Side;
+    using blas::Op;
 
     // Currently SLATE assumes n <= k.
     int n = blas::min( n2, k );
@@ -88,7 +90,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
         print( "T",   T );
     }
 
-    slate::tplqt( l, A1, A2, T );
+    slate::tile::tplqt( l, A1, A2, T );
 
     if (verbose > 1) {
         print( "post A1", A1 );
@@ -106,7 +108,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
                    &A1.at(0, 1), A1.stride() );
 
     // Form Ahat = L Q, where Q = I - V T V^H, V = [ I  V2 ], L = [ A1  L2 ]
-    slate::tpmlqt( slate::Side::Right, slate::Op::NoTrans, l, A2, T, A1, L2 );
+    slate::tile::tpmlqt( Side::Right, Op::NoTrans, l, A2, T, A1, L2 );
     if (verbose > 1) {
         print( "L1 Q", A1 );
         print( "L2 Q", L2 );
@@ -157,13 +159,13 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
         print( "C2", C2 );
     }
 
-    slate::tpmlqt( slate::Side::Left, slate::Op::NoTrans, l, A2, T, C1, C2 );
+    slate::tile::tpmlqt( Side::Left, Op::NoTrans, l, A2, T, C1, C2 );
     if (verbose > 1) {
         print( "Q C1", C1 );
         print( "Q C2", C2 );
     }
 
-    slate::tpmlqt( slate::Side::Left, slate::Op::ConjTrans, l, A2, T, C1, C2 );
+    slate::tile::tpmlqt( Side::Left, Op::ConjTrans, l, A2, T, C1, C2 );
     if (verbose > 1) {
         print( "Q^H C1", C1 );
         print( "Q^H C2", C2 );
@@ -171,7 +173,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
 
     // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
-        slate::tpmlqt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 );
+        slate::tile::tpmlqt( Side::Left, Op::Trans, l, A2, T, C1, C2 );
         if (verbose > 1) {
             print( "Q^T C1", C1 );
             print( "Q^T C2", C2 );
@@ -207,13 +209,13 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
         print( "D2", D2 );
     }
 
-    slate::tpmlqt( slate::Side::Right, slate::Op::NoTrans, l, A2, T, D1, D2 );
+    slate::tile::tpmlqt( Side::Right, Op::NoTrans, l, A2, T, D1, D2 );
     if (verbose > 1) {
         print( "D1 Q", D1 );
         print( "D2 Q", D2 );
     }
 
-    slate::tpmlqt( slate::Side::Right, slate::Op::ConjTrans, l, A2, T, D1, D2 );
+    slate::tile::tpmlqt( Side::Right, Op::ConjTrans, l, A2, T, D1, D2 );
     if (verbose > 1) {
         print( "D1 Q^H", D1 );
         print( "D2 Q^H", D2 );
@@ -221,7 +223,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
 
     // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
-        slate::tpmlqt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 );
+        slate::tile::tpmlqt( Side::Right, Op::Trans, l, A2, T, D1, D2 );
         if (verbose > 1) {
             print( "D1 Q^T", D1 );
             print( "D2 Q^T", D2 );
@@ -232,7 +234,7 @@ void test_tplqt_work( int k, int n2, int l, int cn, int ib )
         // "On entry to ZTPMLQT parameter number  2 had an illegal value"
         // By default, xerbla will exit, so disable this for routine testing.
         //test_assert_throw_std(
-        //    slate::tpmlqt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
+        //    slate::tile::tpmlqt( Side::Right, Op::Trans, l, A2, T, D1, D2 ));
     }
 }
 

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -4,7 +4,6 @@
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include "slate/Tile.hh"
-#include "slate/Tile_blas.hh"
 #include "internal/Tile_lapack.hh"
 #include "internal/Tile_synorm.hh"
 #include "slate/internal/device.hh"

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -80,7 +80,7 @@ void test_genorm(Norm norm)
     else if (norm == lapack::Norm::Fro)
         values.resize( 2 );
 
-    slate::genorm( norm, slate::NormScope::Matrix, A, &values[0] );
+    slate::tile::genorm( norm, slate::NormScope::Matrix, A, &values[0] );
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {
@@ -293,7 +293,7 @@ void test_synorm(Norm norm, Uplo uplo)
     else if (norm == lapack::Norm::Fro)
         values.resize( 2 );
 
-    slate::synorm( norm, A, &values[0] );
+    slate::tile::synorm( norm, A, &values[0] );
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -504,7 +504,7 @@ void test_synorm_offdiag(Norm norm)
 
     std::vector<double> col_sums( n ), row_sums( m );
 
-    slate::synormOffdiag( norm, A, &col_sums[0], &row_sums[0] );
+    slate::tile::synorm_offdiag( norm, A, &col_sums[0], &row_sums[0] );
 
     // check column & row sum results
     if (norm == lapack::Norm::One || norm == lapack::Norm::Inf) {
@@ -633,7 +633,7 @@ void test_trnorm(Norm norm, Uplo uplo, Diag diag)
     else if (norm == lapack::Norm::Fro)
         values.resize( 2 );
 
-    slate::trnorm( norm, diag, A, &values[0] );
+    slate::tile::trnorm( norm, diag, A, &values[0] );
 
     // check column & row sum results
     if (norm == lapack::Norm::One) {

--- a/unit_test/test_qr.cc
+++ b/unit_test/test_qr.cc
@@ -43,6 +43,8 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
     using lapack::Uplo;
     using lapack::Diag;
     using lapack::MatrixType;
+    using lapack::Side;
+    using blas::Op;
 
     // Currently SLATE assumes m <= k.
     int m = blas::min( m2, k );
@@ -87,7 +89,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         print( "T",   T );
     }
 
-    slate::tpqrt( l, A1, A2, T );
+    slate::tile::tpqrt( l, A1, A2, T );
 
     if (verbose > 1) {
         print( "post A1", A1 );
@@ -107,7 +109,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
 
     // Form Ahat = Q R, where Q = I - V T V^H, V = [ I  ],  R = [ A1 ]
     //                                             [ V2 ]       [ R2 ]
-    slate::tpmqrt( slate::Side::Left, slate::Op::NoTrans, l, A2, T, A1, R2 );
+    slate::tile::tpmqrt( Side::Left, Op::NoTrans, l, A2, T, A1, R2 );
     if (verbose > 1) {
         print( "Q R1", A1 );
         print( "Q R2", R2 );
@@ -158,13 +160,13 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         print( "C2", C2 );
     }
 
-    slate::tpmqrt( slate::Side::Left, slate::Op::NoTrans, l, A2, T, C1, C2 );
+    slate::tile::tpmqrt( Side::Left, Op::NoTrans, l, A2, T, C1, C2 );
     if (verbose > 1) {
         print( "Q C1", C1 );
         print( "Q C2", C2 );
     }
 
-    slate::tpmqrt( slate::Side::Left, slate::Op::ConjTrans, l, A2, T, C1, C2 );
+    slate::tile::tpmqrt( Side::Left, Op::ConjTrans, l, A2, T, C1, C2 );
     if (verbose > 1) {
         print( "Q^H C1", C1 );
         print( "Q^H C2", C2 );
@@ -172,7 +174,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
 
     // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
-        slate::tpmqrt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 );
+        slate::tile::tpmqrt( Side::Left, Op::Trans, l, A2, T, C1, C2 );
         if (verbose > 1) {
             print( "Q^T C1", C1 );
             print( "Q^T C2", C2 );
@@ -183,7 +185,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         // "On entry to ZTPMQRT parameter number  2 had an illegal value"
         // By default, xerbla will exit, so disable this for routine testing.
         //test_assert_throw_std(
-        //    slate::tpmqrt( slate::Side::Left, slate::Op::Trans, l, A2, T, C1, C2 ));
+        //    slate::tile::tpmqrt( Side::Left, Op::Trans, l, A2, T, C1, C2 ));
     }
 
     //---------------------
@@ -208,13 +210,13 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         print( "D2", D2 );
     }
 
-    slate::tpmqrt( slate::Side::Right, slate::Op::NoTrans, l, A2, T, D1, D2 );
+    slate::tile::tpmqrt( Side::Right, Op::NoTrans, l, A2, T, D1, D2 );
     if (verbose > 1) {
         print( "D1 Q", D1 );
         print( "D2 Q", D2 );
     }
 
-    slate::tpmqrt( slate::Side::Right, slate::Op::ConjTrans, l, A2, T, D1, D2 );
+    slate::tile::tpmqrt( Side::Right, Op::ConjTrans, l, A2, T, D1, D2 );
     if (verbose > 1) {
         print( "D1 Q^H", D1 );
         print( "D2 Q^H", D2 );
@@ -222,7 +224,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
 
     // Trans applies only to real.
     if (! blas::is_complex< scalar_t >::value) {
-        slate::tpmqrt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 );
+        slate::tile::tpmqrt( Side::Right, Op::Trans, l, A2, T, D1, D2 );
         if (verbose > 1) {
             print( "D1 Q^T", D1 );
             print( "D2 Q^T", D2 );
@@ -233,7 +235,7 @@ void test_tpqrt_work( int m2, int k, int l, int cn, int ib )
         // "On entry to ZTPMQRT parameter number  2 had an illegal value"
         // By default, xerbla will exit, so disable this for routine testing.
         //test_assert_throw_std(
-        //    slate::tpmqrt( slate::Side::Right, slate::Op::Trans, l, A2, T, D1, D2 ));
+        //    slate::tile::tpmqrt( Side::Right, Op::Trans, l, A2, T, D1, D2 ));
     }
 }
 


### PR DESCRIPTION
1. The `tile` namespace was previously added to `Tile_blas.hh`. This adds it to `Tile_lapack.hh` and similar headers.
2. Many files needlessly included `Tile_blas.hh` and similar headers. If a file doesn't call a `tile::` function, it shouldn't include the header.
3. Largely unrelated, remove custom `real`, `imag`, instead using ones from `std`, and remove custom `make`, instead using `blas::make_scalar`. The issue showed up when functions moved into the `tile` namespace, so `make` was no longer in the same namespace.