### PR TITLE
Cleanup

### DIFF
--- a/include/slate/BaseMatrix.hh
+++ b/include/slate/BaseMatrix.hh
@@ -2773,9 +2773,7 @@ void BaseMatrix<scalar_t>::tileGet(std::set<ij_tuple>& tile_set, int device,
     for (auto iter = tile_set.begin(); iter != tile_set.end(); ++iter) {
         int64_t i = std::get<0>(*iter);
         int64_t j = std::get<1>(*iter);
-        {
-            tileGet(i, j, device, layoutConvert, modify, hold, true);
-        }
+        tileGet( i, j, device, layoutConvert, modify, hold, true );
     }
 
     if (! async && device != HostNum)
@@ -2963,12 +2961,14 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::tileGetAllForReading(int device, LayoutConvert layout)
 {
     std::set<ij_tuple> tiles_set;
-    for (int64_t j = 0; j < nt(); ++j)
-        for (int64_t i = 0; i < mt(); ++i)
+    for (int64_t j = 0; j < nt(); ++j) {
+        for (int64_t i = 0; i < mt(); ++i) {
             // todo: if (tileIsLocal(i, j) && (device == HostNum || device == tileDevice(i, j))) {
             if (tileIsLocal(i, j)) {
                 tiles_set.insert({i, j});
             }
+        }
+    }
 
     tileGetForReading(tiles_set, device, layout);
 }
@@ -2992,12 +2992,14 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::tileGetAllForWriting(int device, LayoutConvert layout)
 {
     std::set<ij_tuple> tiles_set;
-    for (int64_t j = 0; j < nt(); ++j)
-        for (int64_t i = 0; i < mt(); ++i)
+    for (int64_t j = 0; j < nt(); ++j) {
+        for (int64_t i = 0; i < mt(); ++i) {
             // todo: if (tileIsLocal(i, j) && (device == HostNum || device == tileDevice(i, j))) {
             if (tileIsLocal(i, j)) {
                 tiles_set.insert({i, j});
             }
+        }
+    }
 
     tileGetForWriting(tiles_set, device, layout);
 }
@@ -3021,12 +3023,14 @@ template <typename scalar_t>
 void BaseMatrix<scalar_t>::tileGetAndHoldAll(int device, LayoutConvert layout)
 {
     std::set<ij_tuple> tiles_set;
-    for (int64_t j = 0; j < nt(); ++j)
-        for (int64_t i = 0; i < mt(); ++i)
+    for (int64_t j = 0; j < nt(); ++j) {
+        for (int64_t i = 0; i < mt(); ++i) {
             // todo: if (tileIsLocal(i, j) && (device == HostNum || device == tileDevice(i, j))) {
             if (tileIsLocal(i, j)) {
                 tiles_set.insert({i, j});
             }
+        }
+    }
 
     tileGetAndHold( tiles_set, device, layout );
 }

--- a/include/slate/Exception.hh
+++ b/include/slate/Exception.hh
@@ -28,9 +28,10 @@ public:
     /// Sets the what() message to msg with func, file, line appended.
     Exception(std::string const& msg,
               const char* func, const char* file, int line)
-        : std::exception(),
-          msg_(msg + " in " + func + " at " + file + ":" + std::to_string(line))
-    {}
+        : std::exception()
+    {
+        what( msg, func, file, line );
+    }
 
     /// @return message describing the exception.
     virtual char const* what() const noexcept override
@@ -40,12 +41,14 @@ public:
 
 protected:
     /// Sets the what() message to msg with func, file, line appended.
+    /// See MpiException in mpi.hh.
     void what(std::string const& msg,
               const char* func, const char* file, int line)
     {
         msg_ = msg + " in " + func + " at " + file + ":" + std::to_string(line);
     }
 
+private:
     std::string msg_;
 };
 
@@ -56,6 +59,7 @@ protected:
     } while(0)
 
 //------------------------------------------------------------------------------
