### PR TITLE
Tester fixes

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -195,8 +195,6 @@ if (not opts.dim):
         tall     = ' --dim 100x50'  # 2:1
         wide     = ' --dim 50x100'  # 1:2
         mnk      = ' --dim 25x50x75'
-        nk_tall  = ' --dim 1x100x50'  # 2:1
-        nk_wide  = ' --dim 1x50x100'  # 1:2
         if (is_default_nb):
             opts.nb = '8'
 
@@ -207,8 +205,6 @@ if (not opts.dim):
         mnk     += ' --dim 10x15x20 --dim 15x10x20' \
                 +  ' --dim 10x20x15 --dim 15x20x10' \
                 +  ' --dim 20x10x15 --dim 20x15x10'
-        nk_tall += ' --dim 1x20x10'
-        nk_wide += ' --dim 1x10x20'
         if (is_default_nb):
             opts.nb = '5,8'
         if (is_default_cond):
@@ -221,8 +217,6 @@ if (not opts.dim):
         mnk     += ' --dim 25x50x75 --dim 50x25x75' \
                 +  ' --dim 25x75x50 --dim 50x75x25' \
                 +  ' --dim 75x25x50 --dim 75x50x25'
-        nk_tall += ' --dim 1x50:200:50x25:100:25'
-        nk_wide += ' --dim 1x25:100:25x50:200:50'
         if (is_default_nb):
             opts.nb = '25,32'
 
@@ -233,8 +227,6 @@ if (not opts.dim):
         mnk     += ' --dim 100x300x600 --dim 300x100x600' \
                 +  ' --dim 100x600x300 --dim 300x600x100' \
                 +  ' --dim 600x100x300 --dim 600x300x100'
-        nk_tall += ' --dim 1x200:1000:200x100:500:100'
-        nk_wide += ' --dim 1x100:500:100x200:1000:200'
         if (is_default_nb):
             opts.nb = parser.get_default('nb')
 
@@ -245,10 +237,12 @@ if (not opts.dim):
         mnk     += ' --dim 1000x3000x6000 --dim 3000x1000x6000' \
                 +  ' --dim 1000x6000x3000 --dim 3000x6000x1000' \
                 +  ' --dim 6000x1000x3000 --dim 6000x3000x1000'
-        nk_tall += ' --dim 1x2000:10000:2000x1000:5000:1000'
-        nk_wide += ' --dim 1x1000:5000:1000x2000:10000:2000'
         if (is_default_nb):
             opts.nb = parser.get_default('nb')
+
+    # For nk, prepend 1x for the unused m dimension.
+    nk_tall = re.sub( r'--dim (\d)', r'--dim 1x\1', tall )
+    nk_wide = re.sub( r'--dim (\d)', r'--dim 1x\1', wide )
 
     mn  = ''
     nk  = ''

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -367,19 +367,19 @@ if (opts.blas3):
 
     [ 'hbmm',  gen + dtype         + la + side + uplo     + mn + ab + kd + matrixBC ],
 
-    [ 'herk',  gen + dtype_real    + la + he_matrix + trans    + mn + ab + matrixC ],
-    [ 'herk',  gen + dtype_complex + la + he_matrix + trans_nc + mn + ab + matrixC ],
+    [ 'herk',  gen + dtype_real    + la + he_matrix + trans    + nk + ab + matrixC ],
+    [ 'herk',  gen + dtype_complex + la + he_matrix + trans_nc + nk + ab + matrixC ],
 
-    [ 'her2k', gen + dtype_real    + la + he_matrix + trans    + mn + ab + matrixBC ],
-    [ 'her2k', gen + dtype_complex + la + he_matrix + trans_nc + mn + ab + matrixBC ],
+    [ 'her2k', gen + dtype_real    + la + he_matrix + trans    + nk + ab + matrixBC ],
+    [ 'her2k', gen + dtype_complex + la + he_matrix + trans_nc + nk + ab + matrixBC ],
 
     [ 'symm',  gen + dtype         + la + side + sy_matrix     + mn + ab + matrixBC ],
 
-    [ 'syr2k', gen + dtype_real    + la + sy_matrix + trans    + mn + ab + matrixC ],
-    [ 'syr2k', gen + dtype_complex + la + sy_matrix + trans_nt + mn + ab + matrixC ],
+    [ 'syr2k', gen + dtype_real    + la + sy_matrix + trans    + nk + ab + matrixC ],
+    [ 'syr2k', gen + dtype_complex + la + sy_matrix + trans_nt + nk + ab + matrixC ],
 
