### PR TITLE
ScaLAPACK enums and namespace

### DIFF
--- a/test/matrix_utils.hh
+++ b/test/matrix_utils.hh
@@ -247,8 +247,8 @@ public:
     void ScaLAPACK_descriptor( blas_int ictxt, blas_int A_desc[9] )
     {
         int64_t info;
-        scalapack_descinit(A_desc, m, n, nb, nb, 0, 0, ictxt, mloc, &info);
-        slate_assert(info == 0);
+        scalapack::descinit( A_desc, m, n, nb, nb, 0, 0, ictxt, mloc, &info );
+        slate_assert( info == 0 );
     }
 
     void create_ScaLAPACK_context( blas_int* ictxt )

--- a/test/test_add.cc
+++ b/test/test_add.cc
@@ -152,12 +152,12 @@ void test_add_work(Params& params, bool run)
 
             int64_t info;
             if (uplo == slate::Uplo::General) {
-                scalapack_pgeadd( to_c_string( trans ), m, n,
+                scalapack::geadd( trans, m, n,
                                   alpha, &Aref_data[0], 1, 1, A_desc,
                                   beta,  &Bref_data[0], 1, 1, B_desc, &info );
             }
             else {
-                scalapack_ptradd( to_c_string( uplo ), to_c_string( trans ), m, n,
+                scalapack::tradd( uplo, trans, m, n,
                                   alpha, &Aref_data[0], 1, 1, A_desc,
                                   beta,  &Bref_data[0], 1, 1, B_desc, &info );
             }

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -152,7 +152,7 @@ void test_copy_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
 
-            scalapack_placpy( to_c_string( uplo ), m, n,
+            scalapack::lacpy( uplo, m, n,
                               &Aref_data[0], 1, 1, A_desc,
                               &Bref_data[0], 1, 1, B_desc );
 

--- a/test/test_gbnorm.cc
+++ b/test/test_gbnorm.cc
@@ -124,19 +124,18 @@ void test_gbnorm_work(Params& params, bool run)
             slate_assert( mycol == mycol_ );
 
             int64_t info;
-            scalapack_descinit(A_desc, m, n, nb, nb, 0, 0, ictxt, lldA, &info);
+            scalapack::descinit( A_desc, m, n, nb, nb, 0, 0, ictxt, lldA, &info );
             slate_assert(info == 0);
 
             // allocate work space
-            std::vector<real_t> worklange(std::max(mlocA, nlocA));
+            std::vector<real_t> work( max( mlocA, nlocA ) );
 
             //==================================================
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            real_t A_norm_ref = scalapack_plange(
-                                    to_c_string( norm ),
-                                    m, n, &A_data[0], 1, 1, A_desc, &worklange[0]);
+            real_t A_norm_ref = scalapack::lange(
+                norm, m, n, &A_data[0], 1, 1, A_desc, &work[0] );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             // difference between norms

--- a/test/test_gecondest.cc
+++ b/test/test_gecondest.cc
@@ -222,7 +222,7 @@ void test_gecondest_work(Params& params, bool run)
             // ScaLAPACK descriptor for the reference matrix
             int64_t info;
             blas_int Aref_desc[9];
-            scalapack_descinit(Aref_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( Aref_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             // ScaLAPACK data for pivots.
@@ -231,8 +231,8 @@ void test_gecondest_work(Params& params, bool run)
             //==================================================
             // Run ScaLAPACK reference routine.
             //==================================================
-            scalapack_pgetrf(
-                n, n, &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0], &info);
+            scalapack::getrf(
+                n, n, &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0], &info );
             slate_assert( info == 0 );
 
             // query for workspace size for pgecon
@@ -240,7 +240,7 @@ void test_gecondest_work(Params& params, bool run)
             int64_t liwork = -1;
             scalar_t dummy;
             blas_int idummy;
-            scalapack_pgecon( to_c_string( norm ), n,
+            scalapack::gecon( norm, n,
                               &Aref_data[0], 1, 1, Aref_desc,
                               &Anorm, &scl_rcond,
                               &dummy, lwork, &idummy, liwork, &info );
@@ -255,7 +255,7 @@ void test_gecondest_work(Params& params, bool run)
             // todo: ScaLAPCK pzgecon has a seg fault
 
             double time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_pgecon( to_c_string( norm ), n,
+            scalapack::gecon( norm, n,
                               &Aref_data[0], 1, 1, Aref_desc,
                               &Anorm, &scl_rcond,
                               &work[0], lwork, &iwork[0], liwork, &info );

--- a/test/test_gelqf.cc
+++ b/test/test_gelqf.cc
@@ -206,13 +206,13 @@ void test_gelqf_work(Params& params, bool run)
             slate_assert( mycol == mycol_ );
 
             int64_t info;
-            scalapack_descinit(A_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( A_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
-            scalapack_descinit(LQ_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( LQ_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
-            scalapack_descinit(Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             // tau vector for ScaLAPACK
@@ -226,8 +226,8 @@ void test_gelqf_work(Params& params, bool run)
 
             // query for workspace size
             scalar_t dummy;
-            scalapack_pgelqf(m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                             &dummy, -1, &info_ref);
+            scalapack::gelqf( m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                              &dummy, -1, &info_ref );
 
             lwork = int64_t( real( dummy ) );
             work.resize(lwork);
@@ -236,8 +236,8 @@ void test_gelqf_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_pgelqf(m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                             work.data(), lwork, &info_ref);
+            scalapack::gelqf( m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                              work.data(), lwork, &info_ref );
             slate_assert(info_ref == 0);
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 

--- a/test/test_gels.cc
+++ b/test/test_gels.cc
@@ -437,20 +437,20 @@ void test_gels_work(Params& params, bool run)
 
             int64_t info;
             blas_int Aref_desc[9], BXref_desc[9];
-            scalapack_descinit(Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
-            scalapack_descinit(BXref_desc, maxmn, nrhs, nb, nb, 0, 0, ictxt, mlocBX, &info);
+            scalapack::descinit( BXref_desc, maxmn, nrhs, nb, nb, 0, 0, ictxt, mlocBX, &info );
             slate_assert(info == 0);
 
             int64_t info_ref = 0;
 
             // query for workspace size
             scalar_t dummy;
-            scalapack_pgels(to_c_string( trans ), m, n, nrhs,
-                            &Aref_data[0],  1, 1, Aref_desc,
-                            &BXref_data[0], 1, 1, BXref_desc,
-                            &dummy, -1, &info_ref);
+            scalapack::gels( trans, m, n, nrhs,
+                             &Aref_data[0],  1, 1, Aref_desc,
+                             &BXref_data[0], 1, 1, BXref_desc,
+                             &dummy, -1, &info_ref );
             slate_assert(info_ref == 0);
             lwork = int64_t( real( dummy ) );
             work.resize(lwork);
@@ -459,10 +459,10 @@ void test_gels_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_pgels(to_c_string( trans ), m, n, nrhs,
-                            &Aref_data[0],  1, 1, Aref_desc,
-                            &BXref_data[0], 1, 1, BXref_desc,
-                            work.data(), lwork, &info_ref);
+            scalapack::gels( trans, m, n, nrhs,
+                             &Aref_data[0],  1, 1, Aref_desc,
+                             &BXref_data[0], 1, 1, BXref_desc,
+                             work.data(), lwork, &info_ref );
             slate_assert(info_ref == 0);
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -244,10 +244,10 @@ void test_gemm_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
 
-            scalapack_pgemm(to_c_string( transA ), to_c_string( transB ), m, n, k, alpha,
-                            &A_data[0], 1, 1, A_desc,
-                            &B_data[0], 1, 1, B_desc, beta,
-                            &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::gemm( transA, transB, m, n, k,
+                             alpha, &A_data[0], 1, 1, A_desc,
+                                    &B_data[0], 1, 1, B_desc,
+                             beta,  &Cref_data[0], 1, 1, Cref_desc );
 
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 

--- a/test/test_geqrf.cc
+++ b/test/test_geqrf.cc
@@ -236,7 +236,7 @@ void test_geqrf_work(Params& params, bool run)
             slate_assert( mycol == mycol_ );
 
             int64_t info;
-            scalapack_descinit(Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             // tau vector for ScaLAPACK
@@ -255,8 +255,8 @@ void test_geqrf_work(Params& params, bool run)
 
             // query for workspace size
             scalar_t dummy;
-            scalapack_pgeqrf(m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                             &dummy, -1, &info);
+            scalapack::geqrf( m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                              &dummy, -1, &info );
             slate_assert( info == 0 );
             lwork = int64_t( real( dummy ) );
             work.resize(lwork);
@@ -265,8 +265,8 @@ void test_geqrf_work(Params& params, bool run)
             // Run ScaLAPACK reference test.
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_pgeqrf(m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                             work.data(), lwork, &info);
+            scalapack::geqrf( m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                              work.data(), lwork, &info );
             slate_assert( info == 0 );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
@@ -294,18 +294,18 @@ void test_geqrf_work(Params& params, bool run)
                 slate::copy(scala_R, scala_R1);
 
                 // Apply Q to R-factor
-                scalapack_punmqr(to_c_string( blas::Side::Left ), to_c_string( slate::Op::NoTrans ), m, n, n,
-                                 &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                                 &scala_QR_data[0], 1, 1, Aref_desc,
-                                 &dummy, -1, &info);
+                scalapack::unmqr( slate::Side::Left, slate::Op::NoTrans, m, n, n,
+                                  &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                                  &scala_QR_data[0], 1, 1, Aref_desc,
+                                  &dummy, -1, &info );
                 slate_assert( info == 0 );
                 lwork = int64_t( real( dummy ) );
                 work.resize(lwork);
 
-                scalapack_punmqr(to_c_string( blas::Side::Left ), to_c_string( slate::Op::NoTrans ), m, n, n,
-                                 &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                                 &scala_QR_data[0], 1, 1, Aref_desc,
-                                 work.data(), lwork, &info);
+                scalapack::unmqr( slate::Side::Left, slate::Op::NoTrans, m, n, n,
+                                  &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                                  &scala_QR_data[0], 1, 1, Aref_desc,
+                                  work.data(), lwork, &info );
                 slate_assert( info == 0 );
 
                 print_matrix("QR", scala_QR, params);

--- a/test/test_gesv.cc
+++ b/test/test_gesv.cc
@@ -394,8 +394,8 @@ void test_gesv_work(Params& params, bool run)
 
             if (params.routine == "getrs") {
                 // Factor matrix A.
-                scalapack_pgetrf(m, n,
-                                 &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0], &info);
+                scalapack::getrf( m, n, &Aref_data[0], 1, 1, Aref_desc,
+                                  &ipiv_ref[0], &info );
                 slate_assert( info == 0 );
             }
 
@@ -404,18 +404,18 @@ void test_gesv_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
             if (params.routine == "getrf") {
-                scalapack_pgetrf(m, n,
-                                 &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0], &info);
+                scalapack::getrf( m, n, &Aref_data[0], 1, 1, Aref_desc,
+                                  &ipiv_ref[0], &info );
             }
             else if (params.routine == "getrs") {
-                scalapack_pgetrs(to_c_string( trans ), n, nrhs,
-                                 &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0],
-                                 &Bref_data[0], 1, 1, Bref_desc, &info);
+                scalapack::getrs( trans, n, nrhs,
+                                  &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0],
+                                  &Bref_data[0], 1, 1, Bref_desc, &info );
             }
             else {
-                scalapack_pgesv(n, nrhs,
-                                &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0],
-                                &Bref_data[0], 1, 1, Bref_desc, &info);
+                scalapack::gesv( n, nrhs,
+                                 &Aref_data[0], 1, 1, Aref_desc, &ipiv_ref[0],
+                                 &Bref_data[0], 1, 1, Bref_desc, &info );
             }
             slate_assert( info == 0 );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;

--- a/test/test_hbnorm.cc
+++ b/test/test_hbnorm.cc
@@ -122,22 +122,22 @@ void test_hbnorm_work(Params& params, bool run)
             slate_assert( mycol == mycol_ );
 
             int64_t info;
-            scalapack_descinit(A_desc, n, n, nb, nb, 0, 0, ictxt, lldA, &info);
+            scalapack::descinit( A_desc, n, n, nb, nb, 0, 0, ictxt, lldA, &info );
             slate_assert(info == 0);
 
             // allocate work space
             int64_t ldw = nb*ceildiv( ceildiv( nlocA, nb ),
                                       std::lcm( p, q ) / p );
             int64_t lwork = 2*mlocA + nlocA + ldw;
-            std::vector<real_t> worklanhe( lwork );
+            std::vector<real_t> work( lwork );
 
             //==================================================
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            real_t A_norm_ref = scalapack_planhe(
-                                    to_c_string( norm ), to_c_string( A.uplo() ),
-                                    n, &A_data[0], 1, 1, A_desc, &worklanhe[0]);
+            real_t A_norm_ref = scalapack::lanhe(
+                                    norm, A.uplo(),
+                                    n, &A_data[0], 1, 1, A_desc, &work[0] );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             //A_norm_ref = lapack::lanhe(

--- a/test/test_heev.cc
+++ b/test/test_heev.cc
@@ -287,11 +287,11 @@ void test_heev_work(Params& params, bool run)
 
             int64_t info;
             blas_int A_desc[9];
-            scalapack_descinit(A_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( A_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             blas_int Z_desc[9];
-            scalapack_descinit(Z_desc, n, n, nb, nb, 0, 0, ictxt, mlocZ, &info);
+            scalapack::descinit( Z_desc, n, n, nb, nb, 0, 0, ictxt, mlocZ, &info );
             slate_assert(info == 0);
 
             // query for workspace size
@@ -301,19 +301,19 @@ void test_heev_work(Params& params, bool run)
             std::vector<real_t> rwork(1);
             std::vector<blas_int> iwork(1);
             if (method_eig == slate::MethodEig::DC && jobz == slate::Job::Vec) {
-                scalapack_pheevd(to_c_string( jobz ), to_c_string( uplo ), n,
-                                &Aref_data[0], 1, 1, A_desc,
-                                &Lambda_ref[0], // global output
-                                &Z_data[0], 1, 1, Z_desc,
-                                &work[0], -1, &rwork[0], -1,
-                                &iwork[0], -1, &info_tst);
+                scalapack::heevd( jobz, uplo, n,
+                                  &Aref_data[0], 1, 1, A_desc,
+                                  &Lambda_ref[0], // global output
+                                  &Z_data[0], 1, 1, Z_desc,
+                                  &work[0], -1, &rwork[0], -1,
+                                  &iwork[0], -1, &info_tst );
             }
             else {
-                scalapack_pheev(to_c_string( jobz ), to_c_string( uplo ), n,
-                                &Aref_data[0], 1, 1, A_desc,
-                                &Lambda_ref[0], // global output
-                                &Z_data[0], 1, 1, Z_desc,
-                                &work[0], -1, &rwork[0], -1, &info_tst);
+                scalapack::heev( jobz, uplo, n,
+                                 &Aref_data[0], 1, 1, A_desc,
+                                 &Lambda_ref[0], // global output
+                                 &Z_data[0], 1, 1, Z_desc,
+                                 &work[0], -1, &rwork[0], -1, &info_tst );
             }
 
             slate_assert(info_tst == 0);
@@ -335,19 +335,19 @@ void test_heev_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
             if (method_eig == slate::MethodEig::DC && jobz == slate::Job::Vec) {
-                scalapack_pheevd(to_c_string( jobz ), to_c_string( uplo ), n,
-                                &Aref_data[0], 1, 1, A_desc,
-                                &Lambda_ref[0],
-                                &Z_data[0], 1, 1, Z_desc,
-                                &work[0], lwork, &rwork[0], lrwork,
-                                &iwork[0], liwork, &info_tst);
+                scalapack::heevd( jobz, uplo, n,
+                                  &Aref_data[0], 1, 1, A_desc,
+                                  &Lambda_ref[0],
+                                  &Z_data[0], 1, 1, Z_desc,
+                                  &work[0], lwork, &rwork[0], lrwork,
+                                  &iwork[0], liwork, &info_tst );
             }
             else {
-                scalapack_pheev(to_c_string( jobz ), to_c_string( uplo ), n,
-                                &Aref_data[0], 1, 1, A_desc,
-                                &Lambda_ref[0],
-                                &Z_data[0], 1, 1, Z_desc,
-                                &work[0], lwork, &rwork[0], lrwork, &info_tst);
+                scalapack::heev( jobz, uplo, n,
+                                 &Aref_data[0], 1, 1, A_desc,
+                                 &Lambda_ref[0],
+                                 &Z_data[0], 1, 1, Z_desc,
+                                 &work[0], lwork, &rwork[0], lrwork, &info_tst );
             }
             slate_assert(info_tst == 0);
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;

--- a/test/test_hegst.cc
+++ b/test/test_hegst.cc
@@ -147,11 +147,11 @@ void test_hegst_work(Params& params, bool run)
 
             int64_t info;
             blas_int A_desc[9], B_desc[9];
-            scalapack_descinit(
-                A_desc, n, n, nb, nb, 0, 0, ictxt, mlocal, &info);
+            scalapack::descinit(
+                A_desc, n, n, nb, nb, 0, 0, ictxt, mlocal, &info );
             slate_assert(info == 0);
-            scalapack_descinit(
-                B_desc, n, n, nb, nb, 0, 0, ictxt, mlocal, &info);
+            scalapack::descinit(
+                B_desc, n, n, nb, nb, 0, 0, ictxt, mlocal, &info );
             slate_assert(info == 0);
             double scale;
 
@@ -164,10 +164,10 @@ void test_hegst_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
 
-            scalapack_phegst(itype, to_c_string( uplo ), n,
-                             Aref_data.data(), 1, 1, A_desc,
-                             B_data.data(),    1, 1, B_desc,
-                             &scale, &info);
+            scalapack::hegst( itype, uplo, n,
+                              Aref_data.data(), 1, 1, A_desc,
+                              B_data.data(),    1, 1, B_desc,
+                              &scale, &info );
             slate_assert(info == 0);
 
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;

--- a/test/test_hegv.cc
+++ b/test/test_hegv.cc
@@ -25,6 +25,7 @@ void test_hegv_work(Params& params, bool run)
 {
     using real_t = blas::real_type<scalar_t>;
     using blas::real;
+    using lapack::Range;
 
     // Constants
     const scalar_t zero = 0.0, one = 1.0;
@@ -369,18 +370,18 @@ void test_hegv_work(Params& params, bool run)
 
             int64_t info;
             blas_int A_desc[9];
-            scalapack_descinit(A_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( A_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             blas_int B_desc[9];
-            scalapack_descinit(B_desc, n, n, nb, nb, 0, 0, ictxt, mlocB, &info);
+            scalapack::descinit( B_desc, n, n, nb, nb, 0, 0, ictxt, mlocB, &info );
             slate_assert(info == 0);
 
             blas_int Z_desc[9];
-            scalapack_descinit(Z_desc, n, n, nb, nb, 0, 0, ictxt, mlocZ, &info);
+            scalapack::descinit( Z_desc, n, n, nb, nb, 0, 0, ictxt, mlocZ, &info );
             slate_assert(info == 0);
 
-            const char* range = "A";
+            Range range = Range::All;
             int64_t vl=0, vu=0, il=0, iu=0;
             real_t abstol=0;
             int64_t nfound=0, nzfound=0;
@@ -399,16 +400,16 @@ void test_hegv_work(Params& params, bool run)
             std::vector<blas_int> ifail(n);
             std::vector<blas_int> iclustr(2*p*q);
             std::vector<real_t> gap(p*q);
-            scalapack_phegvx(itype, to_c_string( jobz ), range, to_c_string( uplo ), n,
-                             &Aref_data[0], 1, 1, A_desc,
-                             &Bref_data[0], 1, 1, B_desc,
-                             vl, vu, il, iu, abstol, &nfound, &nzfound,
-                             &Lambda_ref[0], orfac,
-                             &Zref_data[0], 1, 1, Z_desc,
-                             &work[0], lwork,
-                             &rwork[0], lrwork,
-                             &iwork[0], liwork,
-                             &ifail[0], &iclustr[0], &gap[0], &info_tst);
+            scalapack::hegvx( itype, jobz, range, uplo, n,
+                              &Aref_data[0], 1, 1, A_desc,
+                              &Bref_data[0], 1, 1, B_desc,
+                              vl, vu, il, iu, abstol, &nfound, &nzfound,
+                              &Lambda_ref[0], orfac,
+                              &Zref_data[0], 1, 1, Z_desc,
+                              &work[0], lwork,
+                              &rwork[0], lrwork,
+                              &iwork[0], liwork,
+                              &ifail[0], &iclustr[0], &gap[0], &info_tst );
 
             // resize workspace based on query for workspace sizes
             slate_assert(info_tst == 0);
@@ -427,16 +428,16 @@ void test_hegv_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(mpi_comm);
 
-            scalapack_phegvx(itype, to_c_string( jobz ), range, to_c_string( uplo ), n,
-                             &Aref_data[0], 1, 1, A_desc,
-                             &Bref_data[0], 1, 1, B_desc,
-                             vl, vu, il, iu, abstol, &nfound, &nzfound,
-                             &Lambda_ref[0], orfac,
-                             &Zref_data[0], 1, 1, Z_desc,
-                             &work[0], lwork,
-                             &rwork[0], lrwork,
-                             &iwork[0], liwork,
-                             &ifail[0], &iclustr[0], &gap[0], &info_tst);
+            scalapack::hegvx( itype, jobz, range, uplo, n,
+                              &Aref_data[0], 1, 1, A_desc,
+                              &Bref_data[0], 1, 1, B_desc,
+                              vl, vu, il, iu, abstol, &nfound, &nzfound,
+                              &Lambda_ref[0], orfac,
+                              &Zref_data[0], 1, 1, Z_desc,
+                              &work[0], lwork,
+                              &rwork[0], lrwork,
+                              &iwork[0], liwork,
+                              &ifail[0], &iclustr[0], &gap[0], &info_tst );
 
             slate_assert(info_tst == 0);
             time = barrier_get_wtime(mpi_comm) - time;

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -248,10 +248,10 @@ void test_hemm_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_phemm(to_c_string( side ), to_c_string( uplo ), m, n, alpha,
-                            &A_data[0], 1, 1, A_desc,
-                            &B_data[0], 1, 1, B_desc, beta,
-                            &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::hemm( side, uplo, m, n,
+                             alpha, &A_data[0], 1, 1, A_desc,
+                                    &B_data[0], 1, 1, B_desc,
+                             beta,  &Cref_data[0], 1, 1, Cref_desc );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             // get differences C = C - Cref

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -237,10 +237,10 @@ void test_her2k_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_pher2k(to_c_string( uplo ), to_c_string( trans ), n, k, alpha,
-                             &A_data[0], 1, 1, A_desc,
-                             &B_data[0], 1, 1, B_desc, beta,
-                             &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::her2k( uplo, trans, n, k,
+                              alpha, &A_data[0], 1, 1, A_desc,
+                                     &B_data[0], 1, 1, B_desc,
+                              beta,  &Cref_data[0], 1, 1, Cref_desc );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             print_matrix( "Cref_out", Cref, params );

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -211,9 +211,9 @@ void test_herk_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_pherk(to_c_string( uplo ), to_c_string( transA ), n, k, alpha,
-                            &A_data[0], 1, 1, A_desc, beta,
-                            &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::herk( uplo, transA, n, k,
+                             alpha, &A_data[0], 1, 1, A_desc,
+                             beta,  &Cref_data[0], 1, 1, Cref_desc );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             // get differences C = C - Cref

--- a/test/test_norm.cc
+++ b/test/test_norm.cc
@@ -68,25 +68,25 @@ auto scalapack_norm_dispatch(
 
     real_t A_norm = 0;
     if (std::is_same< matrix_type, Matrix<scalar_t> >::value) {
-        A_norm = scalapack_plange(
-            to_c_string( norm ),
-            m, n, A_data, 1, 1, A_desc, work );
+        A_norm = scalapack::lange(
+            norm, m, n,
+            A_data, 1, 1, A_desc, work );
     }
     else if (std::is_same< matrix_type, TriangularMatrix<scalar_t> >::value
              || std::is_same< matrix_type, TrapezoidMatrix<scalar_t> >::value ) {
-        A_norm = scalapack_plantr(
-            to_c_string( norm ), to_c_string( uplo ), to_c_string( diag ),
-            m, n, A_data, 1, 1, A_desc, work );
+        A_norm = scalapack::lantr(
+            norm, uplo, diag, m, n,
+            A_data, 1, 1, A_desc, work );
     }
     else if (std::is_same< matrix_type, SymmetricMatrix<scalar_t> >::value) {
-        A_norm = scalapack_plansy(
-            to_c_string( norm ), to_c_string( uplo ),
-            n, A_data, 1, 1, A_desc, work );
+        A_norm = scalapack::lansy(
+            norm, uplo, n,
+            A_data, 1, 1, A_desc, work );
     }
     else if (std::is_same< matrix_type, HermitianMatrix<scalar_t> >::value) {
-        A_norm = scalapack_planhe(
-            to_c_string( norm ), to_c_string( uplo ),
-            n, A_data, 1, 1, A_desc, work );
+        A_norm = scalapack::lanhe(
+            norm, uplo, n,
+            A_data, 1, 1, A_desc, work );
     }
     else {
         slate_error( "Unknown matrix type" );
@@ -596,9 +596,9 @@ void test_norm_work( Params& params, bool run )
                     slate_error( "Unsupported matrix type for col scope" );
                 }
                 for (int64_t j = 0; j < n; ++j) {
-                    A_norm_ref = scalapack_plange(
-                        to_c_string( norm ),
-                        m, 1, &Aref_data[0], 1, j+1, Aref_desc, &work[0] );
+                    A_norm_ref = scalapack::lange(
+                        norm, m, 1,
+                        &Aref_data[0], 1, j+1, Aref_desc, &work[0] );
                     error += std::abs( values[ j ] - A_norm_ref ) / A_norm_ref;
                 }
             }

--- a/test/test_pocondest.cc
+++ b/test/test_pocondest.cc
@@ -216,14 +216,13 @@ void test_pocondest_work(Params& params, bool run)
             // ScaLAPACK descriptor for the reference matrix
             int64_t info;
             blas_int Aref_desc[9];
-            scalapack_descinit(Aref_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( Aref_desc, n, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             //==================================================
             // Run ScaLAPACK reference routine.
             //==================================================
-            scalapack_ppotrf(
-                to_c_string( uplo ), n, &Aref_data[0], 1, 1, Aref_desc, &info);
+            scalapack::potrf( uplo, n, &Aref_data[0], 1, 1, Aref_desc, &info );
             slate_assert( info == 0 );
 
             // query for workspace size for ppocon
@@ -231,7 +230,7 @@ void test_pocondest_work(Params& params, bool run)
             int64_t liwork = -1;
             scalar_t dummy;
             blas_int idummy;
-            scalapack_ppocon( to_c_string( uplo ), n,
+            scalapack::pocon( uplo, n,
                               &Aref_data[0], 1, 1, Aref_desc,
                               &Anorm, &scl_rcond,
                               &dummy, lwork, &idummy, liwork, &info );
@@ -246,7 +245,7 @@ void test_pocondest_work(Params& params, bool run)
             // todo: ScaLAPCK pzpocon has a seg fault
 
             double time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_ppocon( to_c_string( uplo ), n,
+            scalapack::pocon( uplo, n,
                               &Aref_data[0], 1, 1, Aref_desc,
                               &Anorm, &scl_rcond,
                               &work[0], lwork, &iwork[0], liwork, &info );

--- a/test/test_posv.cc
+++ b/test/test_posv.cc
@@ -357,13 +357,13 @@ void test_posv_work(Params& params, bool run)
             if (check) {
                 // restore Bref_data
                 Bref_data = B_orig;
-                //scalapack_descinit(Bref_desc, n, nrhs, nb, nb, 0, 0, ictxt, mlocB, &info);
+                //scalapack::descinit( Bref_desc, n, nrhs, nb, nb, 0, 0, ictxt, mlocB, &info );
                 //slate_assert(info == 0);
             }
 
             if (params.routine == "potrs") {
                 // Factor matrix A.
-                scalapack_ppotrf( to_c_string( uplo ), n,
+                scalapack::potrf( uplo, n,
                                   &Aref_data[0], 1, 1, Aref_desc, &info );
                 slate_assert(info == 0);
             }
@@ -373,16 +373,16 @@ void test_posv_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
             if (params.routine == "potrf") {
-                scalapack_ppotrf( to_c_string( uplo ), n,
+                scalapack::potrf( uplo, n,
                                   &Aref_data[0], 1, 1, Aref_desc, &info );
             }
             else if (params.routine == "potrs") {
-                scalapack_ppotrs( to_c_string( uplo ), n, nrhs,
+                scalapack::potrs( uplo, n, nrhs,
                                   &Aref_data[0], 1, 1, Aref_desc,
                                   &Bref_data[0], 1, 1, Bref_desc, &info );
             }
             else {
-                scalapack_pposv( to_c_string( uplo ), n, nrhs,
+                scalapack::posv( uplo, n, nrhs,
                                  &Aref_data[0], 1, 1, Aref_desc,
                                  &Bref_data[0], 1, 1, Bref_desc, &info );
             }

--- a/test/test_scale.cc
+++ b/test/test_scale.cc
@@ -139,7 +139,7 @@ void test_scale_work(Params& params, bool run)
             double time = barrier_get_wtime(MPI_COMM_WORLD);
 
             int64_t info;
-            scalapack_plascl( to_c_string( uplo ), alpha, beta, m, n,
+            scalapack::lascl( uplo, alpha, beta, m, n,
                               &Aref_data[0], 1, 1, A_desc, &info );
             slate_assert(info == 0);
 

--- a/test/test_scale_row_col.cc
+++ b/test/test_scale_row_col.cc
@@ -201,7 +201,7 @@ void test_scale_row_col_work( Params& params, bool run )
                 colcnd = 0.0;
 
             char equed_out;
-            scalapack_plaqge( m, n, &Aref_data[0], 1, 1, A_desc,
+            scalapack::laqge( m, n, &Aref_data[0], 1, 1, A_desc,
                               Rlocal.data(), Clocal.data(),
                               rowcnd, colcnd, A_max, &equed_out );
 

--- a/test/test_set.cc
+++ b/test/test_set.cc
@@ -138,7 +138,7 @@ void test_set_work(Params& params, bool run)
             //==================================================
             double time = barrier_get_wtime(MPI_COMM_WORLD);
 
-            scalapack_plaset( to_c_string( uplo ), m, n, alpha, beta,
+            scalapack::laset( uplo, m, n, alpha, beta,
                               &Aref_data[0], 1, 1, A_desc );
 
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;

--- a/test/test_stedc.cc
+++ b/test/test_stedc.cc
@@ -24,6 +24,7 @@ void test_stedc_work( Params& params, bool run )
     using blas::real;
     using blas::imag;
     using blas::max;
+    using slate::Job;
 
     // Constants
     const scalar_t zero = 0.0;
@@ -238,7 +239,7 @@ void test_stedc_work( Params& params, bool run )
             slate_assert( mycol == mycol_ );
 
             int64_t info;
-            scalapack_descinit( Zref_desc, n, n, nb, nb, 0, 0, ictxt, lldZ, &info );
+            scalapack::descinit( Zref_desc, n, n, nb, nb, 0, 0, ictxt, lldZ, &info );
             slate_assert( info == 0 );
 
             // Query for workspace size.
@@ -246,7 +247,7 @@ void test_stedc_work( Params& params, bool run )
             scalar_t work_query;
             blas_int iwork_query;
             //printf( "call scalapack_pstedc query\n" );
-            scalapack_pstedc( "i", n, &Dref[0], &Eref[0],
+            scalapack::stedc( Job::Vec, n, &Dref[0], &Eref[0],
                               &Zref_data[0], 1, 1, Zref_desc,
                               &work_query, -1, &iwork_query, -1, &info );
             //printf( "done scalapack_pstedc query, info=%d\n", info );
@@ -270,7 +271,7 @@ void test_stedc_work( Params& params, bool run )
             //print_vector( "Eref_in", Eref, params );
 
             //printf( "call scalapack_pstedc\n" );
-            scalapack_pstedc( "i", n, &Dref[0], &Eref[0],
+            scalapack::stedc( Job::Vec, n, &Dref[0], &Eref[0],
                               &Zref_data[0], 1, 1, Zref_desc,
                               &work[0], lwork, &iwork[0], liwork, &info );
             //printf( "done scalapack_pstedc, info=%d\n", info );

--- a/test/test_stedc_deflate.cc
+++ b/test/test_stedc_deflate.cc
@@ -333,7 +333,7 @@ void test_stedc_deflate_work( Params& params, bool run )
             //==================================================
             time = barrier_get_wtime( MPI_COMM_WORLD );
 
-            scalapack_plaed2(
+            scalapack::laed2(
                 ictxt, &nsecular_ref, n, n1, nb,
                 &Dref[0], 0, 0,
                 &Qref_data[0], lldQ, &rho_ref,

--- a/test/test_stedc_secular.cc
+++ b/test/test_stedc_secular.cc
@@ -242,7 +242,7 @@ void test_stedc_secular_work( Params& params, bool run )
             //==================================================
             time = barrier_get_wtime( MPI_COMM_WORLD );
 
-            scalapack_plaed3(
+            scalapack::laed3(
                 ictxt, nsecular, n, nb,
                 &Lambda_ref[0], 0, 0, rho, &D[0], &z[0], &ztilde_ref[0],
                 &Uref_data[0], lldU, &buf[0],

--- a/test/test_stedc_sort.cc
+++ b/test/test_stedc_sort.cc
@@ -22,6 +22,7 @@ template <typename scalar_t>
 void test_stedc_sort_work( Params& params, bool run )
 {
     using real_t = blas::real_type<scalar_t>;
+    using scalapack::SortOrder;
 
     // Constants
     const scalar_t one  = 1.0;
@@ -159,7 +160,7 @@ void test_stedc_sort_work( Params& params, bool run )
             Cblacs_gridinfo( ictxt, &p_, &q_, &myrow_, &mycol_ );
 
             int64_t info;
-            scalapack_descinit( Zref_desc, n, n, nb, nb, 0, 0, ictxt, lldZ, &info );
+            scalapack::descinit( Zref_desc, n, n, nb, nb, 0, 0, ictxt, lldZ, &info );
             slate_assert( info == 0 );
 
             // Undocumented: liwork needs max( n, 2*nb + 2*q )
@@ -173,7 +174,7 @@ void test_stedc_sort_work( Params& params, bool run )
             //==================================================
             time = barrier_get_wtime( MPI_COMM_WORLD );
 
-            scalapack_plasrt( "i", n, &Dref[0],
+            scalapack::lasrt( SortOrder::Increasing, n, &Dref[0],
                               &Zref_data[0], 1, 1, Zref_desc,
                               &work[0], lwork, &iwork[0], liwork, &info );
             slate_assert( info == 0 );

--- a/test/test_stedc_z_vector.cc
+++ b/test/test_stedc_z_vector.cc
@@ -141,7 +141,7 @@ void test_stedc_z_vector_work( Params& params, bool run )
             slate_assert( mycol == mycol_ );
 
             int64_t info;
-            scalapack_descinit( Q_desc, n, n, nb, nb, 0, 0, ictxt, lldQ, &info );
+            scalapack::descinit( Q_desc, n, n, nb, nb, 0, 0, ictxt, lldQ, &info );
             slate_assert( info == 0 );
 
             // plaedz work size is undocumented; guess n.
@@ -153,7 +153,7 @@ void test_stedc_z_vector_work( Params& params, bool run )
             //==================================================
             time = barrier_get_wtime( MPI_COMM_WORLD );
 
-            scalapack_plaedz( n, n1, 1,
+            scalapack::laedz( n, n1, 1,
                               &Qref_data[0], 1, 1, lldQ, Q_desc,
                               &zref[0], &work[0] );
 

--- a/test/test_symm.cc
+++ b/test/test_symm.cc
@@ -240,10 +240,10 @@ void test_symm_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_psymm(to_c_string( side ), to_c_string( uplo ), m, n, alpha,
-                            &A_data[0], 1, 1, A_desc,
-                            &B_data[0], 1, 1, B_desc, beta,
-                            &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::symm( side, uplo, m, n,
+                             alpha, &A_data[0], 1, 1, A_desc,
+                                    &B_data[0], 1, 1, B_desc,
+                             beta,  &Cref_data[0], 1, 1, Cref_desc );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             // get differences C = C - Cref

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -235,10 +235,10 @@ void test_syr2k_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime( MPI_COMM_WORLD );
-            scalapack_psyr2k(to_c_string( uplo ), to_c_string( trans ), n, k, alpha,
-                             &A_data[0], 1, 1, A_desc,
-                             &B_data[0], 1, 1, B_desc, beta,
-                             &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::syr2k( uplo, trans, n, k,
+                              alpha, &A_data[0], 1, 1, A_desc,
+                                     &B_data[0], 1, 1, B_desc,
+                              beta,  &Cref_data[0], 1, 1, Cref_desc );
             time = barrier_get_wtime( MPI_COMM_WORLD ) - time;
 
             print_matrix( "Cref_out", Cref, params );

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -209,9 +209,9 @@ void test_syrk_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime( MPI_COMM_WORLD );
-            scalapack_psyrk(to_c_string( uplo ), to_c_string( transA ), n, k, alpha,
-                            &A_data[0], 1, 1, A_desc, beta,
-                            &Cref_data[0], 1, 1, Cref_desc);
+            scalapack::syrk( uplo, transA, n, k,
+                             alpha, &A_data[0], 1, 1, A_desc,
+                             beta,  &Cref_data[0], 1, 1, Cref_desc );
             time = barrier_get_wtime( MPI_COMM_WORLD ) - time;
 
             // get differences C = C - Cref

--- a/test/test_trcondest.cc
+++ b/test/test_trcondest.cc
@@ -192,7 +192,7 @@ void test_trcondest_work(Params& params, bool run)
             // ScaLAPACK descriptor for the reference matrix
             int64_t info;
             blas_int Aref_desc[9];
-            scalapack_descinit(Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info);
+            scalapack::descinit( Aref_desc, m, n, nb, nb, 0, 0, ictxt, mlocA, &info );
             slate_assert(info == 0);
 
             // tau vector for ScaLAPACK
@@ -212,13 +212,13 @@ void test_trcondest_work(Params& params, bool run)
 
             // query for workspace size for pgeqrf
             scalar_t dummy;
-            scalapack_pgeqrf(m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                             &dummy, -1, &info_ref);
+            scalapack::geqrf( m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                              &dummy, -1, &info_ref );
             lwork = int64_t( real( dummy ) );
             work.resize(lwork);
 
-            scalapack_pgeqrf(m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
-                             work.data(), lwork, &info_ref);
+            scalapack::geqrf( m, n, &Aref_data[0], 1, 1, Aref_desc, tau.data(),
+                              work.data(), lwork, &info_ref );
             slate_assert(info_ref == 0);
 
             // query for workspace size for ptrcon
@@ -229,10 +229,10 @@ void test_trcondest_work(Params& params, bool run)
             scalar_t dummy_trcon;
             slate::Uplo uplo = slate::Uplo::Upper;
             slate::Diag diag = slate::Diag::NonUnit;
-            scalapack_ptrcon( to_c_string( norm ), to_c_string( uplo ), to_c_string( diag ), n,
+            scalapack::trcon( norm, uplo, diag, n,
                               &Aref_data[0], ione, ione, Aref_desc,
                               &scl_rcond, &dummy_trcon, lwork_trcon, &idummy, liwork,
-                              info_ref_trcon);
+                              info_ref_trcon );
             lwork_trcon = (int64_t)( real( dummy_trcon ) );
             liwork = (int64_t)( real( idummy ) );
 
@@ -241,10 +241,10 @@ void test_trcondest_work(Params& params, bool run)
             std::vector<blas_int> iwork( liwork );
 
             double time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_ptrcon( to_c_string( norm ), to_c_string( uplo ), to_c_string( diag ), n,
+            scalapack::trcon( norm, uplo, diag, n,
                               &Aref_data[0], 1, 1, Aref_desc,
                               &scl_rcond, &work_trcon[0], lwork, &iwork[0], liwork,
-                              info_ref_trcon);
+                              info_ref_trcon );
             slate_assert(info_ref_trcon == 0);
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -231,10 +231,10 @@ void test_trmm_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_ptrmm(to_c_string( side ), to_c_string( uplo ), to_c_string( transA ), to_c_string( diag ),
-                            m, n, alpha,
-                            &A_data[0], 1, 1, A_desc,
-                            &Bref_data[0], 1, 1, Bref_desc);
+            scalapack::trmm( side, uplo, transA, diag,
+                             m, n, alpha,
+                             &A_data[0], 1, 1, A_desc,
+                             &Bref_data[0], 1, 1, Bref_desc );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             // get differences B = B - Bref

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -209,10 +209,10 @@ void test_trsm_work(Params& params, bool run)
             // Run ScaLAPACK reference routine.
             //==================================================
             time = barrier_get_wtime(MPI_COMM_WORLD);
-            scalapack_ptrsm(to_c_string( side ), to_c_string( uplo ), to_c_string( transA ), to_c_string( diag ),
-                            m, n, alpha,
-                            &A_data[0], 1, 1, A_desc,
-                            &Bref_data[0], 1, 1, Bref_desc);
+            scalapack::trsm( side, uplo, transA, diag,
+                             m, n, alpha,
+                             &A_data[0], 1, 1, A_desc,
+                             &Bref_data[0], 1, 1, Bref_desc );
             time = barrier_get_wtime(MPI_COMM_WORLD) - time;
 
             print_matrix( "Bref", Bref, params );


### PR DESCRIPTION
Update ScaLAPACK wrappers to take enums and add a `scalapack` namespace. This brings it much closer to the LAPACK++ interface.