### PR TITLE
Trsm test

### DIFF
--- a/test/test.hh
+++ b/test/test.hh
@@ -225,11 +225,6 @@ public:
     testsweeper::ParamInt    debug_rank;
     std::string              routine;
 
-    //----- test matrix parameters
-    MatrixParams matrix;
-    MatrixParams matrixB;
-    MatrixParams matrixC;
-
     //----- routine parameters, enums
     testsweeper::ParamEnum< testsweeper::DataType > datatype;
     testsweeper::ParamEnum< slate::Origin >         origin;
@@ -246,6 +241,11 @@ public:
 
     testsweeper::ParamEnum< slate::GridOrder >      grid_order;
     testsweeper::ParamEnum< slate::GridOrder >      dev_order;
+
+    // test matrix parameters
+    MatrixParams matrix;
+    MatrixParams matrixB;
+    MatrixParams matrixC;
 
     // BLAS & LAPACK options
     // The order here matches the order in most LAPACK functions, e.g.,

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -103,11 +103,15 @@ void test_trsm_work(Params& params, bool run)
     slate::generate_matrix( params.matrix, A );
     slate::generate_matrix( params.matrixB, B );
 
-    // Cholesky factor of A to get a well conditioned triangular matrix.
-    // Even when we replace the diagonal with unit diagonal,
-    // it seems to still be well conditioned.
-    auto AH = slate::HermitianMatrix<scalar_t>( A );
-    slate::potrf( AH, opts );
+    // For non-unit diagonal, the diagonally dominant matrix is
+    // well conditioned; no need for Cholesky.
+    if (diag == slate::Diag::Unit) {
+        // Cholesky factor of A to get a well conditioned triangular matrix.
+        // Even when we replace the diagonal with a unit diagonal,
+        // it seems to still be well conditioned.
+        auto AH = slate::HermitianMatrix<scalar_t>( A );
+        slate::potrf( AH, opts );
+    }
 
     // If reference run is required, record norms to be used in the check/ref.
     if (check || ref) {


### PR DESCRIPTION
* Tweak tester output, moving matrices back to their old column position.
* Don't need Cholesky for non-unit trsm test.