-    [ 'syrk',  gen + dtype_real    + la + sy_matrix + trans    + mn + ab + matrixBC ],
-    [ 'syrk',  gen + dtype_complex + la + sy_matrix + trans_nt + mn + ab + matrixBC ],
+    [ 'syrk',  gen + dtype_real    + la + sy_matrix + trans    + nk + ab + matrixBC ],
+    [ 'syrk',  gen + dtype_complex + la + sy_matrix + trans_nt + nk + ab + matrixBC ],
 
     # todo: tbsm fails for nb=8 or 16 with --quick.
     [ 'tbsm',  gen_no_nb + ' --nb 32' + dtype + la + side + uplo + transA + diag + mn + a + kd + matrixB ],

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -124,9 +124,9 @@ void test_her2k_work(Params& params, bool run)
         opA = conj_transpose( A );
         opB = conj_transpose( B );
     }
-    slate_assert(A.mt() == C.mt());
-    slate_assert(B.mt() == C.mt());
-    slate_assert(A.nt() == B.nt());
+    slate_assert( opA.mt() == C.mt() );
+    slate_assert( opB.mt() == C.mt() );
+    slate_assert( opA.nt() == opB.nt() );
 
     print_matrix("A", A, params);
     print_matrix("B", B, params);
@@ -138,9 +138,9 @@ void test_her2k_work(Params& params, bool run)
     // If check run, perform first half of SLATE residual check.
     TestMatrix<slate::Matrix<scalar_t>> X_alloc, Y_alloc, Z_alloc;
     if (check && ! ref) {
-        X_alloc = allocate_test_Matrix<scalar_t>( false, true, An, nrhs, params );
-        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
-        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
+        X_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, k, nrhs, params );
 
         auto& X = X_alloc.A;
         auto& Y = Y_alloc.A;

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -117,9 +117,9 @@ void test_herk_work(Params& params, bool run)
     // If check run, perform first half of SLATE residual check.
     TestMatrix<slate::Matrix<scalar_t>> X_alloc, Y_alloc, Z_alloc;
     if (check && ! ref) {
-        X_alloc = allocate_test_Matrix<scalar_t>( false, true, An, nrhs, params );
-        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
-        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
+        X_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, k, nrhs, params );
 
         auto& X = X_alloc.A;
         auto& Y = Y_alloc.A;

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -122,9 +122,9 @@ void test_syr2k_work(Params& params, bool run)
         opA = conj_transpose( A );
         opB = conj_transpose( B );
     }
-    slate_assert(opA.mt() == C.mt());
-    slate_assert(opB.mt() == C.mt());
-    slate_assert(opA.nt() == B.nt());
+    slate_assert( opA.mt() == C.mt() );
+    slate_assert( opB.mt() == C.mt() );
+    slate_assert( opA.nt() == opB.nt() );
 
     print_matrix("A", A, params);
     print_matrix("B", B, params);
@@ -136,9 +136,9 @@ void test_syr2k_work(Params& params, bool run)
     // If check run, perform first half of SLATE residual check.
     TestMatrix<slate::Matrix<scalar_t>> X_alloc, Y_alloc, Z_alloc;
     if (check && ! ref) {
-        X_alloc = allocate_test_Matrix<scalar_t>( false, true, An, nrhs, params );
-        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
-        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
+        X_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, k, nrhs, params );
 
         auto& X = X_alloc.A;
         auto& Y = Y_alloc.A;

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -115,9 +115,9 @@ void test_syrk_work(Params& params, bool run)
     // If check run, perform first half of SLATE residual check.
     TestMatrix<slate::Matrix<scalar_t>> X_alloc, Y_alloc, Z_alloc;
     if (check && ! ref) {
-        X_alloc = allocate_test_Matrix<scalar_t>( false, true, An, nrhs, params );
-        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
-        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, Am, nrhs, params );
+        X_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Y_alloc = allocate_test_Matrix<scalar_t>( false, true, n, nrhs, params );
+        Z_alloc = allocate_test_Matrix<scalar_t>( false, true, k, nrhs, params );
 
         auto& X = X_alloc.A;
         auto& Y = Y_alloc.A;


### PR DESCRIPTION
In run_tests, renames `cond` to `condest`, and add `cond` option.
Fix testers for `herk`, `syrk`, `her2k`, `syr2k` to take n-by-k. It was passing m-by-n.

