### PR TITLE
Fixing use of unused variables

### DIFF
--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -183,8 +183,6 @@ void test_copy_work(Params& params, bool run)
             Cblacs_gridexit(ictxt);
             //Cblacs_exit(1) does not handle re-entering
         #else  // not SLATE_HAVE_SCALAPACK
-            int mpi_rank, myrow, mycol;
-            MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
             if (A.mpiRank() == 0)
                 printf( "ScaLAPACK not available\n" );
         #endif

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -183,6 +183,8 @@ void test_copy_work(Params& params, bool run)
             Cblacs_gridexit(ictxt);
             //Cblacs_exit(1) does not handle re-entering
         #else  // not SLATE_HAVE_SCALAPACK
+            int mpi_rank, myrow, mycol;
+            MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
             if (A.mpiRank() == 0)
                 printf( "ScaLAPACK not available\n" );
         #endif

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -183,8 +183,6 @@ void test_copy_work(Params& params, bool run)
             Cblacs_gridexit(ictxt);
             //Cblacs_exit(1) does not handle re-entering
         #else  // not SLATE_HAVE_SCALAPACK
-            SLATE_UNUSED( A_norm );
-            SLATE_UNUSED( B_norm );
             if (A.mpiRank() == 0)
                 printf( "ScaLAPACK not available\n" );
         #endif

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -219,6 +219,8 @@ void test_trsm_work(Params& params, bool run)
             Cblacs_gridexit(ictxt);
             //Cblacs_exit(1) does not handle re-entering.
         #else  // not SLATE_HAVE_SCALAPACK
+            int mpi_rank, myrow, mycol;
+            MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
             if (mpi_rank == 0)
                 printf( "ScaLAPACK not available\n" );
         #endif

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -219,9 +219,7 @@ void test_trsm_work(Params& params, bool run)
             Cblacs_gridexit(ictxt);
             //Cblacs_exit(1) does not handle re-entering.
         #else  // not SLATE_HAVE_SCALAPACK
-            int mpi_rank, myrow, mycol;
-            MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-            if (mpi_rank == 0)
+            if (A.mpiRank() == 0)
                 printf( "ScaLAPACK not available\n" );
         #endif
     }


### PR DESCRIPTION
When configured to not use scalapack for testing, these lines would cause failure due to undefined A_norm and B_norm.