### PR TITLE
Template arg list

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1352,7 +1352,7 @@ ${pkg}:
 
 lib: ${slate} ${matgen}
 
-clean: src/clean test/clean unit_test/clean scalapack_api/clean lapack_api/clean include/clean
+clean: src/clean matgen/clean test/clean unit_test/clean scalapack_api/clean lapack_api/clean include/clean
 	rm -f lib/lib* ${dep}
 	rm -f trace_*.svg
 

--- a/src/gbtrf.cc
+++ b/src/gbtrf.cc
@@ -115,7 +115,7 @@ int64_t gbtrf(
                     // send A(i, k) across row A(i, k+1:nt-1)
                     bcast_list_A.push_back({i, k, {A.sub(i, i, k+1, j_end-1)}});
                 }
-                A.template listBcast(bcast_list_A, layout, tag_k);
+                A.template listBcast<>( bcast_list_A, layout, tag_k );
 
                 // Root broadcasts the pivot to all ranks.
                 // todo: Panel ranks send the pivots to the right.
@@ -190,7 +190,7 @@ int64_t gbtrf(
                         // send A(k, j) across column A(k+1:mt-1, j)
                         bcast_list_A.push_back({k, j, {A.sub(k+1, i_end-1, j, j)}});
                     }
-                    A.template listBcast(bcast_list_A, layout, tag_kl1);
+                    A.template listBcast<>( bcast_list_A, layout, tag_kl1 );
 
                     // A(k+1:mt-1, kl+1:nt-1) -= A(k+1:mt-1, k) * A(k, kl+1:nt-1)
                     internal::gemm<Target::HostTask>(

--- a/src/ge2tb.cc
+++ b/src/ge2tb.cc
@@ -231,7 +231,7 @@ void ge2tb(
                         bcast_list_T.push_back(
                             {row, k, {TUlocal.sub(row, row, k+1, A_nt-1)}});
                     }
-                    TUlocal.template listBcast(bcast_list_T, layout);
+                    TUlocal.template listBcast<>( bcast_list_T, layout );
                 }
 
                 // bcast TUreduce across row for trailing matrix update
@@ -245,7 +245,7 @@ void ge2tb(
                                 {row, k, {TUreduce.sub(row, row, k+1, A_nt-1)}});
                         }
                     }
-                    TUreduce.template listBcast(bcast_list_T, layout);
+                    TUreduce.template listBcast<>( bcast_list_T, layout );
                 }
 
                 int64_t j = k+1;
@@ -380,7 +380,7 @@ void ge2tb(
                             bcast_list_T.push_back(
                                 {k, col, {TVlocal.sub(k+1, A_mt-1, col, col)}});
                         }
-                        TVlocal.template listBcast(bcast_list_T, layout);
+                        TVlocal.template listBcast<>( bcast_list_T, layout );
                     }
 
                     // bcast TVreduce down col for trailing matrix update
@@ -394,7 +394,7 @@ void ge2tb(
                                     {k, col, {TVreduce.sub(k+1, A_mt-1, col, col)}});
                             }
                         }
-                        TVreduce.template listBcast(bcast_list_T, layout);
+                        TVreduce.template listBcast<>( bcast_list_T, layout );
                     }
 
                     int64_t i = k+1;

--- a/src/gelqf.cc
+++ b/src/gelqf.cc
@@ -238,7 +238,7 @@ void gelqf(
                             if (col > k) // exclude the first col of this panel that has no Treduce tile
                                 bcast_list_T.push_back({k, col, {Treduce.sub(k+1, A_mt-1, col, col)}});
                         }
-                        Treduce.template listBcast(bcast_list_T, layout);
+                        Treduce.template listBcast<>( bcast_list_T, layout );
                     }
                 }
             }

--- a/src/gemmA.cc
+++ b/src/gemmA.cc
@@ -118,7 +118,7 @@ void gemmA(
                                           {A.sub( i, i, 0, A.nt()-1 )}
                                         } );
             int tag_0 = 0;
-            C.template listReduce( reduce_list_C, layout, tag_0 );
+            C.template listReduce<>( reduce_list_C, layout, tag_0 );
         }
 
         // Clean up workspace
@@ -180,7 +180,7 @@ void gemmA(
                                               {A.sub( i, i, 0, A.nt()-1 )}
                                             } );
                 int tag_k = k;
-                C.template listReduce( reduce_list_C, layout, tag_k );
+                C.template listReduce<>( reduce_list_C, layout, tag_k );
             }
 
             // Clean up workspace

--- a/src/geqrf.cc
+++ b/src/geqrf.cc
@@ -191,7 +191,7 @@ void geqrf(
                             if (row > k) // exclude the first row of this panel that has no Treduce tile
                                 bcast_list_T.push_back({row, k, {Treduce.sub(row, row, k+1, A_nt-1)}});
                         }
