### PR TITLE
Cleanup

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1363,7 +1363,7 @@ ${pkg}:
 
 lib: ${slate} ${matgen}
 
-clean: test/clean unit_test/clean scalapack_api/clean lapack_api/clean include/clean
+clean: src/clean test/clean unit_test/clean scalapack_api/clean lapack_api/clean include/clean
 	rm -f lib/lib* ${dep}
 	rm -f trace_*.svg
 

--- a/include/slate/TrapezoidMatrix.hh
+++ b/include/slate/TrapezoidMatrix.hh
@@ -544,7 +544,7 @@ TrapezoidMatrix<scalar_t> TrapezoidMatrix<scalar_t>::sub(
 /// This version returns a general Matrix that:
 /// - if uplo = Lower, is strictly below the diagonal, or
 /// - if uplo = Upper, is strictly above the diagonal.
-/// @see TrapezoidMatrix sub(int64_t i1, int64_t i2, int64_T j2)
+/// @see TrapezoidMatrix sub( int64_t i1, int64_t i2, int64_t j2 )
 ///
 /// @param[in] i1
 ///     Starting block row index. 0 <= i1 < mt.

--- a/src/internal/Tile_geqrf.hh
+++ b/src/internal/Tile_geqrf.hh
@@ -158,7 +158,7 @@ void geqrf(
             }
             else {
                 real_t beta =
-                    -std::copysign(lapack::lapy3(alphr, alphi, xnorm), alphr);
+                    -std::copysign( std::hypot( alphr, alphi, xnorm ), alphr );
                 knt = 0;
                 if (std::abs(beta) < safemin) {
                     if (knt < 20 && std::abs(beta) < safemin) {
@@ -217,7 +217,8 @@ void geqrf(
                     thread_barrier.wait(thread_size);
                     alphr = real(alpha);
                     alphi = imag(alpha);
-                    beta = -std::copysign(lapack::lapy3(alphr, alphi, xnorm), alphr);
+                    beta = -std::copysign( std::hypot( alphr, alphi, xnorm ),
+                                           alphr );
                 }
 
                 // todo: Use overflow-safe division (see CLADIV/ZLADIV)

--- a/src/internal/Tile_getrf.hh
+++ b/src/internal/Tile_getrf.hh
@@ -331,8 +331,8 @@ void getrf(
                 auto i_index = tile_indices[idx];
 
                 // column scaling
-                real_t sfmin = std::numeric_limits<real_t>::min();
-                if (cabs1(pivot[j].value()) >= sfmin) {
+                real_t safe_min = std::numeric_limits<real_t>::min();
+                if (cabs1( pivot[ j ].value() ) >= safe_min) {
                     // todo: make it a tile operation
                     if (i_index == 0) {
                         // diagonal tile

--- a/src/internal/Tile_getrf_tntpiv.hh
+++ b/src/internal/Tile_getrf_tntpiv.hh
@@ -208,8 +208,8 @@ void getrf_tntpiv_local(
                 auto tile = tiles[ idx ];
 
                 // column scaling
-                real_t sfmin = std::numeric_limits<real_t>::min();
-                if (cabs1( aux_pivot[ 0 ][ j ].value() ) >= sfmin) {
+                real_t safe_min = std::numeric_limits<real_t>::min();
+                if (cabs1( aux_pivot[ 0 ][ j ].value() ) >= safe_min) {
                     // todo: make it a tile operation
                     if (idx == 0) {
                         // diagonal tile

--- a/src/internal/Tile_householder_reflection_generator.hh
+++ b/src/internal/Tile_householder_reflection_generator.hh
@@ -129,7 +129,7 @@ void householder_reflection_generator(
         thread_barrier.wait(thread_size);
 
         real_t beta =
-            -std::copysign(lapack::lapy3(alphr, alphi, xnorm), alphr);
+            -std::copysign( std::hypot( alphr, alphi, xnorm ), alphr );
 
         scalar_t scal_alpha = one / (alpha-beta);
         scalar_t tau = blas::make_scalar<scalar_t>(

--- a/src/internal/internal_norm1est.cc
+++ b/src/internal/internal_norm1est.cc
@@ -137,8 +137,8 @@ void norm1est(
     using blas::real;
     using blas::imag;
     const auto mpi_real_type = mpi_type< blas::real_type<scalar_t> >::value;
-    real_t safmin = std::numeric_limits< real_t >::min();
-    SLATE_UNUSED(safmin);
+    real_t safe_min = std::numeric_limits< real_t >::min();
+    SLATE_UNUSED( safe_min );
 
     const scalar_t one  = 1.0;
     const scalar_t zero = 0.0;
@@ -202,7 +202,7 @@ void norm1est(
                         // for complex number
                         if constexpr (blas::is_complex<scalar_t>::value) {
                             real_t absx1 = std::abs( Xi_data[ii] );
-                            if (absx1 > safmin) {
+                            if (absx1 > safe_min) {
                                 scalar_t Xi_ii = blas::MakeScalarTraits<scalar_t>::make(
                                         real( Xi_data[ii] ) / absx1,
                                         imag( Xi_data[ii] ) / absx1 );
@@ -301,7 +301,7 @@ void norm1est(
                         auto Xi_data = Xi.data();
                         for (int64_t ii = 0; ii < X.tileMb(i); ++ii) {
                             real_t absx1 = std::abs( Xi_data[ii] );
-                            if (absx1 > safmin) {
+                            if (absx1 > safe_min) {
                                 scalar_t Xi_ii = blas::MakeScalarTraits<scalar_t>::make( real( Xi_data[ii] ) / absx1,
                                         imag( Xi_data[ii] ) / absx1);
                                 Xi_data[ii] = Xi_ii;

--- a/src/stedc.cc
+++ b/src/stedc.cc
@@ -62,7 +62,7 @@ void stedc(
         throw std::domain_error( "Input matrix contains Inf or NaN" );
 
     // Scale if necessary.
-    // todo: steqr scales only if Anorm > sfmax or Anorm < sfmin,
+    // todo: steqr scales only if Anorm > safe_max or Anorm < safe_min,
     // but stedc always scales. Is that right?
     lapack::lascl( MatrixType::General, 0, 0, Anorm, one, n,   1, &D[0], n   );
     lapack::lascl( MatrixType::General, 0, 0, Anorm, one, n-1, 1, &E[0], n-1 );

--- a/src/stedc_deflate.cc
+++ b/src/stedc_deflate.cc
@@ -313,7 +313,7 @@ void stedc_deflate(
             //         [ -s  c ]
             real_t s = -z[ js1 ];
             real_t c =  z[ js2 ];
-            real_t tau = lapack::lapy2( c, s );  // == sqrt( c*c + s*s )
+            real_t tau = std::hypot( c, s );  // == sqrt( c*c + s*s )
             s /= tau;
             c /= tau;
             // Check off-diagonal element after applying G on both sides:


### PR DESCRIPTION
Various cleanup tasks
- Replace deprecated `lapy[23]` with `std::hypot`
- Normalize spelling of `safe_min` and `safe_max`
- Update QR panel to match LAPACK `larfg`, which fixes tests with `--matrix rand_small` (see below)
- Fix `make clean`

Abbreviated output:
```
pangolin slate/test> ./tester --matrix rand,rand_ufl,rand_small,rand_large,rand_ofl geqrf
% SLATE version 2024.05.31, id 4ff661ab
% input: ./tester --matrix rand,rand_ufl,rand_small,rand_large,rand_ofl geqrf
% 2024-06-26 13:06:17, 1 MPI ranks, CPU-only MPI, 4 OpenMP threads per MPI rank

type   A    m    n     error  status
   d   1  500  500  5.23e-18  pass      # rand
   d   2  500  500  1.88e-03  FAILED    # rand_ufl
   d   3  500  500  1.92e-03  FAILED    # rand_small
   d   4  500  500  5.01e-18  pass      # rand_large
   d   5  500  500       nan  FAILED    # rand_ofl

% 3 tests FAILED: geqrf


pangolin slate/test> ./tester --matrix rand,rand_ufl,rand_small,rand_large,rand_ofl geqrf
% SLATE version 2024.05.31, id 57174564
% input: ./tester --matrix rand,rand_ufl,rand_small,rand_large,rand_ofl geqrf
% 2024-06-26 13:06:57, 1 MPI ranks, CPU-only MPI, 4 OpenMP threads per MPI rank

type   A    m    n     error  status
   d   1  500  500  4.93e-18  pass      # rand
   d   2  500  500  1.90e-03  FAILED    # rand_ufl
   d   3  500  500  5.00e-18  pass      # rand_small FIXED!
   d   4  500  500  4.59e-18  pass      # rand_large
   d   5  500  500       nan  FAILED    # rand_ofl

% Matrix kinds:
%  1: rand, cond unknown
%  2: rand_ufl, cond unknown
%  3: rand_small, cond unknown
%  4: rand_large, cond unknown
%  5: rand_ofl, cond unknown

% 2 tests FAILED: geqrf
```