For xsmall matrix sizes, CholQR needs a smaller condition number to pass. Previously failing runs:
```
./run_tests.py --xsmall --type s,d,z
...
--------------------------------------------------------------------------------
./tester  --origin s --target t --ref n --nb 5,8 --lookahead 1 --dim 10 --dim 20x10 --trans n,c --method-gels cholqr --matrix svd --cond 1e3 --type s,c gels
% SLATE version 2023.11.05, id de5d2ec2
% input: ./tester --origin s --target t --ref n --nb 5,8 --lookahead 1 --dim 10 --dim 20x10 --trans n,c --method-gels cholqr --matrix svd --cond 1e3 --type s,c gels
% 2024-05-27 11:44:42, 1 MPI ranks, CPU-only MPI, 4 OpenMP threads per MPI rank
                                                                                                                                                                                                          
 A   B   C  type  origin  target  cholQR    gels    trans       m       n    nrhs    nb  ib    p    q  la  pt  leastsqr  min norm  residual   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
 1   2   2     s  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  2.55e-06        NA  5.34e-07   0.000303        0.0161            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  7.14e-06        NA  1.14e-06   0.000263        0.0186            NA            NA  FAILED  
 1   2   2     s  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  3.50e-07        NA  3.34e-07   0.000266        0.0413            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  1.55e-06        NA  6.43e-07   0.000290        0.0379            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  9.53e-07        NA  5.38e-07   0.000179        0.0273            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  6.91e-07        NA  1.85e-07   0.000343        0.0142            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  8.31e-07  1.24e-07   0.000296        0.0371            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  2.80e-07  1.63e-07   0.000278        0.0395            NA            NA  pass    

 1   2   2     c  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  3.09e-06        NA  5.99e-07   0.000275        0.0734            NA            NA  FAILED  
 1   2   2     c  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  1.84e-06        NA  4.45e-07   0.000203        0.0994            NA            NA  pass    
 1   2   2     c  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  1.26e-06        NA  5.09e-07   0.000216         0.207            NA            NA  pass    
 1   2   2     c  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  1.17e-06        NA  3.46e-07   0.000261         0.172            NA            NA  pass    
 1   2   2     c  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  3.34e-06        NA  1.05e-06   0.000204        0.0989            NA            NA  FAILED  
 1   2   2     c  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  2.61e-06        NA  4.55e-07   0.000185         0.109            NA            NA  pass    
 1   2   2     c  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  1.87e-06  2.14e-07   0.000191         0.234            NA            NA  pass    
 1   2   2     c  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  1.44e-06  4.01e-07   0.000227         0.197            NA            NA  pass    

% Matrix kinds:
%  1: svd, cond = 1000
%  2: rand, cond unknown

% 3 tests FAILED: gels
FAILED: gels, exit code 3
--------------------------------------------------------------------------------
./tester  --origin s --target t --ref n --nb 5,8 --lookahead 1 --dim 10 --dim 20x10 --trans n,c --method-gels cholqr --matrix svd --cond 1e3 --type d,z gels
% SLATE version 2023.11.05, id de5d2ec2
% input: ./tester --origin s --target t --ref n --nb 5,8 --lookahead 1 --dim 10 --dim 20x10 --trans n,c --method-gels cholqr --matrix svd --cond 1e3 --type d,z gels
% 2024-05-27 11:44:42, 1 MPI ranks, CPU-only MPI, 4 OpenMP threads per MPI rank
                                                                                                                                                                                                          
 A   B   C  type  origin  target  cholQR    gels    trans       m       n    nrhs    nb  ib    p    q  la  pt  leastsqr  min norm  residual   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
 1   2   2     d  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  1.49e-15        NA  3.43e-16   0.000292        0.0167            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  2.97e-15        NA  6.80e-16   0.000286        0.0171            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  4.70e-16        NA  2.24e-16   0.000239        0.0459            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  7.68e-16        NA  2.78e-16   0.000269        0.0408            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  1.14e-15        NA  6.25e-16   0.000218        0.0224            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  2.28e-15        NA  4.91e-16   0.000245        0.0199            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  1.59e-15  4.44e-16   0.000285        0.0385            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  1.37e-15  4.10e-16   0.000234        0.0469            NA            NA  pass    

 1   2   2     z  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  6.01e-15        NA  1.42e-15   0.000255        0.0791            NA            NA  FAILED  
 1   2   2     z  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  4.24e-15        NA  9.86e-16   0.000220        0.0917            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  3.14e-15        NA  5.72e-16   0.000266         0.168            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  1.44e-15        NA  6.90e-16   0.000206         0.217            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  5.58e-15        NA  8.71e-16   0.000191         0.106            NA            NA  FAILED  
 1   2   2     z  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  1.17e-14        NA  2.13e-15   0.000192         0.105            NA            NA  FAILED  
 1   2   2     z  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  1.35e-15  2.89e-16   0.000193         0.232            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  2.61e-15  5.14e-16   0.000209         0.214            NA            NA  pass    

% Matrix kinds:
%  1: svd, cond = 1000
%  2: rand, cond unknown

% 3 tests FAILED: gels
FAILED: gels, exit code 3
```
Runs now pass:
```
./run_tests.py --xsmall --type s,d,z
...
--------------------------------------------------------------------------------
./tester  --origin s --target t --ref n --nb 5,8 --type s,d,z --lookahead 1 --dim 10 --dim 20x10 --trans n,c --cond 1e2 --method-gels cholqr --matrix svd gels
% SLATE version 2023.11.05, id de5d2ec2
% input: ./tester --origin s --target t --ref n --nb 5,8 --type s,d,z --lookahead 1 --dim 10 --dim 20x10 --trans n,c --cond 1e2 --method-gels cholqr --matrix svd gels
% 2024-05-27 11:43:33, 1 MPI ranks, CPU-only MPI, 4 OpenMP threads per MPI rank
                                                                                                                                                                                                          
 A   B   C  type  origin  target  cholQR    gels    trans       m       n    nrhs    nb  ib    p    q  la  pt  leastsqr  min norm  residual   time (s)       gflop/s  ref time (s)   ref gflop/s  status  
 1   2   2     s  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  4.30e-07        NA  9.36e-08    0.00135       0.00361            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  7.25e-07        NA  1.49e-07   0.000307        0.0159            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  5.13e-08        NA  3.42e-08   0.000341        0.0322            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  3.19e-08        NA  2.36e-08   0.000286        0.0384            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  8.93e-08        NA  2.14e-08   0.000267        0.0183            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  3.94e-07        NA  6.77e-08   0.000250        0.0195            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  6.27e-08  2.19e-08   0.000267        0.0411            NA            NA  pass    
 1   2   2     s  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  6.94e-08  9.00e-09   0.000216        0.0508            NA            NA  pass    

 1   2   2     d  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  6.51e-16        NA  1.41e-16   0.000300        0.0163            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  1.24e-15        NA  1.24e-16   0.000244        0.0200            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  6.66e-17        NA  3.30e-17   0.000249        0.0441            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  1.79e-16        NA  6.66e-17   0.000268        0.0410            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  8.34e-16        NA  1.01e-16   0.000192        0.0254            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  3.98e-16        NA  1.61e-16   0.000290        0.0168            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  1.43e-16  2.44e-17   0.000295        0.0372            NA            NA  pass    
 1   2   2     d  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  8.80e-17  1.70e-17   0.000171        0.0642            NA            NA  pass    

 1   2   2     z  scalpk    task    auto  CholQR  notrans      10      10      10     5  32    1    1   1   2  3.23e-16        NA  6.96e-17   0.000218        0.0926            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR  notrans      10      10      10     8  32    1    1   1   2  7.27e-16        NA  1.23e-16   0.000154         0.131            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR  notrans      20      10      10     5  32    1    1   1   2  1.00e-16        NA  4.67e-17   0.000165         0.271            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR  notrans      20      10      10     8  32    1    1   1   2  1.16e-16        NA  3.60e-17   0.000154         0.291            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR     conj      10      10      10     5  32    1    1   1   2  3.29e-16        NA  1.46e-16   0.000151         0.134            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR     conj      10      10      10     8  32    1    1   1   2  3.67e-16        NA  1.34e-16   0.000120         0.168            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR     conj      20      10      10     5  32    1    1   1   2        NA  3.20e-16  4.47e-17   0.000152         0.295            NA            NA  pass    
 1   2   2     z  scalpk    task    auto  CholQR     conj      20      10      10     8  32    1    1   1   2        NA  2.47e-16  5.25e-17   0.000132         0.339            NA            NA  pass    

% Matrix kinds:
%  1: svd, cond = 100
%  2: rand, cond unknown

% All tests passed: gels
passed: gels
```