-                        Treduce.template listBcast(bcast_list_T, layout);
+                        Treduce.template listBcast<>( bcast_list_T, layout );
                     }
                 }
             }

--- a/src/gerbt.cc
+++ b/src/gerbt.cc
@@ -181,8 +181,8 @@ void gerbt(Matrix<scalar_t>& U_in,
         internal::gerbt_bcast_filter_duplicates<scalar_t>(bcast_list_U);
         internal::gerbt_bcast_filter_duplicates<scalar_t>(bcast_list_V);
 
-        U.template listBcastMT(bcast_list_U, Layout::ColMajor);
-        V.template listBcastMT(bcast_list_V, Layout::ColMajor);
+        U.template listBcastMT<>( bcast_list_U, Layout::ColMajor );
+        V.template listBcastMT<>( bcast_list_V, Layout::ColMajor );
 
         // NB: only tasks created so far are in listBcastMT
 
@@ -297,7 +297,7 @@ void gerbt(Matrix<scalar_t>& Uin,
 
         // Bcast random factors
         internal::gerbt_bcast_filter_duplicates<scalar_t>(bcast_list);
-        U.template listBcastMT(bcast_list, Layout::ColMajor);
+        U.template listBcastMT<>( bcast_list, Layout::ColMajor );
 
         // NB: only tasks created so far are in listBcastMT
 

--- a/src/getri.cc
+++ b/src/getri.cc
@@ -65,8 +65,8 @@ void getri(
             }
 
             // send W down col A(0:nt-1, k)
-            W.template tileBcast(
-                0, 0, A.sub(0, A.nt()-1, k, k), layout);
+            W.template tileBcast<>(
+                0, 0, A.sub( 0, A.nt()-1, k, k ), layout );
 
             auto Wkk = TriangularMatrix<scalar_t>(Uplo::Lower, Diag::Unit, W);
             internal::trsm<Target::HostTask>(
@@ -106,7 +106,7 @@ void getri(
                 // send W(i) down column A(0:nt-1, k+i)
                 bcast_list_W.push_back({i, 0, {A.sub(0, A.nt()-1, k+i, k+i)}});
             }
-            W.template listBcast(bcast_list_W, layout);
+            W.template listBcast<>( bcast_list_W, layout );
 
             // A(:, k) -= A(:, k+1:nt-1) * W
             internal::gemmA<Target::HostTask>(
@@ -124,7 +124,7 @@ void getri(
                                           {A.sub(i, i, k+1, A.nt()-1)}
                                         });
             }
-            A.template listReduce(reduce_list_A, layout);
+            A.template listReduce<>( reduce_list_A, layout );
 
             // Release workspace tiles from gemmA
             A.sub(0, A.nt()-1, k, k).releaseRemoteWorkspace();

--- a/src/he2hb.cc
+++ b/src/he2hb.cc
@@ -242,7 +242,7 @@ void he2hb(
                                       i } );
                             }
                         }
-                        Treduce.template listBcastMT( bcast_list_T, layout );
+                        Treduce.template listBcastMT<>( bcast_list_T, layout );
                     }
 
                     std::vector<int64_t> panel_rank_rows;

--- a/src/hetrf.cc
+++ b/src/hetrf.cc
@@ -443,7 +443,7 @@ int64_t hetrf(
                     bcast_list_T.push_back({k+1, k, {A.sub(k+1, A_mt-1, k-1, k-1)}});
                     // for computing T(j, j)
                     bcast_list_T.push_back({k+1, k, {A.sub(k+1, k+1,    k+1, k+1)}});
-                    T.template listBcast(bcast_list_T, layout, tag);
+                    T.template listBcast<>( bcast_list_T, layout, tag );
                 }
             }
             #pragma omp task depend(inout:columnL[k])

--- a/src/pbtrf.cc
+++ b/src/pbtrf.cc
@@ -96,7 +96,7 @@ int64_t pbtrf(
                     bcast_list_A.push_back({i, k, {A.sub(i, i, k+1, i),
                                                    A.sub(i, ij_end-1, i, i)}});
                 }
-                A.template listBcast(bcast_list_A, layout);
+                A.template listBcast<>( bcast_list_A, layout );
             }
 
             // update trailing submatrix, normal priority

