### PR TITLE
Fixing bug in unit test test_internal_blas.cc

### DIFF
--- a/unit_test/test_internal_blas.cc
+++ b/unit_test/test_internal_blas.cc
@@ -53,6 +53,7 @@ const char* target_name(slate::Target target)
         case slate::Target::Devices:   return "Devices";
         default: assert(false);
     }
+    return "Error";
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
When compiled with `-DNDEBUG` (e.g. when testing a spack-based installation), the error is:

```
      603    cd /tmp/github/spack-stage/spack-stage-slate-master-gwcu5k4egtjla37
            s45t6l4tn7gbpow45/spack-build-gwcu5k4/test && /tmp/slate/slate/spac
            k/lib/spack/env/gcc/g++ -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_H
            CC__=1 -I/tmp/slate/slate/src -I/tmp/slate/slate/testsweeper -I/tmp
            /slate/slate/include -isystem /tmp/slate/slate/spack/opt/spack/linu
            x-rocky9-x86_64/gcc-11.3.1/intel-oneapi-mpi-2021.12.0-qxrpd74hv6s36
            qzdypoteozwdkgt4rfw/mpi/2021.12/include -isystem /tmp/slate/slate/s
            pack/opt/spack/linux-rocky9-x86_64/gcc-11.3.1/blaspp-master-34muqhq
            5y73ed4drkdndtsn2h5ccusuj/include -isystem /opt/rocm-5.7.1/include 
            -isystem /tmp/slate/slate/spack/opt/spack/linux-rocky9-x86_64/gcc-1
            1.3.1/lapackpp-master-m4zxsforwz7b3bykzljc2ueugexwg2bp/include -O3 
            -DNDEBUG -Wno-unused-command-line-argument -fopenmp -MD -MT test/CM
            akeFiles/tester.dir/matrix_params.cc.o -MF CMakeFiles/tester.dir/ma
            trix_params.cc.o.d -o CMakeFiles/tester.dir/matrix_params.cc.o -c /
            tmp/slate/slate/test/matrix_params.cc
     604    /tmp/slate/slate/unit_test/test_internal_blas.cc: In function 'cons
            t char* test::target_name(slate::Target)':
  >> 605    /tmp/slate/slate/unit_test/test_internal_blas.cc:54:9: warning: con
            trol reaches end of non-void function [-Wreturn-type]
     606       54 |         default: assert(false);
     607          |         ^~~~~~~
```

In this case, the function should return a string if the assert is skipped.