### PR TITLE
Make sure that INT64_MAX is defined in test/matrix_params.cc

### DIFF
--- a/test/matrix_params.cc
+++ b/test/matrix_params.cc
@@ -7,6 +7,7 @@
 
 #include <climits>
 #include <cmath>
+#include <cstdint>
 
 using llong = long long;
 using testsweeper::ParamType;


### PR DESCRIPTION
This fixes half of #168 and makes GCC 13.2.0 happier.