### PR TITLE
ScaLAPACK API singletons

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -875,7 +875,7 @@ TEST_LDFLAGS  = ${LDFLAGS} -L./lib -Wl,-rpath,${abspath ./lib}
 TEST_LDFLAGS += -L./testsweeper -Wl,-rpath,${abspath ./testsweeper}
 TEST_LDFLAGS += -Wl,-rpath,${abspath ./blaspp/lib}
 TEST_LDFLAGS += -Wl,-rpath,${abspath ./lapackpp/lib}
-TEST_LIBS     = -lslate -lslate_matgen -ltestsweeper ${LIBS}
+TEST_LIBS    += -lslate -lslate_matgen -ltestsweeper ${LIBS}
 ifneq (${SCALAPACK_LIBRARIES},none)
     TEST_LIBS += ${SCALAPACK_LIBRARIES}
     CXXFLAGS  += -DSLATE_HAVE_SCALAPACK

--- a/include/slate/config.hh
+++ b/include/slate/config.hh
@@ -19,22 +19,22 @@ public:
     /// @see bool gpu_aware_mpi()
     static bool value()
     {
-        return get().gpu_aware_mpi_;
+        return instance().gpu_aware_mpi_;
     }
 
     /// @see void gpu_aware_mpi( bool )
     static void value( bool val )
     {
-        get().gpu_aware_mpi_ = val;
+        instance().gpu_aware_mpi_ = val;
     }
 
 private:
     /// @return GPU_Aware_MPI singleton.
     /// Uses thread-safe Scott Meyers' singleton to query on first call only.
-    static GPU_Aware_MPI& get()
+    static GPU_Aware_MPI& instance()
     {
-        static GPU_Aware_MPI singleton;
-        return singleton;
+        static GPU_Aware_MPI instance_;
+        return instance_;
     }
 
     /// Constructor checks $SLATE_GPU_AWARE_MPI.

--- a/scalapack_api/README_scalapack_api.txt
+++ b/scalapack_api/README_scalapack_api.txt
@@ -51,13 +51,14 @@ ENVIRONMENT VARIABLES
 ---------------------
 
 The library libslate_scalapack_api.so uses some environment variables
-to make decisions that are not available in a the ScaLAPACK
+to make decisions that are not available in the ScaLAPACK
 parameters.
 
 * SLATE_SCALAPACK_TARGET  HostTask (default), Devices, HostNest, HostBatch (case indifferent)
 * SLATE_SCALAPACK_VERBOSE  0,1 (0: no output,  1: print some minor output)
 * SLATE_SCALAPACK_PANELTHREADS integer (number of threads to serve the panel, default (maximum omp threads)/2 )
 * SLATE_SCALAPACK_IB integer (inner blocking size useful for some routines, default 16)
+* SLATE_SCALAPACK_LOOKAHEAD integer (lookahead number of panels, default 1)
 
 Example on a properly configured SLATE install on a machine with GPUs.
 

