### PR TITLE
Deprecated

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -3460,8 +3460,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
             // else
 
             blas::device_memcpy<scalar_t*>(
-                array_dev, bucket->second.first.data(),
-                batch_count, blas::MemcpyKind::HostToDevice, *queue);
+                array_dev, bucket->second.first.data(), batch_count, *queue );
 
             if (mb == nb) {
                 // in-place transpose
@@ -3474,7 +3473,7 @@ void BaseMatrix<scalar_t>::tileLayoutConvert(
                 // rectangular tiles: out-of-place transpose
                 blas::device_memcpy<scalar_t*>(
                     work_array_dev, bucket->second.second.data(),
-                    batch_count, blas::MemcpyKind::HostToDevice, *queue);
+                    batch_count, *queue );
 
                 if (! extended) {
                     // copy back to data buffer

--- a/include/slate/Tile.hh
+++ b/include/slate/Tile.hh
@@ -90,29 +90,6 @@ MatrixType conj_transpose( MatrixType&& A )
 }
 
 //------------------------------------------------------------------------------
-/// Conjugate-transpose a Tile or any type of Matrix object,
-/// changing op flag from NoTrans to ConjTrans, or from ConjTrans to NoTrans.
-/// @return copy of Tile, etc. with updated op flag.
-/// @see transpose()
-///
-/// @ingroup util
-///
-template<typename MatrixType>
-[[deprecated( "Use conj_transpose instead. Remove 2024-02." )]]
-MatrixType conjTranspose( MatrixType& A )
-{
-    return conj_transpose( A );
-}
-
-//--------------------------------------
-template<typename MatrixType>
-[[deprecated( "Use conj_transpose instead. Remove 2024-02." )]]
-MatrixType conjTranspose( MatrixType&& A )
-{
-    return conj_transpose( A );
-}
-
-//------------------------------------------------------------------------------
 /// Whether a tile is workspace or origin (local non-workspace),
 /// and who owns (allocated, deallocates) the data.
 /// @ingroup enum

--- a/include/slate/slate.hh
+++ b/include/slate/slate.hh
@@ -536,30 +536,6 @@ int64_t gesv_mixed(
     int& iter,
     Options const& opts = Options());
 
-template <typename scalar_t>
-[[deprecated( "Use gesv_mixed instead. Will be removed 2024-02." )]]
-int64_t gesvMixed(
-    Matrix<scalar_t>& A, Pivots& pivots,
-    Matrix<scalar_t>& B,
-    Matrix<scalar_t>& X,
-    int& iter,
-    Options const& opts = Options())
-{
-    return gesv_mixed( A, pivots, B, X, iter, opts );
-}
-
-template <typename scalar_hi, typename scalar_lo>
-[[deprecated( "Use gesv_mixed instead. Will be removed 2024-02." )]]
-int64_t gesvMixed(
-    Matrix<scalar_hi>& A, Pivots& pivots,
-    Matrix<scalar_hi>& B,
-    Matrix<scalar_hi>& X,
-    int& iter,
-    Options const& opts = Options())
-{
-    return gesv_mixed( A, pivots, B, X, iter, opts );
-}
-
 //-----------------------------------------
 // gesv_mixed_gmres()
 template <typename scalar_t>
@@ -707,30 +683,6 @@ int64_t posv_mixed(
     Options const& opts = Options());
 
 // todo: forward real-symmetric matrices to posv_mixed?
-
-template <typename scalar_t>
-[[deprecated( "Use posv_mixed instead. Will be removed 2024-02." )]]
-int64_t posvMixed(
-    HermitianMatrix<scalar_t>& A,
-             Matrix<scalar_t>& B,
-             Matrix<scalar_t>& X,
-    int& iter,
-    Options const& opts = Options())
-{
-    return posv_mixed( A, B, X, iter, opts );
-}
-
-template <typename scalar_hi, typename scalar_lo>
-[[deprecated( "Use posv_mixed instead. Will be removed 2024-02." )]]
-int64_t posvMixed(
-    HermitianMatrix<scalar_hi>& A,
-             Matrix<scalar_hi>& B,
-             Matrix<scalar_hi>& X,
-    int& iter,
-    Options const& opts = Options())
-{
-    return posv_mixed( A, B, X, iter, opts );
-}
 
 //-----------------------------------------
 // posv_mixed_gmres()
@@ -925,17 +877,6 @@ void gels_cholqr(
     Matrix<scalar_t>& A, Matrix<scalar_t>& R,
     Matrix<scalar_t>& BX,
     Options const& opts = Options());
-
-// Backward compatibility
-template <typename scalar_t>
-[[deprecated( "Use gels( A, BX[, opts] ) instead. Will be removed 2024-02." )]]
-void gels(
-    Matrix<scalar_t>& A, TriangularFactors<scalar_t>& T,
-    Matrix<scalar_t>& BX,
-    Options const& opts = Options())
-{
-    gels_qr( A, T, BX, opts );
-}
 
 // Routine selection
 template <typename scalar_t>

--- a/include/slate/types.hh
+++ b/include/slate/types.hh
@@ -183,10 +183,10 @@ struct is_complex< std::complex<T> >:
 /// @param[in] opt
 ///     Map of options and values.
 ///
-///  @param[in] option
+/// @param[in] option
 ///     Option to get.
 ///
-///  @param [in] defval
+/// @param[in] defval
 ///     Default option value if option is not found in map.
 ///
 template <typename T>

--- a/matgen/random.cc
+++ b/matgen/random.cc
@@ -193,10 +193,10 @@ void generate_helper( int64_t seed,
 /// @param[in] joffset
 ///     The first column of the sub-matrix in the global matrix.
 ///
-/// @param[out]A
+/// @param[out] A
 ///     The m-by-n, column-major sub-matrix to fill with random values.
 ///
-/// @param[in]lda
+/// @param[in] lda
 ///     The leading dimension of the matrix.
 template<typename scalar_t>
 void generate(Dist dist, int64_t seed,

--- a/old/src/internal/internal_gemm_split.cc
+++ b/old/src/internal/internal_gemm_split.cc
@@ -20,7 +20,7 @@ namespace internal {
 /// if $op(C)$ is transpose, then $op(A)$ and $op(B)$ cannot be conj_transpose;
 /// if $op(C)$ is conj_transpose, then $op(A)$ and $op(B)$ cannot be transpose.
 ///
-/// @param[inout] batchArrays
+/// @param[in,out] batchArrays
 ///     holds the pointer arrays to be prepared for later execution
 ///     of the batch-gemm kernel in gemmExec()
 ///

--- a/src/internal/internal_batch.hh
+++ b/src/internal/internal_batch.hh
@@ -217,10 +217,10 @@ public:
 //------------------------------------------------------------------------------
 /// @copydoc device_regions_build(std::array< std::reference_wrapper<BaseMatrix<scalar_t>>, mat_count >, std::array< scalar_t**, mat_count >, int64_t, std::function<void(int64_t, int64_t, int64_t)>)
 ///
-/// @params[in] irange
+/// @param[in] irange
 ///     The ranges of tiles with a uniform number of rows
 ///
-/// @params[in] jrange
+/// @param[in] jrange
 ///     The ranges of tiles with a uniform number of columns
 ///
 template< bool store_diag, int mat_count, typename scalar_t, bool diag_same=!store_diag >

--- a/src/internal/internal_gbnorm.cc
+++ b/src/internal/internal_gbnorm.cc
@@ -418,10 +418,8 @@ void norm(
             {
                 trace::Block trace_block("slate::device::genorm");
 
-                blas::device_memcpy<scalar_t*>(a_dev_array, a_host_array,
-                                    batch_count,
-                                    blas::MemcpyKind::HostToDevice,
-                                    *queue);
+                blas::device_memcpy<scalar_t*>(
+                    a_dev_array, a_host_array, batch_count, *queue );
 
                 scalar_t** a_dev_array_g = a_dev_array;
                 real_t* vals_dev_array_g = vals_dev_array;
@@ -437,10 +435,8 @@ void norm(
                     }
                 }
 
-                blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
-                                    batch_count*ldv,
-                                    blas::MemcpyKind::DeviceToHost,
-                                    *queue);
+                blas::device_memcpy<real_t>(
+                    vals_host_array, vals_dev_array, batch_count*ldv, *queue );
 
                 queue->sync();
             }

--- a/src/internal/internal_geadd.cc
+++ b/src/internal/internal_geadd.cc
@@ -160,10 +160,8 @@ void add(internal::TargetType<Target::Devices>,
 
             blas::Queue* queue = B.compute_queue(device, queue_index);
 
-            blas::device_memcpy<scalar_t*>(a_array_dev, a_array_host,
-                                batch_size*2,
-                                blas::MemcpyKind::HostToDevice,
-                                *queue);
+            blas::device_memcpy<scalar_t*>(
+                a_array_dev, a_array_host, batch_size*2, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/src/internal/internal_gecopy.cc
+++ b/src/internal/internal_gecopy.cc
@@ -187,15 +187,11 @@ void copy(internal::TargetType<Target::Devices>,
 
             blas::Queue* queue = B.compute_queue(device, queue_index);
 
-            blas::device_memcpy<src_scalar_t*>(a_array_dev, a_array_host,
-                                batch_count,
-                                blas::MemcpyKind::HostToDevice,
-                                *queue);
+            blas::device_memcpy<src_scalar_t*>(
+                a_array_dev, a_array_host, batch_count, *queue );
 
-            blas::device_memcpy<dst_scalar_t*>(b_array_dev, b_array_host,
-                                batch_count,
-                                blas::MemcpyKind::HostToDevice,
-                                *queue);
+            blas::device_memcpy<dst_scalar_t*>(
+                b_array_dev, b_array_host, batch_count, *queue );
 
             bool is_trans = (A.op() != B.op());
             bool is_conj = false;

--- a/src/internal/internal_genorm.cc
+++ b/src/internal/internal_genorm.cc
@@ -460,10 +460,8 @@ void norm(
                 trace::Block trace_block("slate::device::genorm");
 
 
-                blas::device_memcpy<scalar_t*>(a_array_dev, a_array_host,
-                                               batch_size,
-                                               blas::MemcpyKind::HostToDevice,
-                                               *queue);
+                blas::device_memcpy<scalar_t*>(
+                    a_array_dev, a_array_host, batch_size, *queue );
 
                 real_t* vals_dev_array_group = vals_dev_array;
                 for (size_t g = 0; g < group_params.size(); ++g) {
@@ -479,10 +477,8 @@ void norm(
                     vals_dev_array_group += group_count * ldv;
                 }
 
-                blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
-                                            batch_size*ldv,
-                                            blas::MemcpyKind::DeviceToHost,
-                                            *queue);
+                blas::device_memcpy<real_t>(
+                    vals_host_array, vals_dev_array, batch_size*ldv, *queue );
 
                 queue->sync();
             }

--- a/src/internal/internal_geqrf.cc
+++ b/src/internal/internal_geqrf.cc
@@ -226,8 +226,7 @@ void geqrf(
             blas::device_memcpy_2d<scalar_t>(
                     &dA[ temp_loc ], mlocal,
                     Ai0.data(), Ai0.stride(),
-                    Ai0.mb(), nb,
-                    blas::MemcpyKind::Default, *queue );
+                    Ai0.mb(), nb, *queue );
             temp_loc += Ai0.mb();
         }
     }
@@ -263,8 +262,7 @@ void geqrf(
             blas::device_memcpy_2d<scalar_t>(
                     Ai0.data(), Ai0.stride(),
                     &dA[ temp_loc ], mlocal,
-                    Ai0.mb(), nb,
-                    blas::MemcpyKind::Default, *queue );
+                    Ai0.mb(), nb, *queue );
             temp_loc += Ai0.mb();
         }
     }
@@ -273,8 +271,7 @@ void geqrf(
     //
     // TODO: Would be better to have trmm allow for pointer vs scalar to avoid
     //       this copy.
-    blas::device_memcpy<scalar_t>( htau.data(), dtau, diag_len,
-                                   blas::MemcpyKind::Default, *queue);
+    blas::device_memcpy<scalar_t>( htau.data(), dtau, diag_len, *queue );
 
     // Constructing T-(blocking)-factor.
     T.tileInsert  ( tile_index_zero, 0, device );

--- a/src/internal/internal_gescale.cc
+++ b/src/internal/internal_gescale.cc
@@ -119,8 +119,7 @@ void scale(internal::TargetType<Target::Devices>,
 
             scalar_t** a_array_dev = A.array_device( device, queue_index );
             blas::device_memcpy<scalar_t*>(
-                a_array_dev, a_array_host, batch_size,
-                blas::MemcpyKind::HostToDevice, *queue);
+                a_array_dev, a_array_host, batch_size, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/src/internal/internal_geset.cc
+++ b/src/internal/internal_geset.cc
@@ -129,8 +129,7 @@ void set(internal::TargetType<Target::Devices>,
 
             scalar_t** a_array_dev = A.array_device( device, queue_index );
             blas::device_memcpy<scalar_t*>(
-                a_array_dev, a_array_host, batch_size,
-                blas::MemcpyKind::HostToDevice, *queue);
+                a_array_dev, a_array_host, batch_size, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/src/internal/internal_getrf_tntpiv.cc
+++ b/src/internal/internal_getrf_tntpiv.cc
@@ -325,8 +325,7 @@ void getrf_tntpiv_local(
     lapack::getrf( mlocal, nb, dA, mlocal, dipiv,
                    dwork, dsize, hwork, hsize, dinfo, *queue );
 
-    blas::device_memcpy<device_pivot_int>( &hipiv[0], dipiv, diag_len,
-                                   blas::MemcpyKind::Default, *queue);
+    blas::device_memcpy<device_pivot_int>( &hipiv[0], dipiv, diag_len, *queue );
 
     // todo: could merge with above memcpy if host_info and dinfo are
     // made the last entry of hipiv and dipiv; slightly complicated if
@@ -427,8 +426,7 @@ void getrf_tntpiv_panel(
                 blas::device_memcpy_2d<scalar_t>(
                         &dA[ temp_loc ], mlocal,
                         Ai0.data(), Ai0.stride(),
-                        Ai0.mb(), nb,
-                        blas::MemcpyKind::Default, *queue );
+                        Ai0.mb(), nb, *queue );
                 temp_loc += Ai0.mb();
             }
         }
@@ -643,8 +641,7 @@ void getrf_tntpiv_panel(
                     blas::device_memcpy_2d<scalar_t>(
                             Ai0.data(), Ai0.stride(),
                             &dA[ temp_loc ], mlocal,
-                            Ai0.mb(), nb,
-                            blas::MemcpyKind::Default, *queue );
+                            Ai0.mb(), nb, *queue );
                     temp_loc += Ai0.mb();
                 }
             }

--- a/src/internal/internal_getrf_tntpiv.cc
+++ b/src/internal/internal_getrf_tntpiv.cc
@@ -122,13 +122,13 @@ void permutation_to_sequential_pivot(
 //------------------------------------------------------------------------------
 /// Multi-threaded LU factorization of local tiles.
 ///
-/// @params[in] target
+/// @param[in] target
 ///     Target for dispacth to correct implementation.
 ///
-/// @params[in,out] tiles
+/// @param[in,out] tiles
 ///     List of tiles to factor on the CPU.
 ///
-/// @params[in,out] dwork_array
+/// @param[in,out] dwork_array
 ///     Array of GPU device workspaces, dimension (num_devices).
 ///     dwork_array[ dev ] stores dA, dwork, dipiv, and dinfo on GPU dev;
 ///     dA    is contiguous copy of tiles on GPU,
@@ -136,46 +136,46 @@ void permutation_to_sequential_pivot(
 ///     dipiv is pivot vector,
 ///     dinfo is getrf return value.
 ///
-/// @params[in] dwork_bytes
+/// @param[in] dwork_bytes
 ///    Total size of dwork_array[ dev ] in bytes for each GPU device.
 ///
-/// @params[in] mlocal
+/// @param[in] mlocal
 ///    Number of rows in dwork_array.
 ///
-/// @params[in] device
+/// @param[in] device
 ///    Device performing factorization,
 ///    needed for pointing to correct memory in dwork_array.
 ///    Device == HostNum for CPU implementation.
 ///
-/// @params[in] queue
+/// @param[in] queue
 ///    Queue associated to input device.
 ///
-/// @params[in] diag_len
+/// @param[in] diag_len
 ///     Length of diagonal, min( mb, nb ) of diagonal tile.
 ///
-/// @params[in] ib
+/// @param[in] ib
 ///     Inner blocking.
 ///
-/// @params[in] stage
+/// @param[in] stage
 ///     Stage = 0 is initial local tiles,
 ///     stage = 1 is subsequent tournament.
 ///
-/// @params[in] mb
+/// @param[in] mb
 ///     Tile row block size.
 ///
-/// @params[in] nb
+/// @param[in] nb
 ///     Tile column block size.
 ///
-/// @params[in] tile_indices
+/// @param[in] tile_indices
 ///     Block row indices of tiles in tiles array.
 ///
-/// @params[in] mpi_rank
+/// @param[in] mpi_rank
 ///     MPI rank of this process.
 ///
-/// @params[in] max_panel_threads
+/// @param[in] max_panel_threads
 ///     Maximum number of threads to launch for local panel.
 ///
-/// @params[in] priority
+/// @param[in] priority
 ///     OpenMP priority.
 ///     todo: unused. Should it be on taskloop?
 ///

--- a/src/internal/internal_hbnorm.cc
+++ b/src/internal/internal_hbnorm.cc
@@ -517,10 +517,8 @@ void norm(
             {
                 trace::Block trace_block("slate::device::henorm");
 
-                blas::device_memcpy<scalar_t*>(a_dev_array, a_host_array,
-                                    batch_count,
-                                    blas::MemcpyKind::HostToDevice,
-                                    *queue);
+                blas::device_memcpy<scalar_t*>(
+                    a_dev_array, a_host_array, batch_count, *queue );
 
                 scalar_t** a_dev_array_g = a_dev_array;
                 real_t* vals_dev_array_g = vals_dev_array;
@@ -559,10 +557,8 @@ void norm(
                     }
                 }
 
-                blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
-                                    batch_count*ldv,
-                                    blas::MemcpyKind::DeviceToHost,
-                                    *queue);
+                blas::device_memcpy<real_t>(
+                    vals_host_array, vals_dev_array, batch_count*ldv, *queue );
 
                 queue->sync();
             }

--- a/src/internal/internal_henorm.cc
+++ b/src/internal/internal_henorm.cc
@@ -414,10 +414,8 @@ void norm(
             {
                 trace::Block trace_block("slate::device::henorm");
 
-                blas::device_memcpy<scalar_t*>(a_array_dev, a_array_host,
-                                               batch_size,
-                                               blas::MemcpyKind::HostToDevice,
-                                               *queue);
+                blas::device_memcpy<scalar_t*>(
+                    a_array_dev, a_array_host, batch_size, *queue );
 
                 real_t* vals_dev_array_group = vals_dev_array;
                 for (size_t g = 0; g < group_params.size(); ++g) {
@@ -453,10 +451,8 @@ void norm(
                     queue->sync();
                 }
 
-                blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
-                                            batch_size*ldv,
-                                            blas::MemcpyKind::DeviceToHost,
-                                            *queue);
+                blas::device_memcpy<real_t>(
+                    vals_host_array, vals_dev_array, batch_size*ldv, *queue );
 
                 queue->sync();
             }

--- a/src/internal/internal_hettmqr.cc
+++ b/src/internal/internal_hettmqr.cc
@@ -64,7 +64,7 @@ void hettmqr(
 /// Host implementation.
 /// @ingroup heev_internal
 ///
-/// @param tag_base[in]
+/// @param[in] tag_base
 ///     This process uses MPI tags from the range [tag_base, tag_base+mt*nt)
 ///
 template <typename scalar_t>

--- a/src/internal/internal_swap.hh
+++ b/src/internal/internal_swap.hh
@@ -102,8 +102,7 @@ void swapRemoteRowDevice(
     // todo: this assumes row is contiguous on GPU, right? Add asserts.
 
     blas::device_memcpy<scalar_t>(
-        local_row.data(), &A.at(i, j), n,
-        blas::MemcpyKind::DeviceToHost, queue);
+        local_row.data(), &A.at(i, j), n, queue );
 
     queue.sync();
 
@@ -113,8 +112,7 @@ void swapRemoteRowDevice(
         mpi_comm, MPI_STATUS_IGNORE);
 
     blas::device_memcpy<scalar_t>(
-        &A.at(i, j), other_row.data(), n,
-        blas::MemcpyKind::HostToDevice, queue);
+        &A.at(i, j), other_row.data(), n, queue );
 
     queue.sync();
 }

--- a/src/internal/internal_synorm.cc
+++ b/src/internal/internal_synorm.cc
@@ -418,10 +418,8 @@ void norm(
             {
                 trace::Block trace_block("slate::device::synorm");
 
-                blas::device_memcpy<scalar_t*>(a_array_dev, a_array_host,
-                                               batch_size,
-                                               blas::MemcpyKind::HostToDevice,
-                                               *queue);
+                blas::device_memcpy<scalar_t*>(
+                    a_array_dev, a_array_host, batch_size, *queue );
 
                 real_t* vals_dev_array_group = vals_dev_array;
                 for (size_t g = 0; g < group_params.size(); ++g) {
@@ -457,10 +455,8 @@ void norm(
                     queue->sync();
                 }
 
-                blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
-                                            batch_size*ldv,
-                                            blas::MemcpyKind::DeviceToHost,
-                                            *queue);
+                blas::device_memcpy<real_t>(
+                    vals_host_array, vals_dev_array, batch_size*ldv, *queue );
 
                 queue->sync();
             }

--- a/src/internal/internal_trnorm.cc
+++ b/src/internal/internal_trnorm.cc
@@ -438,10 +438,8 @@ void norm(
             {
                 trace::Block trace_block("slate::device::trnorm");
 
-                blas::device_memcpy<scalar_t*>(a_array_dev, a_array_host,
-                                               batch_size,
-                                               blas::MemcpyKind::HostToDevice,
-                                               *queue);
+                blas::device_memcpy<scalar_t*>(
+                    a_array_dev, a_array_host, batch_size, *queue );
 
                 real_t* vals_dev_array_group = vals_dev_array;
                 for (size_t g = 0; g < group_params.size(); ++g) {
@@ -467,10 +465,8 @@ void norm(
                     vals_dev_array_group += group_count * ldv;
                 }
 
-                blas::device_memcpy<real_t>(vals_host_array, vals_dev_array,
-                                            batch_size*ldv,
-                                            blas::MemcpyKind::DeviceToHost,
-                                            *queue);
+                blas::device_memcpy<real_t>(
+                    vals_host_array, vals_dev_array, batch_size*ldv, *queue );
 
                 queue->sync();
             }

--- a/src/internal/internal_tzadd.cc
+++ b/src/internal/internal_tzadd.cc
@@ -185,10 +185,8 @@ void add(internal::TargetType<Target::Devices>,
 
             blas::Queue* queue = A.compute_queue(device, queue_index);
 
-            blas::device_memcpy<scalar_t*>(a_array_dev, a_array_host,
-                                batch_size*2,
-                                blas::MemcpyKind::HostToDevice,
-                                *queue);
+            blas::device_memcpy<scalar_t*>(
+                a_array_dev, a_array_host, batch_size*2, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/src/internal/internal_tzcopy.cc
+++ b/src/internal/internal_tzcopy.cc
@@ -174,15 +174,11 @@ void copy(internal::TargetType<Target::Devices>,
 
             blas::Queue* queue = A.compute_queue(device, queue_index);
 
-            blas::device_memcpy<src_scalar_t*>(a_array_dev, a_array_host,
-                                batch_count,
-                                blas::MemcpyKind::HostToDevice,
-                                *queue);
+            blas::device_memcpy<src_scalar_t*>(
+                a_array_dev, a_array_host, batch_count, *queue );
 
-            blas::device_memcpy<dst_scalar_t*>(b_array_dev, b_array_host,
-                                batch_count,
-                                blas::MemcpyKind::HostToDevice,
-                                *queue);
+            blas::device_memcpy<dst_scalar_t*>(
+                b_array_dev, b_array_host, batch_count, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/src/internal/internal_tzscale.cc
+++ b/src/internal/internal_tzscale.cc
@@ -152,8 +152,7 @@ void scale(internal::TargetType<Target::Devices>,
 
             scalar_t** a_array_dev = A.array_device( device, queue_index );
             blas::device_memcpy<scalar_t*>(
-                a_array_dev, a_array_host, batch_size,
-                blas::MemcpyKind::HostToDevice, *queue);
+                a_array_dev, a_array_host, batch_size, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/src/internal/internal_tzset.cc
+++ b/src/internal/internal_tzset.cc
@@ -162,8 +162,7 @@ void set(
             blas::Queue* queue = A.compute_queue(device, queue_index);
 
             blas::device_memcpy<scalar_t*>(
-                a_array_dev, a_array_host, batch_size,
-                blas::MemcpyKind::HostToDevice, *queue);
+                a_array_dev, a_array_host, batch_size, *queue );
 
             for (size_t g = 0; g < group_params.size(); ++g) {
                 int64_t group_count = group_params[ g ].count;

--- a/test/matrix_utils.cc
+++ b/test/matrix_utils.cc
@@ -340,20 +340,20 @@ TestMatrix<slate::TriangularMatrix<std::complex<double>>> allocate_test_Triangul
 //------------------------------------------------------------------------------
 /// Allocates a TrapezoidMatrix<scalar_t> and a reference version for testing.
 ///
-/// @param ref_matrix[in]
+/// @param[in] ref_matrix
 ///     Whether to allocate a reference matrix
 ///
-/// @param nonuniform_ref[in]
+/// @param[in] nonuniform_ref
 ///     If params.nonuniform_nb(), whether to also allocate the reference matrix
 ///     with non-uniform tiles.
 ///
-/// @param m[in]
+/// @param[in] m
 ///     The number of rows
 ///
-/// @param n[in]
+/// @param[in] n
 ///     The number of columns
 ///
-/// @param params[in]
+/// @param[in] params
 ///     The test params object which contains many of the key parameters
 ///
 template <typename scalar_t>

--- a/unit_test/test_Memory.cc
+++ b/unit_test/test_Memory.cc
@@ -173,9 +173,7 @@ void test_alloc_device()
             test_assert(int(mem.capacity (dev)) == max(cnt, i+1));
 
             // Touch memory to verify it is valid.
-            blas::device_memcpy<double>(dx[i], hx, nb * nb,
-                                        blas::MemcpyKind::HostToDevice,
-                                        *dev_queues[dev]);
+            blas::device_memcpy<double>( dx[i], hx, nb * nb, *dev_queues[dev] );
         }
 
         // Free some.

--- a/unit_test/test_Tile_kernels.cc
+++ b/unit_test/test_Tile_kernels.cc
@@ -1016,10 +1016,8 @@ void test_device_convert_layout(int m, int n)
     blas::Queue queue( device );
 
     Adata_dev = blas::device_malloc<scalar_t>(Adata.size(), queue);
-    blas::device_memcpy<scalar_t>(Adata_dev, Adata.data(),
-                        Adata.size(),
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<scalar_t>(
+        Adata_dev, Adata.data(), Adata.size(), queue );
 
     scalar_t* dev_work = blas::device_malloc<scalar_t>(lda*n, queue);
 

--- a/unit_test/test_geadd.cc
+++ b/unit_test/test_geadd.cc
@@ -348,8 +348,7 @@ void test_geadd_batch_dev_worker(
         auto dA = list_dA[ m_i ];
         Aarray[ m_i ] = dA.data();
     }
-    blas::device_memcpy<scalar_t*>(
-        dAarray, Aarray, batch_count, blas::MemcpyKind::HostToDevice, queue );
+    blas::device_memcpy<scalar_t*>( dAarray, Aarray, batch_count, queue );
 
     // Create batch array of dB
     scalar_t** Barray = new scalar_t*[ batch_count ];
@@ -360,8 +359,7 @@ void test_geadd_batch_dev_worker(
         auto dB = list_dB[ m_i ];
         Barray[ m_i ] = dB.data();
     }
-    blas::device_memcpy<scalar_t*>(
-        dBarray, Barray, batch_count, blas::MemcpyKind::HostToDevice, queue );
+    blas::device_memcpy<scalar_t*>( dBarray, Barray, batch_count, queue );
 
     // Add: B[k] = \alpha * A[k] + \beta * B[k]
     slate::device::batch::geadd( m, n,

--- a/unit_test/test_gecopy.cc
+++ b/unit_test/test_gecopy.cc
@@ -68,20 +68,14 @@ void test_gecopy_dev()
     test_assert(dAarray != nullptr);
     Aarray[0] = dA.data();
 
-    blas::device_memcpy<double*>(dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<double*>( dAarray, Aarray, batch_count, queue );
 
     double* Barray[batch_count];
     double** dBarray;
     dBarray = blas::device_malloc<double*>(batch_count, queue);
     test_assert(dBarray != nullptr);
     Barray[0] = dB.data();
-    blas::device_memcpy<double*>(dBarray, Barray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<double*>( dBarray, Barray, batch_count, queue );
 
     slate::device::gecopy( m, n,
                            dAarray, lda,
@@ -90,10 +84,7 @@ void test_gecopy_dev()
 
     queue.sync();
 
-    blas::device_memcpy<double*>(Barray, dBarray,
-                        batch_count,
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+    blas::device_memcpy<double*>( Barray, dBarray, batch_count, queue );
     queue.sync(); // sync before looking at data
 
     dB.copyData(&B, queue);

--- a/unit_test/test_gescale.cc
+++ b/unit_test/test_gescale.cc
@@ -101,11 +101,7 @@ void test_gescale_dev_worker(
 
     setup_data( A, offdiag_value, diag_value );
 
-    blas::device_memcpy<scalar_t>(
-                        dA.data(), A.data(),
-                        lda * n,
-                        blas::MemcpyKind::HostToDevice,
-                        queue );
+    blas::device_memcpy<scalar_t>( dA.data(), A.data(), lda * n, queue );
 
     slate::device::gescale(
                           m, n,
@@ -329,18 +325,10 @@ void test_gescale_batch_dev_worker(
         Aarray[ m_i ] = dA.data();
 
         // Copy the m_i'th matrix to the device
-        blas::device_memcpy<scalar_t>(
-                            dA.data(), A.data(),
-                            lda * n,
-                            blas::MemcpyKind::HostToDevice,
-                            queue );
+        blas::device_memcpy<scalar_t>( dA.data(), A.data(), lda * n, queue );
     }
     // Transfer the batch_array to the device
-    blas::device_memcpy<scalar_t*>(
-                        dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue );
+    blas::device_memcpy<scalar_t*>( dAarray, Aarray, batch_count, queue );
 
     slate::device::batch::gescale(
                           m, n,

--- a/unit_test/test_geset.cc
+++ b/unit_test/test_geset.cc
@@ -230,7 +230,7 @@ void test_geset_batch_dev_worker(
 
     // dAarray setup device-pointers to device-data in Aarray[]=dA[].data() for batch call
     blas::device_memcpy<scalar_t*>(
-        dAarray, Aarray, batch_count, blas::MemcpyKind::HostToDevice, queue );
+        dAarray, Aarray, batch_count, queue );
 
     // call device::batch::geset
     slate::device::batch::geset( m, n,

--- a/unit_test/test_norm.cc
+++ b/unit_test/test_norm.cc
@@ -180,10 +180,8 @@ void test_genorm_dev(Norm norm)
     dAarray = blas::device_malloc<double*>(batch_count, queue);
     test_assert(dAarray != nullptr);
     Aarray[0] = dA.data();
-    blas::device_memcpy<double*>(dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<double*>(
+        dAarray, Aarray, batch_count, queue );
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -204,10 +202,8 @@ void test_genorm_dev(Norm norm)
     slate::device::genorm( norm, slate::NormScope::Matrix, m, n, dAarray, lda,
                            dvalues, ldv, batch_count, queue );
     queue.sync();
-    blas::device_memcpy<double>(&values[0], dvalues,
-                        values.size(),
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+    blas::device_memcpy<double>(
+        &values[0], dvalues, values.size(), queue );
     queue.sync(); // sync before looking at values
 
     // check column & row sum results
@@ -401,10 +397,8 @@ void test_synorm_dev(Norm norm, Uplo uplo)
     dAarray = blas::device_malloc<double*>(batch_count, queue);
     test_assert(dAarray != nullptr);
     Aarray[0] = dA.data();
-    blas::device_memcpy<double*>(dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<double*>(
+        dAarray, Aarray, batch_count, queue );
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -423,10 +417,8 @@ void test_synorm_dev(Norm norm, Uplo uplo)
     slate::device::synorm( norm, uplo, n, dAarray, lda,
                            dvalues, ldv, batch_count, queue );
     queue.sync();
-    blas::device_memcpy<double>(&values[0], dvalues,
-                        values.size(),
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+    blas::device_memcpy<double>(
+        &values[0], dvalues, values.size(), queue );
     queue.sync(); // sync before looking at values
 
     // check column & row sum results
@@ -569,10 +561,8 @@ void test_synorm_offdiag_dev(Norm norm)
     dAarray = blas::device_malloc<double*>(batch_count, queue);
     test_assert(dAarray != nullptr);
     Aarray[0] = dA.data();
-    blas::device_memcpy<double*>(dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<double*>(
+        dAarray, Aarray, batch_count, queue );
 
     int ldv = n + m;
     std::vector<double> values( ldv );
@@ -585,10 +575,8 @@ void test_synorm_offdiag_dev(Norm norm)
                                   dvalues, ldv,
                                   batch_count, queue );
     queue.sync();
-    blas::device_memcpy<double>(&values[0], dvalues,
-                        values.size(),
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+    blas::device_memcpy<double>(
+        &values[0], dvalues, values.size(), queue );
     queue.sync(); // sync before looking at values
 
     // check column & row sum results
@@ -815,10 +803,8 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
     dAarray = blas::device_malloc<double*>(batch_count, queue);
     test_assert(dAarray != nullptr);
     Aarray[0] = dA.data();
-    blas::device_memcpy<double*>(dAarray, Aarray,
-                        batch_count,
-                        blas::MemcpyKind::HostToDevice,
-                        queue);
+    blas::device_memcpy<double*>(
+        dAarray, Aarray, batch_count, queue );
 
     std::vector<double> values;
     size_t ldv = 1;
@@ -839,10 +825,8 @@ void test_trnorm_dev(Norm norm, Uplo uplo, Diag diag)
     slate::device::trnorm( norm, uplo, diag, m, n, dAarray, lda,
                            dvalues, ldv, batch_count, queue );
     queue.sync();
-    blas::device_memcpy<double>(&values[0], dvalues,
-                        values.size(),
-                        blas::MemcpyKind::DeviceToHost,
-                        queue);
+    blas::device_memcpy<double>(
+        &values[0], dvalues, values.size(), queue );
     queue.sync(); // sync before looking at values
 
     // check column & row sum results


### PR DESCRIPTION
Remove uses of `blas::MemcpyKind`, which was deprecated. The direction (host => device, device => host, etc.) is determined implicitly by the pointers.
Remove SLATE functions that were deprecated.
Fix Doxygen `@param` that were misspelled (params, inout => in,out).