--- a/src/tbsmPivots.cc
+++ b/src/tbsmPivots.cc
@@ -131,7 +131,7 @@ void tbsm(
                 #pragma omp task depend(inout:row[k]) priority(1)
                 {
                     // send A(k, k) to ranks owning block row B(k, :)
-                    A.template tileBcast(k, k, B.sub(k, k, 0, nt-1), layout);
+                    A.template tileBcast<>( k, k, B.sub( k, k, 0, nt-1 ), layout );
 
                     // solve A(k, k) B(k, :) = B(k, :)
                     internal::trsm<Target::HostTask>(
@@ -215,7 +215,7 @@ void tbsm(
                 #pragma omp task depend(inout:row[k]) priority(1)
                 {
                     // send A(k, k) to ranks owning block row B(k, :)
-                    A.template tileBcast(k, k, B.sub(k, k, 0, nt-1), layout);
+                    A.template tileBcast<>( k, k, B.sub( k, k, 0, nt-1 ), layout );
 
                     // solve A(k, k) B(k, :) = B(k, :)
                     internal::trsm<Target::HostTask>(
@@ -324,7 +324,7 @@ void tbsm(
                 // solve diagonal block (Akk tile)
                 {
                     // send A(k, k) to ranks owning block row B(k, :)
-                    A.template tileBcast(k, k, B.sub(k, k, 0, nt-1), layout);
+                    A.template tileBcast<>( k, k, B.sub( k, k, 0, nt-1 ), layout );
 
                     // solve A(k, k) B(k, :) = B(k, :)
                     internal::trsm<Target::HostTask>(

--- a/src/trtrm.cc
+++ b/src/trtrm.cc
@@ -77,7 +77,7 @@ void trtrm(
                     bcast_list_A.push_back({k, j, {A.sub(j, k-1, j, j),
                                                    A.sub(j, j, 0, j)}});
                 }
-                A.template listBcast(bcast_list_A, layout);
+                A.template listBcast<>( bcast_list_A, layout );
             }
 
             // update tailing submatrix

--- a/src/unmlq.cc
+++ b/src/unmlq.cc
@@ -151,7 +151,7 @@ void unmlq(
                         bcast_list_T.push_back(
                             {k, j, {C.sub(i0, i1, j0, j1)}});
                     }
-                    Tlocal.template listBcast(bcast_list_T, layout);
+                    Tlocal.template listBcast<>( bcast_list_T, layout );
                 }
 
                 // Send Treduce(j) across row C(j, 0:nt-1) or col C(0:mt-1, j).
@@ -173,7 +173,7 @@ void unmlq(
                                 {k, j, {C.sub(i0, i1, j0, j1)}});
                         }
                     }
-                    Treduce.template listBcast(bcast_list_T, layout);
+                    Treduce.template listBcast<>( bcast_list_T, layout );
                 }
 
                 Matrix<scalar_t> C_trail, W_trail;

--- a/src/unmqr.cc
+++ b/src/unmqr.cc
@@ -155,7 +155,7 @@ void unmqr(
                         bcast_list_T.push_back(
                             {i, k, {C.sub(i0, i1, j0, j1)}});
                     }
-                    Tlocal.template listBcast(bcast_list_T, layout);
+                    Tlocal.template listBcast<>( bcast_list_T, layout );
                 }
 
                 // Send Treduce(i) across row C(i, 0:nt-1) or col C(0:mt-1, i).
@@ -177,7 +177,7 @@ void unmqr(
                                 {i, k, {C.sub(i0, i1, j0, j1)}});
                         }
                     }
-                    Treduce.template listBcast(bcast_list_T, layout);
+                    Treduce.template listBcast<>( bcast_list_T, layout );
                 }
 
                 Matrix<scalar_t> C_trail, W_trail;

--- a/src/work/work_trsm.cc
+++ b/src/work/work_trsm.cc
@@ -106,7 +106,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
             #pragma omp task depend(inout:row[k]) priority(1)
             {
                 // send A(k, k) to ranks owning block row B(k, :)
-                A.template tileBcast(k, k, B.sub(k, k, 0, nt-1), layout);
+                A.template tileBcast<>( k, k, B.sub( k, k, 0, nt-1 ), layout );
 
                 // solve A(k, k) B(k, :) = alpha B(k, :)
                 internal::trsm<target>(
@@ -191,7 +191,7 @@ void trsm(Side side, scalar_t alpha, TriangularMatrix<scalar_t> A,
             #pragma omp task depend(inout:row[k]) priority(1)
             {
                 // send A(k, k) to ranks owning block row B(k, :)
-                A.template tileBcast(k, k, B.sub(k, k, 0, nt-1), layout);
+                A.template tileBcast<>( k, k, B.sub( k, k, 0, nt-1 ), layout );
 
                 // solve A(k, k) B(k, :) = alpha B(k, :)
                 internal::trsm<target>(


### PR DESCRIPTION
Fixes #205.
This syntax is invalid but was long accepted by compilers:
```
    A.template listBcast( ... );
```
It is required to have `<>`:
```
    A.template listBcast<>( ... );
```
See C++ standard, Names of template specializations (§14.2 ¶5 in N3337 C++11 draft):
```
template <class T> void f(T t) {
  A<T> a;
  a.template f<>(t);  // OK: calls template
  a.template f(t);    // error: not a template-id
};
```