+/// Exception class for slate_not_implemented().
 class NotImplemented : public Exception {
 public:
     NotImplemented(const char* msg,

--- a/include/slate/Tile_aux.hh
+++ b/include/slate/Tile_aux.hh
@@ -19,7 +19,7 @@ class Tile;
 namespace tile {
 
 //------------------------------------------------------------------------------
-/// Copy and precision conversion.
+/// Copy and precision conversion, copying tile A to B.
 /// @ingroup copy_tile
 ///
 template <typename src_scalar_t, typename dst_scalar_t>
@@ -226,9 +226,10 @@ void transpose(int64_t n,
 ///     Leading dimension of matrix AT. ldat >= n.
 ///
 template <typename scalar_t>
-void transpose(int64_t m, int64_t n,
-               scalar_t* A, int64_t lda,
-               scalar_t* AT, int64_t ldat)
+void transpose(
+    int64_t m, int64_t n,
+    scalar_t const* A, int64_t lda,
+    scalar_t* AT, int64_t ldat)
 {
     assert(lda >= m);
     assert(ldat >= n);
@@ -293,9 +294,10 @@ void conjTranspose(int64_t n,
 ///     Leading dimension of matrix AT. ldat >= n.
 ///
 template <typename scalar_t>
-void conjTranspose(int64_t m, int64_t n,
-                   scalar_t* A, int64_t lda,
-                   scalar_t* AT, int64_t ldat)
+void conjTranspose(
+    int64_t m, int64_t n,
+    scalar_t const* A, int64_t lda,
+    scalar_t* AT, int64_t ldat)
 {
     using blas::conj;
     assert(lda >= m);
@@ -323,7 +325,7 @@ void deepTranspose(Tile<scalar_t>&& A)
 /// Host implementation.
 ///
 template <typename scalar_t>
-void deepTranspose(Tile<scalar_t>&& A, Tile<scalar_t>&& AT)
+void deepTranspose( Tile<scalar_t> const&& A, Tile<scalar_t>&& AT )
 {
     assert(A.mb() == AT.nb());
     assert(A.nb() == AT.mb());
@@ -346,7 +348,7 @@ void deepConjTranspose(Tile<scalar_t>&& A)
 /// Host implementation.
 ///
 template <typename scalar_t>
-void deepConjTranspose(Tile<scalar_t>&& A, Tile<scalar_t>&& AT)
+void deepConjTranspose( Tile<scalar_t> const&& A, Tile<scalar_t>&& AT )
 {
     assert(A.mb() == AT.nb());
     assert(A.nb() == AT.mb());

--- a/test/test.hh
+++ b/test/test.hh
@@ -225,11 +225,6 @@ public:
     testsweeper::ParamInt    debug_rank;
     std::string              routine;
 
-    //----- test matrix parameters
-    MatrixParams matrix;
-    MatrixParams matrixB;
-    MatrixParams matrixC;
-
     //----- routine parameters, enums
     testsweeper::ParamEnum< testsweeper::DataType > datatype;
     testsweeper::ParamEnum< slate::Origin >         origin;
@@ -246,6 +241,11 @@ public:
 
     testsweeper::ParamEnum< slate::GridOrder >      grid_order;
     testsweeper::ParamEnum< slate::GridOrder >      dev_order;
+
+    // test matrix parameters
+    MatrixParams matrix;
+    MatrixParams matrixB;
+    MatrixParams matrixC;
 
     // BLAS & LAPACK options
     // The order here matches the order in most LAPACK functions, e.g.,

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -103,11 +103,15 @@ void test_trsm_work(Params& params, bool run)
     slate::generate_matrix( params.matrix, A );
     slate::generate_matrix( params.matrixB, B );
 
-    // Cholesky factor of A to get a well conditioned triangular matrix.
-    // Even when we replace the diagonal with unit diagonal,
-    // it seems to still be well conditioned.
-    auto AH = slate::HermitianMatrix<scalar_t>( A );
-    slate::potrf( AH, opts );
+    // For non-unit diagonal, the diagonally dominant matrix is
+    // well conditioned; no need for Cholesky.
+    if (diag == slate::Diag::Unit) {
+        // Cholesky factor of A to get a well conditioned triangular matrix.
+        // Even when we replace the diagonal with a unit diagonal,
+        // it seems to still be well conditioned.
+        auto AH = slate::HermitianMatrix<scalar_t>( A );
+        slate::potrf( AH, opts );
+    }
 
     // If reference run is required, record norms to be used in the check/ref.
     if (check || ref) {


### PR DESCRIPTION
Minor cleanup.
* Cleanup braces. Style guide prefers to have braces on multi-line loops, even if C++ doesn't require them. (But many instances still remaining.)
* Add const to transpose functions.
* Simplify and document Exception classes.