--- a/scalapack_api/scalapack_gecon.cc
+++ b/scalapack_api/scalapack_gecon.cc
@@ -94,11 +94,11 @@ void slate_pgecon(const char* normstr, int n, scalar_t* a, int ia, int ja, int* 
     Norm norm{};
     from_string( std::string( 1, normstr[0] ), &norm );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // todo: extract the real info from getrf

--- a/scalapack_api/scalapack_gels.cc
+++ b/scalapack_api/scalapack_gels.cc
@@ -104,11 +104,11 @@ void slate_pgels(const char* transstr, int m, int n, int nrhs, scalar_t* a, int 
     Op trans{};
     from_string( std::string( 1, transstr[0] ), &trans );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t inner_blocking = slate_scalapack_set_ib();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t inner_blocking = IBConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // A is m-by-n, BX is max(m, n)-by-nrhs.

--- a/scalapack_api/scalapack_gemm.cc
+++ b/scalapack_api/scalapack_gemm.cc
@@ -121,9 +121,9 @@ void slate_pgemm(const char* transastr, const char* transbstr, int m, int n, int
     from_string( std::string( 1, transastr[0] ), &transA );
     from_string( std::string( 1, transbstr[0] ), &transB );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // sizes of A and B

--- a/scalapack_api/scalapack_gesv.cc
+++ b/scalapack_api/scalapack_gesv.cc
@@ -91,11 +91,11 @@ extern "C" void pzgesv_(int* n, int* nrhs, std::complex<double>* a, int* ia, int
 template< typename scalar_t >
 void slate_pgesv(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* b, int ib, int jb, int* descb, int* info)
 {
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t inner_blocking = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t inner_blocking = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_gesv_mixed.cc
+++ b/scalapack_api/scalapack_gesv_mixed.cc
@@ -61,11 +61,11 @@ void slate_pgesv_mixed(int n, int nrhs, scalar_t* a, int ia, int ja, int* desca,
 {
     using real_t = blas::real_type<scalar_t>;
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t inner_blocking = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t inner_blocking = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_gesvd.cc
+++ b/scalapack_api/scalapack_gesvd.cc
@@ -102,11 +102,11 @@ void slate_pgesvd(const char* jobustr, const char* jobvtstr, int m, int n, scala
     from_string( std::string( 1, jobustr[0] ), &jobu );
     from_string( std::string( 1, jobvtstr[0] ), &jobvt );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // todo: extract the real info from gesvd

--- a/scalapack_api/scalapack_getrf.cc
+++ b/scalapack_api/scalapack_getrf.cc
@@ -91,11 +91,11 @@ extern "C" void pzgetrf_(int* m, int* n, std::complex<double>* a, int* ia, int* 
 template< typename scalar_t >
 void slate_pgetrf(int m, int n, scalar_t* a, int ia, int ja, int* desca, int* ipiv, int* info)
 {
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_getri.cc
+++ b/scalapack_api/scalapack_getri.cc
@@ -91,11 +91,11 @@ extern "C" void pzgetri_(int* n, std::complex<double>* a, int* ia, int* ja, int*
 template< typename scalar_t >
 void slate_pgetri(int n, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* work, int lwork, int* iwork, int liwork, int* info)
 {
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     slate::Options const opts = {

--- a/scalapack_api/scalapack_getrs.cc
+++ b/scalapack_api/scalapack_getrs.cc
@@ -91,9 +91,9 @@ extern "C" void pzgetrs_(const char* trans, int* n, int* nrhs, std::complex<doub
 template< typename scalar_t >
 void slate_pgetrs(const char* transstr, int n, int nrhs, scalar_t* a, int ia, int ja, int* desca, int* ipiv, scalar_t* b, int ib, int jb, int* descb, int* info)
 {
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     slate::Options const opts =  {

--- a/scalapack_api/scalapack_heev.cc
+++ b/scalapack_api/scalapack_heev.cc
@@ -102,11 +102,11 @@ void slate_pheev(const char* jobzstr, const char* uplostr, int n, scalar_t* a, i
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, jobzstr[0] ), &jobz );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // todo: extract the real info from heev

--- a/scalapack_api/scalapack_heevd.cc
+++ b/scalapack_api/scalapack_heevd.cc
@@ -102,11 +102,11 @@ void slate_pheevd(const char* jobzstr, const char* uplostr, int n, scalar_t* a, 
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, jobzstr[0] ), &jobz );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // todo: extract the real info from heevd

--- a/scalapack_api/scalapack_hemm.cc
+++ b/scalapack_api/scalapack_hemm.cc
@@ -80,9 +80,9 @@ void slate_phemm(const char* sidestr, const char* uplostr, int m, int n, scalar_
     from_string( std::string( 1, sidestr[0] ), &side );
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     int64_t An = (side == blas::Side::Left ? m : n);

--- a/scalapack_api/scalapack_her2k.cc
+++ b/scalapack_api/scalapack_her2k.cc
@@ -64,9 +64,9 @@ void slate_pher2k(const char* uplostr, const char* transstr, int n, int k, scala
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, transstr[0] ), &trans );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // setup so op(A) and op(B) are n-by-k

--- a/scalapack_api/scalapack_herk.cc
+++ b/scalapack_api/scalapack_herk.cc
@@ -64,9 +64,9 @@ void slate_pherk(const char* uplostr, const char* transstr, int n, int k, blas::
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, transstr[0] ), &transA );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // setup so op(A) is n-by-k

--- a/scalapack_api/scalapack_lange.cc
+++ b/scalapack_api/scalapack_lange.cc
@@ -94,9 +94,9 @@ blas::real_type<scalar_t> slate_plange(const char* normstr, int m, int n, scalar
     Norm norm{};
     from_string( std::string( 1, normstr[0] ), &norm );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_lanhe.cc
+++ b/scalapack_api/scalapack_lanhe.cc
@@ -64,9 +64,9 @@ blas::real_type<scalar_t> slate_planhe(const char* normstr, const char* uplostr,
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, normstr[0] ), &norm );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_lansy.cc
+++ b/scalapack_api/scalapack_lansy.cc
@@ -96,9 +96,9 @@ blas::real_type<scalar_t> slate_plansy(const char* normstr, const char* uplostr,
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, normstr[0] ), &norm );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_lantr.cc
+++ b/scalapack_api/scalapack_lantr.cc
@@ -101,9 +101,9 @@ blas::real_type<scalar_t> slate_plantr(const char* normstr, const char* uplostr,
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, diagstr[0] ), &diag );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_pocon.cc
+++ b/scalapack_api/scalapack_pocon.cc
@@ -94,11 +94,11 @@ void slate_ppocon(const char* uplostr, int n, scalar_t* a, int ia, int ja, int* 
     Uplo uplo{};
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // todo: extract the real info from getrf

--- a/scalapack_api/scalapack_posv.cc
+++ b/scalapack_api/scalapack_posv.cc
@@ -97,9 +97,9 @@ void slate_pposv(const char* uplostr, int n, int nrhs, scalar_t* a, int ia, int 
     Uplo uplo{};
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_potrf.cc
+++ b/scalapack_api/scalapack_potrf.cc
@@ -97,9 +97,9 @@ void slate_ppotrf(const char* uplostr, int n, scalar_t* a, int ia, int ja, int* 
     Uplo uplo{};
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_potri.cc
+++ b/scalapack_api/scalapack_potri.cc
@@ -97,9 +97,9 @@ void slate_ppotri(const char* uplostr, int n, scalar_t* a, int ia, int ja, int* 
     Uplo uplo{};
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // Matrix sizes

--- a/scalapack_api/scalapack_potrs.cc
+++ b/scalapack_api/scalapack_potrs.cc
@@ -97,9 +97,9 @@ void slate_ppotrs(const char* uplostr, int n, int nrhs, scalar_t* a, int ia, int
     Uplo uplo{};
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // create SLATE matrices from the ScaLAPACK layouts

--- a/scalapack_api/scalapack_slate.hh
+++ b/scalapack_api/scalapack_slate.hh
@@ -138,66 +138,251 @@ inline slate::HermitianMatrix<scalar_t> slate_scalapack_submatrix(int Am, int An
     return A.sub(i1, i2);
 }
 
-inline slate::Target slate_scalapack_set_target()
+//==============================================================================
+/// Initialize target setting from environment variable.
+/// Uses thread-safe Scott Meyers Singleton.
+class TargetConfig
 {
-    // set the SLATE default computational target
-    // 5th character from: hostTask hostNest hostBatch deviCes
-    slate::Target target = slate::Target::HostTask;
-    char* targetstr = std::getenv("SLATE_SCALAPACK_TARGET");
-    if (targetstr) {
-        char targetchar = (char)(toupper(targetstr[4]));
-        if (targetchar == 'T') target = slate::Target::HostTask;
-        else if (targetchar == 'N') target = slate::Target::HostNest;
-        else if (targetchar == 'B') target = slate::Target::HostBatch;
-        else if (targetchar == 'C') target = slate::Target::Devices;
+public:
+    /// @return target (HostTask, Devices, etc.) to use.
+    static slate::Target value()
+    {
+        return instance().target_;
     }
-    return target;
-}
 
-inline int64_t slate_scalapack_set_panelthreads()
-{
-    int64_t max_panel_threads = 1;
-    char* thrstr = std::getenv("SLATE_SCALAPACK_PANELTHREADS");
-    if (thrstr) {
-        max_panel_threads = (int64_t)strtol(thrstr, NULL, 0);
-        if (max_panel_threads != 0) return max_panel_threads;
+    /// Set target to use.
+    static void value( slate::Target target )
+    {
+        instance().target_ = target;
     }
-    return std::max(omp_get_max_threads()/2, 1);
-}
 
-inline int64_t slate_scalapack_set_ib()
-{
-    int64_t ib = 0;
-    char* ibstr = std::getenv("SLATE_SCALAPACK_IB");
-    if (ibstr) {
-        ib = (int64_t)strtol(ibstr, NULL, 0);
-        if (ib != 0) return ib;
+private:
+    /// On first call, creates the singleton instance, which queries the
+    /// environment variable.
+    /// @return singleton instance.
+    static TargetConfig& instance()
+    {
+        static TargetConfig instance_;
+        return instance_;
     }
-    return 16;
-}
 
-inline int slate_scalapack_set_verbose()
-{
-    // set the SLATE verbose (specific to scalapack_api)
-    int verbose = 0; // default
-    char* verbosestr = std::getenv("SLATE_SCALAPACK_VERBOSE");
-    if (verbosestr) {
-        if (verbosestr[0] == '1')
-            verbose = 1;
+    /// Constructor queries the environment variable or sets to default value.
+    TargetConfig()
+    {
+        target_ = slate::Target::HostTask;
+        const char* str = std::getenv( "SLATE_SCALAPACK_TARGET" );
+        if (str) {
+            std::string str_ = str;
+            std::transform( str_.begin(), str_.end(), str_.begin(), ::tolower );
+            if (str_ == "devices")
+                target_ = slate::Target::Devices;
+            else if (str_ == "hosttask")
+                target_ = slate::Target::HostTask;
+            else if (str_ == "hostnest")
+                target_ = slate::Target::HostNest;
+            else if (str_ == "hostbatch")
+                target_ = slate::Target::HostBatch;
+            else
+                slate_error( std::string( "Invalid target: " ) + str );
+        }
     }
-    return verbose;
-}
 
-inline int64_t slate_scalapack_set_lookahead()
+    // Prevent copy construction and copy assignment.
+    TargetConfig( const TargetConfig& orig ) = delete;
+    TargetConfig& operator= ( const TargetConfig& orig ) = delete;
+
+    //----------------------------------------
+    // Data
+    slate::Target target_;
+};
+
+//==============================================================================
+/// Initialize panel threads setting from environment variable.
+/// Uses thread-safe Scott Meyers Singleton.
+class PanelThreadsConfig
 {
-    int64_t la = 0;
-    char* lastr = std::getenv("SLATE_SCALAPACK_LOOKAHEAD");
-    if (lastr) {
-        la = (int64_t)strtol(lastr, NULL, 0);
-        if (la != 0) return la;
+public:
+    /// @return number of panel threads to use.
+    static int value()
+    {
+        return instance().panel_threads_;
     }
-    return 1;
-}
+
+    /// Set number of panel threads to use.
+    static void value( int panel_threads )
+    {
+        instance().panel_threads_ = panel_threads;
+    }
+
+private:
+    /// On first call, creates the singleton instance, which queries the
+    /// environment variable.
+    /// @return singleton instance.
+    static PanelThreadsConfig& instance()
+    {
+        static PanelThreadsConfig instance_;
+        return instance_;
+    }
+
+    /// Constructor queries the environment variable or sets to default value.
+    PanelThreadsConfig()
+    {
+        panel_threads_ = blas::max( omp_get_max_threads()/2, 1 );
+        const char* str = std::getenv( "SLATE_SCALAPACK_PANELTHREADS" );
+        if (str) {
+            panel_threads_ = blas::max( strtol( str, NULL, 0 ), 1 );
+        }
+    }
+
+    // Prevent copy construction and copy assignment.
+    PanelThreadsConfig( const PanelThreadsConfig& orig ) = delete;
+    PanelThreadsConfig& operator= ( const PanelThreadsConfig& orig ) = delete;
+
+    //----------------------------------------
+    // Data
+    int panel_threads_;
+};
+
+//==============================================================================
+/// Initialize ib setting from environment variable.
+/// Uses thread-safe Scott Meyers Singleton.
+class IBConfig
+{
+public:
+    /// @return inner blocking to use.
+    static int64_t value()
+    {
+        return instance().ib_;
+    }
+
+    /// Set inner blocking to use.
+    static void value( int64_t ib )
+    {
+        instance().ib_ = ib;
+    }
+
+private:
+    /// On first call, creates the singleton instance, which queries the
+    /// environment variable.
+    /// @return singleton instance.
+    static IBConfig& instance()
+    {
+        static IBConfig instance_;
+        return instance_;
+    }
+
+    /// Constructor queries the environment variable or sets to default value.
+    IBConfig()
+    {
+        ib_ = 16;
+        const char* str = std::getenv( "SLATE_SCALAPACK_IB" );
+        if (str) {
+            ib_ = blas::max( strtol( str, NULL, 0 ), 1 );
+        }
+    }
+
+    // Prevent copy construction and copy assignment.
+    IBConfig( const IBConfig& orig ) = delete;
+    IBConfig& operator= ( const IBConfig& orig ) = delete;
+
+    //----------------------------------------
+    // Data
+    int64_t ib_;
+};
+
+//==============================================================================
+/// Initialize verbose setting from environment variable.
+/// Uses thread-safe Scott Meyers Singleton.
+class VerboseConfig
+{
+public:
+    /// @return verbose flag to use.
+    static int value()
+    {
+        return instance().verbose_;
+    }
+
+    /// Set verbose flag to use.
+    static void value( int verbose )
+    {
+        instance().verbose_ = verbose;
+    }
+
+private:
+    /// On first call, creates the singleton instance, which queries the
+    /// environment variable.
+    /// @return singleton instance.
+    static VerboseConfig& instance()
+    {
+        static VerboseConfig instance_;
+        return instance_;
+    }
+
+    /// Constructor queries the environment variable or sets to default value.
+    VerboseConfig()
+    {
+        verbose_ = 0;
+        const char* str = std::getenv( "SLATE_SCALAPACK_VERBOSE" );
+        if (str) {
+            verbose_ = strtol( str, NULL, 0 );
+        }
+    }
+
+    // Prevent copy construction and copy assignment.
+    VerboseConfig( const VerboseConfig& orig ) = delete;
+    VerboseConfig& operator= ( const VerboseConfig& orig ) = delete;
+
+    //----------------------------------------
+    // Data
+    int verbose_;
+};
+
+//==============================================================================
+/// Initialize lookahead setting from environment variable.
+/// Uses thread-safe Scott Meyers Singleton.
+class LookaheadConfig
+{
+public:
+    /// @return lookahead to use.
+    static int64_t value()
+    {
+        return instance().lookahead_;
+    }
+
+    /// Set lookahead to use.
+    static void value( int64_t lookahead )
+    {
+        instance().lookahead_ = lookahead;
+    }
+
+private:
+    /// On first call, creates the singleton instance, which queries the
+    /// environment variable.
+    /// @return singleton instance.
+    static LookaheadConfig& instance()
+    {
+        static LookaheadConfig instance_;
+        return instance_;
+    }
+
+    /// Constructor queries the environment variable or sets to default value.
+    LookaheadConfig()
+    {
+        lookahead_ = 1;
+        const char* str = std::getenv( "SLATE_SCALAPACK_LOOKAHEAD" );
+        if (str) {
+            lookahead_ = blas::max( strtol( str, NULL, 0 ), 1 );
+        }
+    }
+
+    // Prevent copy construction and copy assignment.
+    LookaheadConfig( const LookaheadConfig& orig ) = delete;
+    LookaheadConfig& operator= ( const LookaheadConfig& orig ) = delete;
+
+    //----------------------------------------
+    // Data
+    int64_t lookahead_;
+};
 
 // -----------------------------------------------------------------------------
 // helper funtion to check and do type conversion

--- a/scalapack_api/scalapack_symm.cc
+++ b/scalapack_api/scalapack_symm.cc
@@ -124,9 +124,9 @@ void slate_psymm(const char* sidestr, const char* uplostr, int m, int n, scalar_
     from_string( std::string( 1, sidestr[0] ), &side );
     from_string( std::string( 1, uplostr[0] ), &uplo );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     int64_t An = (side == blas::Side::Left ? m : n);

--- a/scalapack_api/scalapack_syr2k.cc
+++ b/scalapack_api/scalapack_syr2k.cc
@@ -101,9 +101,9 @@ void slate_psyr2k(const char* uplostr, const char* transstr, int n, int k, scala
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, transstr[0] ), &trans );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // setup so op(A) and op(B) are n-by-k

--- a/scalapack_api/scalapack_syrk.cc
+++ b/scalapack_api/scalapack_syrk.cc
@@ -101,9 +101,9 @@ void slate_psyrk(const char* uplostr, const char* transstr, int n, int k, scalar
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, transstr[0] ), &transA );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // setup so op(A) is n-by-k

--- a/scalapack_api/scalapack_trcon.cc
+++ b/scalapack_api/scalapack_trcon.cc
@@ -98,11 +98,11 @@ void slate_ptrcon(const char* normstr, const char* uplostr, const char* diagstr,
     from_string( std::string( 1, uplostr[0] ), &uplo );
     from_string( std::string( 1, diagstr[0] ), &diag );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
-    static int64_t panel_threads = slate_scalapack_set_panelthreads();
-    static int64_t ib = slate_scalapack_set_ib();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
+    int64_t panel_threads = PanelThreadsConfig::value();
+    int64_t ib = IBConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // todo: extract the real info from getrf

--- a/scalapack_api/scalapack_trmm.cc
+++ b/scalapack_api/scalapack_trmm.cc
@@ -105,9 +105,9 @@ void slate_ptrmm(const char* sidestr, const char* uplostr, const char* transastr
     from_string( std::string( 1, transastr[0] ), &transA );
     from_string( std::string( 1, diagstr[0] ), &diag );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // setup so op(B) is m-by-n

--- a/scalapack_api/scalapack_trsm.cc
+++ b/scalapack_api/scalapack_trsm.cc
@@ -105,9 +105,9 @@ void slate_ptrsm(const char* sidestr, const char* uplostr, const char* transastr
     from_string( std::string( 1, transastr[0] ), &transA );
     from_string( std::string( 1, diagstr[0] ), &diag );
 
-    static slate::Target target = slate_scalapack_set_target();
-    static int verbose = slate_scalapack_set_verbose();
-    static int64_t lookahead = slate_scalapack_set_lookahead();
+    slate::Target target = TargetConfig::value();
+    int verbose = VerboseConfig::value();
+    int64_t lookahead = LookaheadConfig::value();
     slate::GridOrder grid_order = slate_scalapack_blacs_grid_order();
 
     // setup so trans(B) is m-by-n


### PR DESCRIPTION
Replaces the internal `slate_scalapack_set_target()` and similar functions with singletons `TargetConfig::value()` that query the environment only once. For Target, this also compares the entire string instead of just the 5th character, making it safe from buffer overrun and more robust.